### PR TITLE
Pic32mx ram optimize

### DIFF
--- a/applications/async_blink/main.cxx
+++ b/applications/async_blink/main.cxx
@@ -80,6 +80,8 @@ OVERRIDE_CONST(main_thread_stack_size, 2500);
 OVERRIDE_CONST(main_thread_stack_size, 1200);
 #elif defined(STM32F072xB) || defined(STM32F10X_MD)
 OVERRIDE_CONST(main_thread_stack_size, 1200);
+#elif defined(TARGET_PIC32MX)
+OVERRIDE_CONST(main_thread_stack_size, 1400);
 #endif
 OVERRIDE_CONST(num_memory_spaces, 4);
 

--- a/applications/async_blink/main.cxx
+++ b/applications/async_blink/main.cxx
@@ -205,7 +205,7 @@ openlcb::BitEventConsumer consumer(&logger);
 int appl_main(int argc, char* argv[])
 {
 #if defined (BOARD_LAUNCHPAD_EK)
-    new Console(stack.executor(), Console::FD_STDIN, Console::FD_STDOUT);
+    //new Console(stack.executor(), Console::FD_STDIN, Console::FD_STDOUT);
 #elif defined (__linux__)
     new Console(stack.executor(), Console::FD_STDIN, Console::FD_STDOUT, 2121);
 #endif
@@ -215,8 +215,6 @@ int appl_main(int argc, char* argv[])
     stack.connect_tcp_gridconnect_hub("localhost",12021);
 #elif defined(TARGET_LPC11Cxx)
     lpc11cxx::CreateCanDriver(stack.can_hub());
-#elif defined(TARGET_PIC32MX)
-    stack.add_can_port_blocking("/dev/can0");
 #elif defined(__FreeRTOS__)
     stack.add_can_port_select("/dev/can0");
 #elif defined(__EMSCRIPTEN__)

--- a/boards/microchip-pic32mx-duinomitemega/ISRwrapper.S
+++ b/boards/microchip-pic32mx-duinomitemega/ISRwrapper.S
@@ -36,8 +36,9 @@
 .text
         // CAN1 interrupt
 /* Ensure correct instructions is used. */
-.set	nomips16
-.set 	noreorder
+        .set	nomips16
+        .set 	noreorder
+        .set    noat
 
 /* Interrupt entry point. */
 vCan1InterruptWrapper:

--- a/boards/microchip-pic32mx-duinomitemega/ISRwrapper.S
+++ b/boards/microchip-pic32mx-duinomitemega/ISRwrapper.S
@@ -21,11 +21,44 @@
 */
 
 #include "proc/p32mx795f512h.h"
-.include "ISRwrapper.inc"
-        
+#include <xc.h>
+#include <sys/asm.h>
 
+        .include "ISRwrapper.inc"
+
+/* Header file in which portSAVE_CONTEXT and portRESTORE_CONTEXT are defined. */
+#include "ISR_Support.h"
+
+// Core FreeRTOS interrupts have internal save and restore contexts.        
         RAW_ISR_wrapper _TIMER_1_VECTOR,vPortTickInterruptHandler
         RAW_ISR_wrapper _CORE_SOFTWARE_0_VECTOR,vPortYieldISR
+
+.text
+        // CAN1 interrupt
+/* Ensure correct instructions is used. */
+.set	nomips16
+.set 	noreorder
+
+/* Interrupt entry point. */
+vCan1InterruptWrapper:
+
+  /* Save the current task context.  This line MUST be included! */
+  portSAVE_CONTEXT
+
+  /* Call the C function to handle the interrupt. */
+  jal can1_interrupt
+  nop
+
+  /* Restore the context of the next task to execute.  This line
+  MUST be included! */
+  portRESTORE_CONTEXT
+
+  .end  vCan1InterruptWrapper        
+
+.section .vector_46,"ax",%progbits
+        j vCan1InterruptWrapper
+        nop
+.text
         
 // See p32mx440f256h.h etc. for vector assignments for specific processor.
 // Create wrappers for ISRs used in a specific application.

--- a/boards/microchip-pic32mx-duinomitemega/target.ld
+++ b/boards/microchip-pic32mx-duinomitemega/target.ld
@@ -34,7 +34,7 @@ OUTPUT_ARCH(mips)
 ENTRY(__cs3_reset_PIC32MX) /* for debugger support, use actual HW-level entry and not _start */
 SEARCH_DIR(.)
 /* Force repeated search of CS3 and GCC libraries */
-GROUP(-lcs3hal -lgcc -lc -lcs3 -lcs3unhosted)
+GROUP(-lcs3hal -lgcc -lc -lcs3)
 /**/
 
 /*

--- a/etc/freertos.mips4k.pic32mx.mk
+++ b/etc/freertos.mips4k.pic32mx.mk
@@ -9,7 +9,7 @@ ifeq ($(TOOLPATH),)
 TOOLPATH=$(MIPSGCCPATH)
 endif
 
-DEPS+= MIPSGCCPATH PIC32MXLIBPATH PIC32MXLEGACYPLIBPATH
+DEPS+= MIPSGCCPATH PIC32MXLIBPATH PIC32MXLEGACYPLIBPATH MIPSNEWLIBPATH
 
 PREFIX = $(TOOLPATH)/bin/mips-sde-elf-
 
@@ -31,7 +31,8 @@ INCLUDES += -I$(FREERTOSPATH)/Source/include \
             -I$(FREERTOSPATH)/Source/portable/MPLAB/PIC32MX \
             -I$(OPENMRNPATH)/include/freertos \
             -idirafter $(OPENMRNPATH)/include/freertos_select \
-            -I$(OPENMRNPATH)/src/freertos_drivers/common
+            -I$(OPENMRNPATH)/src/freertos_drivers/common \
+            -isystem $(MIPSNEWLIBPATH)/include
 
 ARCH = -mips16
 ARCHOPTIMIZATION = $(ARCH) -Os -fno-strict-aliasing
@@ -75,6 +76,7 @@ LDFLAGS = -EL $(ARCH) -g -T target.ld -fdata-sections -ffunction-sections  -Xlin
 	-Map="$(@:%.elf=%.map)"  \
 	-msoft-float -Wl,--defsym,__cs3_mips_float_type=2 \
 	-Wl,--gc-sections -Wl,--undefined=ignore_fn \
+	-L$(MIPSNEWLIBPATH)/lib/el/mips16/sof \
           $(LDFLAGSEXTRA) $(LDFLAGSENV)
 
 ifdef TRACE_MALLOC

--- a/etc/path.mk
+++ b/etc/path.mk
@@ -386,6 +386,18 @@ MIPSGCCPATH:=$(TRYPATH)
 endif
 endif #MIPSGCCPATH
 
+################### MIPS-ELF-NEWLIB #####################
+ifndef MIPSNEWLIBPATH
+SEARCHPATH := \
+  /opt/newlib/mips-sde-elf \
+  $(MIPSGCCPATH)/mips-sde-elf
+
+TRYPATH:=$(call findfirst,lib/el/mips16/sof/libc.a,$(SEARCHPATH))
+ifneq ($(TRYPATH),)
+MIPSNEWLIBPATH:=$(TRYPATH)
+endif
+endif #MIPSNEWLIBPATH
+
 ################### PIC32MXLIB #####################
 ifndef PIC32MXLIBPATH
 SEARCHPATH := \

--- a/etc/path_windows.mk
+++ b/etc/path_windows.mk
@@ -57,6 +57,19 @@ MIPSGCCPATH:=$(TRYPATH)
 endif
 endif #MIPSGCCPATH
 
+################### MIPS-ELF-NEWLIB #####################
+ifndef MIPSNEWLIBPATH
+SEARCHPATH := \
+  /opt/newlib/mips-sde-elf \
+  c:/mgc/newlib/mips-sde-elf \
+  $(MIPSGCCPATH)/mips-sde-elf
+
+TRYPATH:=$(call findfirst,lib/el/mips16/sof/libc.a,$(SEARCHPATH))
+ifneq ($(TRYPATH),)
+MIPSNEWLIBPATH:=$(TRYPATH)
+endif
+endif #MIPSNEWLIBPATH
+
 ################### PIC32MXLIB #####################
 ifndef PIC32MXLIBPATH
 SEARCHPATH := \

--- a/include/freertos/FreeRTOSConfig.h
+++ b/include/freertos/FreeRTOSConfig.h
@@ -244,6 +244,7 @@ standard names - or at least those used in the unmodified vector table. */
 #define configTOTAL_HEAP_SIZE          ( ( size_t ) 9000 )
 #define configTIMER_TASK_STACK_DEPTH   ( configMINIMAL_STACK_SIZE * 2 )
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION 0
+#define configCHECK_FOR_STACK_OVERFLOW 3
 
 /* The priority at which the tick interrupt runs.  This should probably be
 kept at 1. */
@@ -292,7 +293,9 @@ extern unsigned long blinker_pattern;
 #define configUSE_RECURSIVE_MUTEXES    1
 #define configUSE_COUNTING_SEMAPHORES  1
 #define configUSE_CO_ROUTINES          0
+#ifndef configCHECK_FOR_STACK_OVERFLOW
 #define configCHECK_FOR_STACK_OVERFLOW 2
+#endif
 
 #define configMAX_PRIORITIES        ( 5 )
 #define configMAX_CO_ROUTINE_PRIORITIES ( 2 )

--- a/include/freertos/FreeRTOSConfig.h
+++ b/include/freertos/FreeRTOSConfig.h
@@ -239,10 +239,10 @@ standard names - or at least those used in the unmodified vector table. */
 
 #define configCPU_CLOCK_HZ             ( pic32_cpu_clock_hz )
 #define configPERIPHERAL_CLOCK_HZ      ( pic32_periph_clock_hz )
-#define configMINIMAL_STACK_SIZE       ( 190 )
-#define configISR_STACK_SIZE           ( 250 )
+#define configMINIMAL_STACK_SIZE       ( 90 )
+#define configISR_STACK_SIZE           ( 120 )
 #define configTOTAL_HEAP_SIZE          ( ( size_t ) 9000 )
-#define configTIMER_TASK_STACK_DEPTH   ( configMINIMAL_STACK_SIZE * 2 )
+#define configTIMER_TASK_STACK_DEPTH   ( 190 )
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION 0
 #define configCHECK_FOR_STACK_OVERFLOW 3
 

--- a/src/freertos_drivers/common/DeviceBuffer.hxx
+++ b/src/freertos_drivers/common/DeviceBuffer.hxx
@@ -48,7 +48,7 @@ public:
      * @param file file to wait on
      * @param read true if this is a read operation, false for write operation
      */
-    void block_until_condition(File *file, bool read);
+    static void block_until_condition(File *file, bool read);
 
     /** Signal the wakeup condition.  This will also wakeup select.
      */

--- a/src/freertos_drivers/pic32mx/Pic32mxCan.cxx
+++ b/src/freertos_drivers/pic32mx/Pic32mxCan.cxx
@@ -34,6 +34,7 @@
  */
 
 #include "Devtab.hxx"
+#include "DeviceBuffer.hxx"
 #include "nmranet_config.h"
 #include "can_frame.h"
 #include <fcntl.h>
@@ -45,6 +46,8 @@ extern "C" {
 #include "peripheral/CAN.h"
 #include "peripheral/int.h"
 }
+
+volatile int* g_pic32_last_stack_ptr;
 
 /// CAN-bus device driver for the Pic32MX.
 class Pic32mxCan : public Node
@@ -79,7 +82,13 @@ private:
 
     ssize_t read(File *file, void *buf, size_t count);
     ssize_t write(File *file, const void *buf, size_t count);
-    int ioctl(File *file, unsigned long int key, unsigned long data);
+    /** Device select method. Default impementation returns true.
+     * @param file reference to the file
+     * @param mode FREAD for read active, FWRITE for write active, 0 for
+     *        exceptions
+     * @return true if active, false if inactive
+     */
+    bool select(File* file, int mode) OVERRIDE;
 
     /// Hordware (pointer into address space).
     CAN_MODULE hw_;
@@ -88,19 +97,13 @@ private:
     int overrunCount_;
     /// Points to the shared RAM area between the hardware and the driver.
     void *messageFifoArea_;
-    /// Semaphore for waking up transmitting tasks.
-    OSSem txSem_;
-    /// Semaphore for waking up receiving tasks.
-    OSSem rxSem_;
+    // Select for the transmit buffers.
+    SelectInfo txSelect_;
+    // Select for the receive buffers.
+    SelectInfo rxSelect_;
 
     DISALLOW_COPY_AND_ASSIGN(Pic32mxCan);
 };
-
-int Pic32mxCan::ioctl(File *file, unsigned long int key,
-                      unsigned long data)
-{
-    return -EINVAL;
-}
 
 /// Translates a hardware buffer to a struct can_frame.
 ///
@@ -236,7 +239,7 @@ ssize_t Pic32mxCan::read(File *file, void *buf, size_t count)
 
         CANEnableChannelEvent(hw_, CAN_CHANNEL1, CAN_RX_CHANNEL_NOT_EMPTY,
                               TRUE);
-        rxSem_.wait();
+        DeviceBufferBase::block_until_condition(file, true);
     }
 
     /* As a good-bye we wake up the interrupt handler once more to post on the
@@ -244,6 +247,11 @@ ssize_t Pic32mxCan::read(File *file, void *buf, size_t count)
     CANEnableChannelEvent(hw_, CAN_CHANNEL1, CAN_RX_CHANNEL_NOT_EMPTY,
                           TRUE);
 
+    if (!result && (file->flags & O_NONBLOCK))
+    {
+        return -EAGAIN;
+    }
+    
     return result;
 }
 
@@ -299,7 +307,7 @@ ssize_t Pic32mxCan::write(File *file, const void *buf, size_t count)
          * us up. */
         CANEnableChannelEvent(hw_, CAN_CHANNEL0, CAN_TX_CHANNEL_NOT_FULL,
                               TRUE);
-        txSem_.wait();
+        DeviceBufferBase::block_until_condition(file, false);
     }
 
     /* As a good-bye we wake up the interrupt handler once more to post on the
@@ -307,7 +315,55 @@ ssize_t Pic32mxCan::write(File *file, const void *buf, size_t count)
     CANEnableChannelEvent(hw_, CAN_CHANNEL0, CAN_TX_CHANNEL_NOT_FULL,
                           TRUE);
 
+    if (!result && (file->flags & O_NONBLOCK))
+    {
+        return -EAGAIN;
+    }
+
     return result;
+}
+
+/** Device select method. Default impementation returns true.
+ * @param file reference to the file
+ * @param mode FREAD for read active, FWRITE for write active, 0 for
+ *        exceptions
+ * @return true if active, false if inactive
+ */
+bool Pic32mxCan::select(File* file, int mode)
+{
+    portENTER_CRITICAL();
+    bool retval = false;
+    switch (mode)
+    {
+        case FREAD:
+            if (CANGetChannelEvent(hw_, CAN_CHANNEL1) &
+                CAN_RX_CHANNEL_NOT_EMPTY)
+            {
+                retval = true;
+            }
+            else
+            {
+                Device::select_insert(&rxSelect_);
+            }
+            break;
+        case FWRITE:
+            if (CANGetChannelEvent(hw_, CAN_CHANNEL0) & CAN_TX_CHANNEL_NOT_FULL)
+            {
+                retval = true;
+            }
+            else
+            {
+                Device::select_insert(&txSelect_);
+            }
+            break;
+        default:
+        case 0:
+            /* we don't support any exceptions */
+            break;
+    }
+    portEXIT_CRITICAL();
+
+    return retval;
 }
 
 void Pic32mxCan::enable()
@@ -422,6 +478,7 @@ Pic32mxCan can1(CAN2, "/dev/can1");
 */
 void Pic32mxCan::isr()
 {
+    int woken = 0;
     if ((CANGetModuleEvent(hw_) & CAN_RX_EVENT) != 0)
     //    if(CANGetPendingEventCode(hw_) == CAN_CHANNEL1_EVENT)
     {
@@ -442,8 +499,7 @@ void Pic32mxCan::isr()
          * */
         CANEnableChannelEvent(hw_, CAN_CHANNEL1, CAN_RX_CHANNEL_NOT_EMPTY,
                               FALSE);
-        int woken;
-        rxSem_.post_from_isr(&woken);
+        Device::select_wakeup_from_isr(&rxSelect_, &woken);
     }
     if ((CANGetModuleEvent(hw_) & CAN_TX_EVENT) != 0)
     //    if(CANGetPendingEventCode(hw_) == CAN_CHANNEL0_EVENT)
@@ -451,9 +507,9 @@ void Pic32mxCan::isr()
         /* Same with the TX event. */
         CANEnableChannelEvent(hw_, CAN_CHANNEL0, CAN_TX_CHANNEL_NOT_FULL,
                               FALSE);
-        int woken;
-        txSem_.post_from_isr(&woken);
+        Device::select_wakeup_from_isr(&txSelect_, &woken);
     }
+    g_pic32_last_stack_ptr = &woken;
 }
 
 extern "C" {

--- a/src/freertos_drivers/pic32mx/Pic32mxCan.cxx
+++ b/src/freertos_drivers/pic32mx/Pic32mxCan.cxx
@@ -515,7 +515,7 @@ void Pic32mxCan::isr()
 extern "C" {
 
 /// Hardware interrupt for CAN1.
-void __attribute__((interrupt,nomips16)) can1_interrupt(void)
+void can1_interrupt(void)
 {
     can0.isr();
     INTClearFlag(INT_CAN1);
@@ -535,8 +535,8 @@ void __attribute__((interrupt,nomips16)) can2_interrupt(void)
 
 /// Places a jump instruction to can1_interrupt to the proper interrupt vector
 /// location.
-asm("\n\t.section .vector_46,\"ax\",%progbits\n\tj "
-    "can1_interrupt\n\tnop\n.text\n");
+//asm("\n\t.section .vector_46,\"ax\",%progbits\n\tj "
+//    "can1_interrupt\n\tnop\n.text\n");
 /*
 /// Places a jump instruction to can2_interrupt to the proper interrupt vector
 /// location.

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -967,34 +967,6 @@ OS_INLINE unsigned sleep(unsigned seconds)
 }
 #endif
 
-/* This section of code is required because CodeSourcery's mips-gcc
- * distribution contains a strangely compiled NewLib (in the unhosted-libc.a
- * version) that does not forward these function calls to the implementations
- * we have. We are thus forced to override their weak definition of these
- * functions. */
-#if defined(TARGET_PIC32MX) || defined(ESP_NONOS)
-#include "reent.h"
-
-OS_INLINE int open(const char* b, int flags, ...) {
-    return _open_r(_impure_ptr, b, flags, 0);
-}
-OS_INLINE int close(int fd) {
-    return _close_r(_impure_ptr, fd);
-}
-OS_INLINE ssize_t read(int fd, void* buf, size_t count) {
-    return _read_r(_impure_ptr, fd, buf, count);
-}
-OS_INLINE ssize_t write(int fd, const void* buf, size_t count) {
-    return _write_r(_impure_ptr, fd, buf, count);
-}
-OS_INLINE off_t lseek(int fd, off_t offset, int whence) {
-    return _lseek_r(_impure_ptr, fd, offset, whence);
-}
-OS_INLINE int fstat(int fd, struct stat* buf) {
-    return _fstat_r(_impure_ptr, fd, buf);
-}
-
-#endif
 
 #ifdef __cplusplus
 }

--- a/targets/freertos.mips4k.pic32mx/freertos/sources
+++ b/targets/freertos.mips4k.pic32mx/freertos/sources
@@ -17,5 +17,7 @@ port.o queue.o tasks.o croutine.o timers.o event_groups.o: ARCH = -mips32r2 -min
 
 CXXSRCS +=
 
+# Bug in port.c causes compile error because string.h is not #included
+CFLAGS += -include string.h
 
 ASMSRCS += port_asm.S


### PR DESCRIPTION
Optimizes the PIC32MX RAM memory usage:
- uses an optimized build of NEWLIB
  - this saves space in the struct reent and the malloc implementation static tables
- implements select in the Pic32MXCAN driver
  - this removes the read and write threads, their stacks, reents et al
- moves to dedicated interrupt stack with the CAN driver interrupt as well
  - this reduces the stack space needed on user tasks and the idle task
- tunes stack space allocation.