### PR TITLE
FreeRTOSTCP for TI Launchpad 129/1294 fixes

### DIFF
--- a/applications/can_eth/main.cxx
+++ b/applications/can_eth/main.cxx
@@ -55,7 +55,7 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 
-#define version "can_eth Vrs 0.1"
+#define VERSION "can_eth Vrs 0.1"
 
 
 Executor<1> g_executor("g_executor", 0, 1024);
@@ -84,7 +84,7 @@ int appl_main(int argc, char* argv[])
     const int listen_port = 12021;
     int serial_fd = ::open("/dev/ser0", O_RDWR); // or /dev/ser0
     HASSERT(serial_fd >= 0);
-    printf(version);
+    printf(VERSION);
     printf(" started, listening on port %d\n",listen_port);
 
     GcTcpHub hub(&can_hub0,listen_port);

--- a/applications/can_eth/main.cxx
+++ b/applications/can_eth/main.cxx
@@ -55,6 +55,8 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 
+#define version "can_eth Vrs 0.1"
+
 
 Executor<1> g_executor("g_executor", 0, 1024);
 Service g_service(&g_executor);
@@ -79,11 +81,13 @@ OVERRIDE_CONST(main_thread_stack_size, 900);
  */
 int appl_main(int argc, char* argv[])
 {
+    const int listen_port = 12021;
     int serial_fd = ::open("/dev/ser0", O_RDWR); // or /dev/ser0
     HASSERT(serial_fd >= 0);
-    printf("Started\n");
+    printf(version);
+    printf(" started, listening on port %d\n",listen_port);
 
-    GcTcpHub hub(&can_hub0,9000);
+    GcTcpHub hub(&can_hub0,listen_port);
 
     int can_fd = ::open("/dev/can0", O_RDWR);
     HASSERT(can_fd >= 0);

--- a/src/freertos_drivers/net_freertos_tcp/FreeRTOSTCPSocket.cxx
+++ b/src/freertos_drivers/net_freertos_tcp/FreeRTOSTCPSocket.cxx
@@ -277,7 +277,7 @@ int FreeRTOSTCPSocket::accept(
 
     Socket_t sd = FreeRTOS_accept(s->sd, &fr_address, &fr_address_len);
 
-    if (address && address_len)
+    if (address && address_len && (*address_len >= sizeof(sockaddr_in)))
     {
         // copy the address across and set the address family
         sin->sin_port = fr_address.sin_port;
@@ -342,16 +342,20 @@ int FreeRTOSTCPSocket::connect(
 
     struct freertos_sockaddr fr_address;
     socklen_t fr_address_len = sizeof(fr_address);
+    fr_address.sin_len = sizeof(fr_address);
+
     switch (sin->sin_family)
     {
         case AF_INET:
+        	fr_address.sin_family = FREERTOS_AF_INET;
             break;
         default:
             errno = EINVAL;
             return -1;
     }
 
-    memcpy(&fr_address, address->sa_data, fr_address_len);
+    fr_address.sin_addr = sin->sin_addr.s_addr;
+    fr_address.sin_port = sin->sin_port;
 
     int result = FreeRTOS_connect(s->sd, &fr_address, fr_address_len);
 

--- a/src/freertos_drivers/net_freertos_tcp/FreeRTOSTCPSocket.cxx
+++ b/src/freertos_drivers/net_freertos_tcp/FreeRTOSTCPSocket.cxx
@@ -169,9 +169,12 @@ int FreeRTOSTCPSocket::bind(
     }
 
     struct freertos_sockaddr fr_address;
+    fr_address.sin_len = sizeof(fr_address);
+
     switch (address->sa_family)
     {
         case AF_INET:
+        	fr_address.sin_family = FREERTOS_AF_INET;
             break;
         default:
             errno = EINVAL;
@@ -182,7 +185,7 @@ int FreeRTOSTCPSocket::bind(
     fr_address.sin_addr = sin->sin_addr.s_addr;
     fr_address.sin_port = sin->sin_port;
 
-    int result = FreeRTOS_bind(s->sd, &fr_address, address_len);
+    int result = FreeRTOS_bind(s->sd, &fr_address, sizeof(fr_address));
 
     if (result < 0)
     {

--- a/src/freertos_drivers/net_freertos_tcp/FreeRTOSTCPSocket.cxx
+++ b/src/freertos_drivers/net_freertos_tcp/FreeRTOSTCPSocket.cxx
@@ -177,9 +177,10 @@ int FreeRTOSTCPSocket::bind(
             errno = EINVAL;
             return -1;
     }
-    // fr_address.sin_addr = ((const struct sockaddr_in *)(address))->sin_addr;
-    // fr_address.sin_port = address->sin_port;
-    memcpy(&fr_address, address->sa_data, sizeof(fr_address));
+
+    struct sockaddr_in *sin = (struct sockaddr_in *)(address);
+    fr_address.sin_addr = sin->sin_addr.s_addr;
+    fr_address.sin_port = sin->sin_port;
 
     int result = FreeRTOS_bind(s->sd, &fr_address, address_len);
 


### PR DESCRIPTION
Fixes a compatibility issue due to changes in the FreeRTOS Labs
sockaddr structure which were manifest in bind operations failing to
function properly.
Change the port number used by the can_eth application from 9000 to
12021 for consistency with the hub application.