### PR TITLE
Fix EEPROMEmu bug

### DIFF
--- a/src/freertos_drivers/common/EEPROMEmulation.cxx
+++ b/src/freertos_drivers/common/EEPROMEmulation.cxx
@@ -290,12 +290,10 @@ void EEPROMEmulation::read(unsigned int offset, void *buf, size_t len)
     memset(byte_data, 0xff, len); // default if data not found
 
     for (unsigned block_index = slot_first();
-         block_index <= slot_last();
+         block_index < rawBlockCount_ - availableSlots_;
          ++block_index)
     {
     	const uint32_t *address = block(activeSector_, block_index);
-    	if (*address == MAGIC_ERASED)
-            break;
         unsigned slot_offset = (address[0] >> 16) * BYTES_PER_BLOCK;
         // Check if slot overlaps with desired data.
         if (offset + len <= slot_offset)

--- a/src/freertos_drivers/common/EEPROMEmulation.cxx
+++ b/src/freertos_drivers/common/EEPROMEmulation.cxx
@@ -93,7 +93,7 @@ void EEPROMEmulation::mount()
     {
         /* look for first data block */
         for (unsigned block_index = rawBlockCount_ - 1;
-        	 block_index != MAGIC_COUNT; --block_index)
+             block_index >= MAGIC_COUNT; --block_index)
         {
             if (*block(activeSector_, block_index) != MAGIC_ERASED)
             {

--- a/src/utils/EEPROMEmuTest.hxx
+++ b/src/utils/EEPROMEmuTest.hxx
@@ -268,6 +268,10 @@ TEST_F(EepromTest, smalloverflow) {
     EXPECT_AT(13, "abcd");
     overflow_block();
     EXPECT_AT(13, "abcd");
+    EXPECT_EQ(3, e->activeSector_);
+    create(false);
+    EXPECT_AT(13, "abcd");
+    EXPECT_EQ(3, e->activeSector_);
 }
 
 TEST_F(EepromTest, many_overflow) {
@@ -280,4 +284,8 @@ TEST_F(EepromTest, many_overflow) {
         overflow_block();
     }
     EXPECT_AT(13, "abcd");
+    unsigned s = e->activeSector_;
+    create(false);
+    EXPECT_AT(13, "abcd");
+    EXPECT_EQ(s, e->activeSector_);
 }

--- a/src/utils/EEPROMEmuTest.hxx
+++ b/src/utils/EEPROMEmuTest.hxx
@@ -91,9 +91,7 @@ public:
         }
         mount();
 
-        LOG(INFO, "sector count %d", sector_count());
-        LOG(INFO, "slot count %d", slot_count());
-        LOG(INFO, "active index %d", activeSector_);
+        LOG(INFO, "sector count %d, active index %d, slot count %d, available count %d", sector_count(), activeSector_, slot_count(), avail());
     }
 
     /// @return how many blocks are available in the current sector.
@@ -234,6 +232,19 @@ TEST_F(EepromTest, readwrite) {
     // Reboot MCU
     create(false);
     EXPECT_AT(12, "kqbcd\xFF");
+}
+
+TEST_F(EepromTest, readwrite_recreate) {
+    create();
+    // Reboot MCU after creating empty.
+    create(false);
+
+    write_to(13, "abcd");
+    EXPECT_AT(13, "abcd");
+
+    // Reboot MCU
+    create(false);
+    EXPECT_AT(13, "abcd");
 }
 
 TEST_F(EepromTest, smalloverflow) {


### PR DESCRIPTION
There was an off-by-one bug in the eeprom emulation driver, which could be triggered by the following actions:
- with all-erased EEPROM, boot the MCU
- then reboot without writing anything
- then write stuff

and the written stuff would never show up.

This PR adds a regression test for this sequence of actions, and fixes a bug and and an inconsistency in the code to make the issue not show up again and any EEPROMs that have the issue to not be sensitive to it anymore.
