### PR TITLE
bracz: gridconnect select support

### DIFF
--- a/include/nmranet_config.h
+++ b/include/nmranet_config.h
@@ -108,6 +108,10 @@ DECLARE_CONST(gridconnect_buffer_size);
  * off to the lowlevel system (such as a TCP socket). */
 DECLARE_CONST(gridconnect_buffer_delay_usec);
 
+/** Whether the GridConnect TCP server should use select (single-threaded) or
+ * two threads per client (multi-threaded) execution model. */
+DECLARE_CONST(gridconnect_tcp_use_select);
+
 /** Number of entries in the remote alias cache */
 DECLARE_CONST(remote_alias_cache_size);
 

--- a/src/utils/BufferPort.hxx
+++ b/src/utils/BufferPort.hxx
@@ -129,6 +129,10 @@ private:
         tgtBuf_ = nullptr;
         b->data()->assign(sendBuf_, bufEnd_);
         bufEnd_ = 0;
+        if (message())
+        {
+            b->set_done(message()->new_child());
+        }
         downstream_->send(b);
     }
 

--- a/src/utils/GcTcpHub.cxx
+++ b/src/utils/GcTcpHub.cxx
@@ -35,6 +35,7 @@
 
 #include "utils/GcTcpHub.hxx"
 
+#include "nmranet_config.h"
 #include "utils/GridConnectHub.hxx"
 
 void GcTcpHub::OnNewConnection(int fd)

--- a/src/utils/GcTcpHub.cxx
+++ b/src/utils/GcTcpHub.cxx
@@ -39,7 +39,9 @@
 
 void GcTcpHub::OnNewConnection(int fd)
 {
-    create_gc_port_for_can_hub(canHub_, fd);
+    const bool use_select =
+        (config_gridconnect_tcp_use_select() == CONSTANT_TRUE);
+    create_gc_port_for_can_hub(canHub_, fd, nullptr, use_select);
 }
 
 GcTcpHub::GcTcpHub(CanHubFlow *can_hub, int port)

--- a/src/utils/GridConnectHub.cxx
+++ b/src/utils/GridConnectHub.cxx
@@ -160,13 +160,21 @@ public:
                 /// performance.
                 target_buffer->data()->resize(size);
                 memcpy((char *)target_buffer->data()->data(), dbuf_, size);
+                target_buffer->set_done(bn_.reset(this));
                 delayPort_.send(target_buffer, 0);
+                release();
+                return wait_and_call(STATE(buffer_accepted));
             }
             else
             {
                 LOG(INFO, "gc generate failed.");
             }
             return release_and_exit();
+        }
+
+        Action buffer_accepted()
+        {
+            return exit();
         }
 
     private:
@@ -181,6 +189,8 @@ public:
         HubPort *skipMember_;
         /// Non-zero if doubling was requested.
         int double_bytes_;
+        /// Helper object
+        BarrierNotifiable bn_;
     };
 
     /// HubPort (on a string hub) that turns a gridconnect-formatted CAN packet

--- a/src/utils/GridConnectHub.hxx
+++ b/src/utils/GridConnectHub.hxx
@@ -121,9 +121,9 @@ private:
     std::unique_ptr<Impl> impl_;
 };
 
-/** Creates a new port on a CAN hub in gridconnect format. The port will
- * automatically be closed, deleted and on_exit notified when the fd encounters
- * an error.
+/** Creates a new port on a CAN hub in gridconnect format for a
+ * select-compatible file descriptor. The port will automatically be closed,
+ * deleted and on_exit notified when the fd encounters an error.
  *
  * NOTE(balazs.racz): this could be expanded to return an object pointer via
  * which the port can be closed.
@@ -131,8 +131,11 @@ private:
  * @param can_hub the raw CAN packets are coming/going to this object.
  * @param fd the file descriptor of the port to send/receive the gridconnect
  * ascii data to/from.
- * @param on_exit is a notificable (may be null) which will be called in case
- * an error is encountered on this port and the port is subsequently closed. */
-void create_gc_port_for_can_hub(CanHubFlow* can_hub, int fd, Notifiable* on_exit = nullptr);
+ * @param on_exit is a notifiable (may be null) which will be called in case
+ * an error is encountered on this port and the port is subsequently closed.
+ * @param use_select when true, the FD will be used with select, when false,
+ * separate threads will be started with blocking read and write calls. */
+void create_gc_port_for_can_hub(CanHubFlow *can_hub, int fd,
+    Notifiable *on_exit = nullptr, bool use_select = false);
 
 #endif //_UTILS_GRIDCONNECTHUB_HXX_

--- a/src/utils/Hub.hxx
+++ b/src/utils/Hub.hxx
@@ -213,4 +213,23 @@ private:
                        ///printed.
 };
 
+
+/** Shared base class for thread-based and select-based hub devices. */
+class FdHubPortInterface : public Destructable {
+public:
+    /// @return the filedes to read/write.
+    int fd()
+    {
+        return fd_;
+    }
+
+protected:
+    FdHubPortInterface() : fd_(-1) {}
+
+    FdHubPortInterface(int fd) : fd_(fd) {}
+
+    /** The device file descriptor. */
+    int fd_{-1};
+};
+
 #endif // _UTILS_HUB_HXX_

--- a/src/utils/HubDevice.hxx
+++ b/src/utils/HubDevice.hxx
@@ -44,7 +44,7 @@ template <class Data> class FdHubWriteFlow;
 /// Template-nonspecific base class for @ref FdHubPort. The purpose of this
 /// class is to avoid compiling this code multiple times for differently typed
 /// devices (and thus saving flash space).
-class FdHubPortBase : public Destructable, private Atomic
+class FdHubPortBase : public FdHubPortInterface, private Atomic
 {
 public:
     /// How many bytes of stack should we allocate to the write thread's stack.
@@ -56,7 +56,7 @@ public:
     /// @param done will be called when this file is closed and removed from
     /// the hub (usually due to an error).
     FdHubPortBase(int fd, Notifiable *done)
-        : fd_(fd)
+        : FdHubPortInterface(fd)
         , writeThread_(fill_thread_name('W', fd), 3, kWriteThreadStackSize)
         , writeService_(&writeThread_)
         , barrier_(done)
@@ -68,12 +68,6 @@ public:
 
     virtual ~FdHubPortBase()
     {
-    }
-
-    /// @return the filedes to read/write.
-    int fd()
-    {
-        return fd_;
     }
 
     /// Puts the desired thread name for the read or write thread.
@@ -192,8 +186,6 @@ protected:
 
     /** Temporary buffer used for rendering thread names. */
     char threadName_[30];
-    /** The device file descriptor. */
-    int fd_;
     /** This executor is running the writes. */
     Executor<1> writeThread_;
     /** Service for the write flow. */

--- a/src/utils/constants.cxx
+++ b/src/utils/constants.cxx
@@ -148,3 +148,5 @@ DEFAULT_CONST(gridconnect_buffer_delay_usec, 300);
 DEFAULT_CONST(gridconnect_port_max_incoming_packets, 6);
 /// 1 = infinite, do not preallocate memory
 DEFAULT_CONST(gridconnect_bridge_max_incoming_packets, 1);
+
+DEFAULT_CONST(gridconnect_tcp_use_select, CONSTANT_FALSE);


### PR DESCRIPTION
Adds the ability to have select-aware files/sockets as gridconnect ports.
Fixes some buffering (flow control) issues in sending traffic to/from gridconnect ports.