### PR TITLE
Fixes for the bootloader

### DIFF
--- a/applications/bootloader/targets/bare.armv7m.bracz-railcom/NodeId.cxx
+++ b/applications/bootloader/targets/bare.armv7m.bracz-railcom/NodeId.cxx
@@ -6,5 +6,5 @@ const openlcb::NodeID NODE_ID = 0x050101011400ULL | NODEID_LOW_BITS;
 extern const uint16_t DEFAULT_ALIAS;
 const uint16_t DEFAULT_ALIAS = 0x400 | NODEID_LOW_BITS;
 
-#define BOOTLOADER_STREAM
+#define BOOTLOADER_DATAGRAM
 #include "openlcb/Bootloader.hxx"

--- a/applications/bootloader/targets/bare.armv7m.bracz-railcom/memory_map.ld
+++ b/applications/bootloader/targets/bare.armv7m.bracz-railcom/memory_map.ld
@@ -1,1 +1,1 @@
-../../../../boards/ti-ek-tm4c123gxl-launchpad/memory_map.ld
+../../../../boards/bracz-railcom/memory_map.ld

--- a/boards/bracz-railcom/HwInit.cxx
+++ b/boards/bracz-railcom/HwInit.cxx
@@ -343,8 +343,6 @@ void hw_preinit(void)
     MAP_IntEnable(INT_TIMER4A);
     // Still above kernel but not prio zero
     MAP_IntPrioritySet(INT_TIMER4A, 0x80);
-    MAP_TimerIntEnable(TIMER4_BASE, TIMER_TIMA_TIMEOUT);
-    MAP_TimerEnable(TIMER4_BASE, TIMER_A);
 
     /* Checks the SW1 pin at boot time in case we want to allow for a debugger
      * to connect. */
@@ -357,6 +355,16 @@ void hw_preinit(void)
       }
     } while (blinker_pattern || rest_pattern);
     asm volatile ("cpsid i\n");
+}
+
+/** Initialize the processor hardware.
+ */
+void hw_postinit(void)
+{
+    // Enables charlieplexing interrupt only after the static initialization
+    // has created the object itself.
+    MAP_TimerIntEnable(TIMER4_BASE, TIMER_TIMA_TIMEOUT);
+    MAP_TimerEnable(TIMER4_BASE, TIMER_A);
 }
 
 }

--- a/boards/bracz-railcom/HwInit.cxx
+++ b/boards/bracz-railcom/HwInit.cxx
@@ -289,7 +289,7 @@ void uart1_interrupt_handler(void)
 
 void diewith(uint32_t pattern)
 {
-    vPortClearInterruptMask(0x20);
+    vPortClearInterruptMask(0xA0);
     asm("cpsie i\n");
 
     resetblink(pattern);

--- a/boards/bracz-railcom/Makefile
+++ b/boards/bracz-railcom/Makefile
@@ -62,3 +62,7 @@ endif
 
 rflash: $(EXECUTABLE).bin
 	$(OPENMRNPATH)/applications/bootloader_client/targets/linux.x86/bootloader_client -c tiva123 -r -n 0x0501010114$$(printf %02x $(ADDRESS)) -f $<
+
+
+package: $(EXECUTABLE).bin
+	$(OPENMRNPATH)/applications/bootloader_client/targets/linux.x86/bootloader_client -c tiva123 -f $< -D $(EXECUTABLE).upload

--- a/boards/bracz-railcom/memory_map.ld
+++ b/boards/bracz-railcom/memory_map.ld
@@ -1,9 +1,13 @@
+
+___ram_for_bootloader_api = 8;
+
 MEMORY
 {
   FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 240K
   EEPROMEMU (r): ORIGIN = 0x3C000, LENGTH = 8K
   BOOTLOADER (rx) : ORIGIN = 0x0003E000, LENGTH = 8K
-  RAM  (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
+  RAM  (rwx) : ORIGIN = 0x20000000, LENGTH = 32K - ___ram_for_bootloader_api
+  BOOTLOADERAPI (rw) : ORIGIN = 0x20000000 + 32K - ___ram_for_bootloader_api, LENGTH = ___ram_for_bootloader_api
 }
 
 __flash_start = ORIGIN(FLASH);
@@ -13,3 +17,4 @@ __eeprom_end = ORIGIN(EEPROMEMU) + LENGTH(EEPROMEMU);
 __bootloader_start = ORIGIN(BOOTLOADER);
 __app_header_offset = 0x270;
 __bootloader_magic_ptr = ORIGIN(RAM);
+__application_node_id = ORIGIN(BOOTLOADERAPI);

--- a/boards/ti-ek-tm4c123gxl-launchpad/memory_map.ld
+++ b/boards/ti-ek-tm4c123gxl-launchpad/memory_map.ld
@@ -1,6 +1,4 @@
 ___ram_for_bootloader_api = 8;
-___total_ram = 32K;
-___bootloader_api_origin = ___total_ram - ___ram_for_bootloader_api;
 
 
 MEMORY
@@ -9,7 +7,7 @@ MEMORY
   EEPROMEMU (r): ORIGIN = 0x3C000, LENGTH = 8K
   BOOTLOADER (rx) : ORIGIN = 0x0003E000, LENGTH = 8K
   RAM  (rwx) : ORIGIN = 0x20000000, LENGTH = 32K - ___ram_for_bootloader_api
-  BOOTLOADERAPI (rw) : ORIGIN = ___bootloader_api_origin, LENGTH = ___ram_for_bootloader_api        
+  BOOTLOADERAPI (rw) : ORIGIN = 0x20000000 + 32K - ___ram_for_bootloader_api, LENGTH = ___ram_for_bootloader_api
 }
 
 __flash_start = ORIGIN(FLASH);

--- a/boards/ti-ek-tm4c123gxl-launchpad/memory_map.ld
+++ b/boards/ti-ek-tm4c123gxl-launchpad/memory_map.ld
@@ -1,9 +1,15 @@
+___ram_for_bootloader_api = 8;
+___total_ram = 32K;
+___bootloader_api_origin = ___total_ram - ___ram_for_bootloader_api;
+
+
 MEMORY
 {
   FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 240K
   EEPROMEMU (r): ORIGIN = 0x3C000, LENGTH = 8K
   BOOTLOADER (rx) : ORIGIN = 0x0003E000, LENGTH = 8K
-  RAM  (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
+  RAM  (rwx) : ORIGIN = 0x20000000, LENGTH = 32K - ___ram_for_bootloader_api
+  BOOTLOADERAPI (rw) : ORIGIN = ___bootloader_api_origin, LENGTH = ___ram_for_bootloader_api        
 }
 
 __flash_start = ORIGIN(FLASH);
@@ -14,3 +20,4 @@ __bootloader_start = ORIGIN(BOOTLOADER);
 __bootloader_end = ORIGIN(BOOTLOADER) + LENGTH(BOOTLOADER);
 __app_header_offset = 0x270;
 __bootloader_magic_ptr = ORIGIN(RAM);
+__application_node_id = ORIGIN(BOOTLOADERAPI);

--- a/boards/ti-tm4c123-generic/BootloaderHal.hxx
+++ b/boards/ti-tm4c123-generic/BootloaderHal.hxx
@@ -156,6 +156,8 @@ void bootloader_reboot(void)
 
 void application_entry(void)
 {
+    extern uint64_t __application_node_id;
+    __application_node_id = nmranet_nodeid();
     extern char __flash_start;
     // We store the application reset in interrupt vecor 13, which is reserved
     // / unused on all Cortex_M3 processors.

--- a/src/openlcb/Bootloader.cxxtest
+++ b/src/openlcb/Bootloader.cxxtest
@@ -564,6 +564,31 @@ TEST_F(BootloaderTest, PIPReply)
     exit_bootloader();
 }
 
+
+TEST_F(BootloaderTest, VerifyAddressed)
+{
+    proper_startup();
+
+    expect_packet(":X191704AAN1A2A3A4A5A6A;");
+    send_packet(":X19488321N04AA;");
+    wait();
+    Mock::VerifyAndClear(&canBus_);
+
+    exit_bootloader();
+}
+
+TEST_F(BootloaderTest, VerifyGlobal)
+{
+    proper_startup();
+
+    expect_packet(":X191704AAN1A2A3A4A5A6A;");
+    send_packet(":X19490321N;");
+    wait();
+    Mock::VerifyAndClear(&canBus_);
+
+    exit_bootloader();
+}
+
 TEST_F(BootloaderTest, StartWriteAtOffsetZero)
 {
     print_all_packets();

--- a/src/openlcb/Bootloader.hxx
+++ b/src/openlcb/Bootloader.hxx
@@ -563,6 +563,18 @@ void handle_addressed_message(Defs::MTI mti)
             memcpy(state_.output_frame.data + 2, &PIP_REPLY, 6);
             break;
         }
+        case Defs::MTI_VERIFY_NODE_ID_ADDRESSED:
+        {
+            if (state_.output_frame_full)
+            {
+                // No buffer. Re-try next round.
+                return;
+            }
+            set_can_frame_global(Defs::MTI_VERIFIED_NODE_ID_NUMBER);
+            set_can_frame_nodeid();
+            state_.input_frame_full = 0;
+            return;
+        }
         case Defs::MTI_DATAGRAM_OK:
         {
             if (state_.datagram_reply_waiting)
@@ -647,6 +659,23 @@ void handle_addressed_message(Defs::MTI mti)
 /// Handles incoming global message.
 void handle_global_message(Defs::MTI mti)
 {
+    switch (mti)
+    {
+        case Defs::MTI_VERIFY_NODE_ID_GLOBAL:
+        {
+            if (state_.output_frame_full)
+            {
+                // No buffer. Re-try next round.
+                return;
+            }
+            set_can_frame_global(Defs::MTI_VERIFIED_NODE_ID_NUMBER);
+            set_can_frame_nodeid();
+            state_.input_frame_full = 0;
+            return;
+        }
+    default:
+        break;
+    }
     // Drop to the floor.
     state_.input_frame_full = 0;
     /// @todo(balazs.racz) what about global identify messages?


### PR DESCRIPTION
Adds a facility to have the bootloader hand off the Node ID to the application.
Adds verify node ID support for the bootloader (both global and addressed).

Minor fixes for the bracz-railcom board.