### PR TITLE
Adding some documentation on the example applications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ page will give you a good idea of status of the specifications.
 
 OpenMRN is a set of C++ code that is designed to make it easier to implement
 support for LCC. This might be in accessory decoders, in a command station, in a
-throttle, or any other device. The code is designed to be able to run on micro
-controllers. There are currently a number of different 32-bit micro controllers
+throttle, or any other device. The code is designed to be able to run on
+microcontrollers. There are currently a number of different 32-bit microcontrollers
 supported. To find the full list, you'll need to check the boards folder.
 
 **Note:** The software license terms are 2-clause BSD in order to be commercial
@@ -37,7 +37,7 @@ virtual machine. Below are some high-level instructions on getting started.
 
 ## Create a Linux Virtual Machine
 
-* Install Oracle [VirtualBox](https://www.virtualbox.org/) with is available for
+* Install Oracle [VirtualBox](https://www.virtualbox.org/) which is available for
 free.
 * Create a virtual machine
     * Ideally, this should be a 64-bit virtual machine

--- a/README.md
+++ b/README.md
@@ -72,9 +72,17 @@ sudo apt-get install git
 sudo apt-get install doxygen
 cd ~
 git clone https://github.com/bakerstu/openmrn/
-cd openmrn/doc
+```
+## Building and Viewing the Documentation
+
+At this point you can build, and then view the documentation. Here are the steps
+to build the documentation:
+
+```
+cd ~openmrn/doc
 make html
 ```
+
 That should create the HTML files. Now open the **Files** application, navigate
 to Home/openmrn/doc and double-click **index.html**. This will open the OpenMRN
 documentation in your browser (which is Firefox by default).

--- a/README.md
+++ b/README.md
@@ -1,53 +1,70 @@
 # OpenMRN
 
-OpenMRN (Open Model Railroad Network) is a set of software libraries that are designed to make it easier to implement support for the NMRA's
-LCC (Layout Command Control) bus.
+OpenMRN (Open Model Railroad Network) is a set of software libraries that are
+designed to make it easier to implement support for the NMRA's LCC (Layout
+Command Control) bus.
 
-The work to define LCC was done by the [OpenLCB group](http://openlcb.org/), and that's a good place to go in order to learn more about LCC.
-In particular, [Introduction to OpenLCB](http://openlcb.org/about-openlcb/introduction-to-openlcb/). Whenever you see _OpenLCB_, just think
-of this as a public working group that is creating standards that, once approved by the NMRA, become LCC standards. The 
-[OpenLCB & LCC Standards](http://openlcb.org/openlcb-and-lcc-documents/layout-command-control-lcc/) page will give you a good idea of status
-of the specifications.
+The work to define LCC was done by the [OpenLCB group](http://openlcb.org/),
+and that's a good place to go in order to learn more about LCC. In particular,
+[Introduction to OpenLCB](http://openlcb.org/about-openlcb/introduction-to-openlcb/).
+Whenever you see _OpenLCB_, just think of this as a public working group that is
+creating standards that, once approved by the NMRA, become LCC standards. The 
+[OpenLCB & LCC Standards](http://openlcb.org/openlcb-and-lcc-documents/layout-command-control-lcc/)
+page will give you a good idea of status of the specifications.
 
 ## Why OpenMRN
 
-OpenMRN is a set of C++ code that is designed to make it easier to implement support for LCC. This might be in accessory decoders, in a command
-station, in a throttle, or any other device. The code is designed to be able to run on micro controllers. There are currently a number of
-different 32-bit micro controllers supported. To find the full list, you'll need to check the boards folder.
+OpenMRN is a set of C++ code that is designed to make it easier to implement
+support for LCC. This might be in accessory decoders, in a command station, in a
+throttle, or any other device. The code is designed to be able to run on micro
+controllers. There are currently a number of different 32-bit micro controllers
+supported. To find the full list, you'll need to check the boards folder.
 
-**Note:** The software license terms are 2-clause BSD in order to be commercial friendly. This allows commercial applications to be written that use
-the open source OpenMRN libraries without having to be open source themselves.
+**Note:** The software license terms are 2-clause BSD in order to be commercial
+friendly. This allows commercial applications to be written that use the open
+source OpenMRN libraries without having to be open source themselves.
 
 # Getting Started
 
-Most of the documentation for OpenMRN is in [doxygen](http://www.stack.nl/~dimitri/doxygen/) format. The best way to view the documents is to
-build the HTML files (instructions below).
+Most of the documentation for OpenMRN is in
+[doxygen](http://www.stack.nl/~dimitri/doxygen/) format. The best way to view
+the documents is to build the HTML files (instructions below).
 
-The existing OpenMRN stack makes heavy use of Linux build tools. As a result, the best way to get up and running, and to build the documentation,
-is within Linux or Mac OS X. If you have a Windows, we recommend that you create a Linux virtual machine. Below are some high-level
-instructions on getting started.
+The existing OpenMRN stack makes heavy use of Linux build tools. As a result,
+the best way to get up and running, and to build the documentation, is within
+Linux or Mac OS X. If you have a Windows, we recommend that you create a Linux
+virtual machine. Below are some high-level instructions on getting started.
 
 ## Create a Linux Virtual Machine
 
-* Install Oracle [VirtualBox](https://www.virtualbox.org/) with is available for free.
+* Install Oracle [VirtualBox](https://www.virtualbox.org/) with is available for
+free.
 * Create a virtual machine
     * Ideally, this should be a 64-bit virtual machine
     * Assign it at least 4GB of RAM
     * Assign it multiple cores (improves build speed)
-    * Create a _dynamically allocated_ virtual disk that is larger than the default. The default is 10GB, and we recommend at least 30GB. More is
-    better because the virtual machine file itself will expand, but the maximum size is hard to change in the future
-* Download a copy of Ubuntu desktop. At the time of this writing, 16.04 LTS is a good machine. Download this as an ISO disk image
-* Start the virtual machine. It will ask you to select a startup disk. Select the ISO file that you downloaded for Ubuntu desktop
+    * Create a _dynamically allocated_ virtual disk that is larger than the
+      default. The default is 10GB, and we recommend at least 30GB. More is
+      better because the virtual machine file itself will expand, but the
+      maximum size is hard to change in the future
+* Download a copy of Ubuntu desktop. At the time of this writing, 16.04 LTS is a
+  good machine. Download this as an ISO disk image
+* Start the virtual machine. It will ask you to select a startup disk. Select
+  the ISO file that you downloaded for Ubuntu desktop
 
-Once you've done this, you'll need to do a few more things before you can get the source code and build the documentation.
+Once you've done this, you'll need to do a few more things before you can get
+the source code and build the documentation.
 
 ## Installing Required Software (Linux or Mac)
 
-All software installation will be done through the command line, known as a _terminal_ in Ubuntu Linux. Most of these commands will start with
-**sudo** in order to run them with administrator privileges. Building the documentation requires the gcc/g++ or LLVM compiler to be installed.
-Ubuntu LTS comes with the compilers already installed.
+All software installation will be done through the command line, known as a
+_terminal_ in Ubuntu Linux. Most of these commands will start with **sudo** in
+order to run them with administrator privileges. Building the documentation
+requires the gcc/g++ or LLVM compiler to be installed. Ubuntu LTS comes with the
+compilers already installed.
 
-Open a terminal window (for Ubuntu, right click anywhere on the desktop and click **Open Terminal**) and enter the following commands (these all require
+Open a terminal window (for Ubuntu, right click anywhere on the desktop and
+click **Open Terminal**) and enter the following commands (these all require
 access to the internet):
 
 ```
@@ -58,5 +75,6 @@ git clone https://github.com/bakerstu/openmrn/
 cd openmrn/doc
 make html
 ```
-That should create the HTML files. Now open the **Files** application, navigate to Home/openmrn/doc and double-click **index.html**. This will
-open the OpenMRN documentation in your browser (which is Firefox by default).
+That should create the HTML files. Now open the **Files** application, navigate
+to Home/openmrn/doc and double-click **index.html**. This will open the OpenMRN
+documentation in your browser (which is Firefox by default).

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ At this point you can build, and then view the documentation. Here are the steps
 to build the documentation:
 
 ```
-cd ~openmrn/doc
+cd ~/openmrn/doc
 make html
 ```
 

--- a/doc/1_applications.dox
+++ b/doc/1_applications.dox
@@ -8,46 +8,54 @@
 
 The easiest way to get started for many people is with samples. We've provided
 the source for some applications. Some of these applications you can run
-directly from the command line. While others will require a device.
+directly from the command line, while others will require a device.
 
 @section application_folders Directory Organization
 
 The sample applications typically have the following folder structure:
 
+@code
     targets/
     config.mk
     Makefile
     subdirs
+@endcode
 
-The code for an application typcially consists of two parts: shared and
-target-specific. The shared code will be at the top folder for the application.
-While the target-specific information will be under a target folder. As an
-example, the blink_raw application has shared code here:
+The code for an application typically consists of two parts: shared and
+target-specific. The shared code will be at the top folder for the application,
+while the target-specific information will be under a target folder. As an
+example, the blink_raw application has these files among the shared and target-
+specific code, respectively:
 
+@code
     applications/blink_raw/
         main.cxx
         targets/freertos.armv7m.mbed-1768/
             hw_init.cxx
+@endcode
 
 The idea is that you can have target-specific (platform-specific) code that
-allows customizing the shared code for different platforms.
+allows customizing the shared code for different platforms. This is typically
+for initializing hardware, while the shared code is used typically for the
+application behavior.
 
 @subsection application_build Building a Sample
 
 Generally when you build a sample, you'll want to do so from a single target
-directory, as that will build faster and only build what you need. Here we're
+directory, as that will build faster and only build what you need. Below we're
 going to build the Linux versions so you can run them without needing a
-specific board.
+specific board, starting with the @ref hub_application example.
 
 @section grid_connect GridConnect Protocol
 
 Some of the sample applications use a protocol referred to here as the
-GridConnect protocol. This is an ASCII protocol that is used by USB-to-CAN
-interfaces sold by [GridConnect](http://gridconnect.com/).
+GridConnect protocol to represent CAN-bus frames. This is an ASCII protocol
+that is used by USB-to-CAN interfaces sold by
+[GridConnect](http://gridconnect.com/).
 
 A normal CAN message in GidConnect format looks like this:
 
-:X <_Identifier_> <N> <_Data-0_><_Data-1_>...<_Data-7_>;
+    :X <_Identifier_> <N> <_Data-0_><_Data-1_>...<_Data-7_>;
 
 This ASCII format is used for TCP messages. On the CAN network all traffic is
 binary.
@@ -56,10 +64,10 @@ Here is an actual example:
 
     :X19545415N0502010202000000;
 
-The ID is 19545415. LCC uses 29-bit CAN identifiers. The data bytes are encoded
-as HEX.
+The ID is 19545415. LCC uses 29-bit CAN identifiers. The identifier and data
+bytes are encoded as HEX.
 
-You can also have messages that contains no extra data. For example:
+You can also have messages that contain no extra data. For example:
 
     :X17050415N;
 
@@ -76,7 +84,7 @@ rather than alphabetical order.
 
 The hub application will run from the command line and it's a great place to
 start with working on an LCC application. You can send CAN packets to the hub
-over TCP and it will display the packets, and also forward them to any others
+over TCP and it will display the packets, and also forward them to any other
 programs that have connected to the same port. This application knows about CAN
 packets, but nothing about LCC. It will forward all CAN packets, regardless of
 their format.
@@ -88,9 +96,11 @@ your desktop computer.
 As mentioned above in the @ref application_folders section, you should typically
 build samples from within a platform-specific folder. For example:
 
-    cd ~/openmrn/applications/hub/targets/linux.x86
-    make
-    ./hub -h
+@code
+cd ~/openmrn/applications/hub/targets/linux.x86
+make
+./hub -h
+@endcode
 
 This will build the application, and then show you the options for the hub
 application. You can run the hub application without any parameters to start
@@ -101,7 +111,7 @@ async_blink, will send out such traffic.
 
 This is a more involved application, and is a good place to start with LCC. This
 application can be run from the command line, or it can be hosted on a
-micro controller to act as a very simple node.
+microcontroller to act as a very simple node.
 
 This node sends out a "blink" event every second.
 
@@ -109,8 +119,10 @@ The Node ID is defined at the target level rather than the shared level. For
 example, if you look at the linux.x86 target folder, you'll find the following
 in the **NodeId.cxx** file:
 
-*   extern const openlcb::NodeID NODE_ID;
-*   const openlcb::NodeID NODE_ID = 0x050101011410ULL;
+@code
+extern const openlcb::NodeID NODE_ID;
+const openlcb::NodeID NODE_ID = 0x050101011410ULL;
+@endcode
 
 * **Note:** Node IDs are required to be unique, so you must obtain your own ID
 before you ship anything using code you built with OpenMRN.
@@ -126,8 +138,8 @@ with both the sample applications, and applications you write. In other words,
 you can start writing and testing the LCC aspects of your application without
 an actual device.
 
-Why is this useful? In general, desktop develop is faster than embedded
-development, as you're delaing with software that is running locally on a much
+Why is this useful? In general, desktop development is faster than embedded
+development, as you're dealing with software that is running locally on a much
 faster machine with richer debugging tools available. As mentioned in
 @ref application_folders, you can easily create two versions of an application
 that share a certain amount of code. So that means you can share your LCC code

--- a/doc/1_applications.dox
+++ b/doc/1_applications.dox
@@ -45,13 +45,14 @@ Some of the sample applications use a protocol referred to here as the
 GridConnect protocol. This is an ASCII protocol that is used by USB-to-CAN
 interfaces sold by [GridConnect](http://gridconnect.com/).
 
-A normal CAN message has the following format:
+A normal CAN message in GidConnect format looks like this:
 
 :X <_Identifier_> <N> <_Data-0_><_Data-1_>...<_Data-7_>;
 
-These messages are sent within a single network (such as a CAN network or over
-TCP) as binary. But if you're using one of the GridConnect devices, their
-I/O format is text. Here is an actual example:
+This ASCII format is used for TCP messages. On the CAN network all traffic is
+binary.
+
+Here is an actual example:
 
     :X19545415N0502010202000000;
 
@@ -63,8 +64,7 @@ You can also have messages that contains no extra data. For example:
     :X17050415N;
 
 A couple of the sample applications output this format to the console in order
-to display the traffic. But, again, the actual CAN/TCP messages will be
-binary messages.
+to display the traffic.
 
 @section application_list Applications
 
@@ -77,13 +77,13 @@ rather than alphabetical order.
 The hub application will run from the command line and it's a great place to
 start with working on an LCC application. You can send CAN packets to the hub
 over TCP and it will display the packets, and also forward them to any others
-programs listening on the same port. This application knows about CAN packets,
-but nothing about LCC. It will forward all CAN packets, regardless of their
-format.
+programs that have connected to the same port. This application knows about CAN
+packets, but nothing about LCC. It will forward all CAN packets, regardless of
+their format.
 
 In addition, you can connect this application to an actual USB-to-CAN interface
-in order to have packets flow between the LCC bus and programs running on your
-desktop computer.
+in order to have packets flow between an LCC CAN segment and programs running on
+your desktop computer.
 
 As mentioned above in the @ref application_folders section, you should typically
 build samples from within a platform-specific folder. For example:
@@ -115,24 +115,27 @@ in the **NodeId.cxx** file:
 * **Note:** Node IDs are required to be unique, so you must obtain your own ID
 before you ship anything using code you built with OpenMRN.
 
+- http://registry.openlcb.org/uniqueidranges
+- http://registry.openlcb.org/requestuniqueidrange
+
 @section application_with_jmri Using JMRI's OpenLCB support
 
 The two samples above both work on Linux using TCP traffic on port 12021. This
 is the same port that JMRI can use, which means you can use JMRI to interact
 with both the sample applications, and applications you write. In other words,
 you can start writing and testing the LCC aspects of your application without
-and actual device.
+an actual device.
 
 Why is this useful? In general, desktop develop is faster than embedded
 development, as you're delaing with software that is running locally on a much
-faster machine. As mentioned in @ref application_folders, you can easily create
-two versions of an application that share a certain amount of code. So that
-means you can share your LCC code between a desktop application and an embedded
-application.
+faster machine with richer debugging tools available. As mentioned in
+@ref application_folders, you can easily create two versions of an application
+that share a certain amount of code. So that means you can share your LCC code
+between a desktop application and an embedded application.
 
 @subsection jmri_adding_openlcb Adding OpenLCB
 
-In order to beging using JMRI with OpenLCB, assuming you have it installed,
+In order to begin using JMRI with OpenLCB, assuming you have it installed,
 you'll need to add an OpenLCB connection to JMRI, following these steps:
 
 - Open the **Edit** menu and click **Preferences**.

--- a/doc/1_applications.dox
+++ b/doc/1_applications.dox
@@ -1,0 +1,160 @@
+/**
+
+@page applications Sample Applications
+
+@tableofcontents
+
+@section application_introduction Introduction
+
+The easiest way to get started for many people is with samples. We've provided
+the source for some applications. Some of these applications you can run
+directly from the command line. While others will require a device.
+
+@section application_folders Directory Organization
+
+The sample applications typically have the following folder structure:
+
+    targets/
+    config.mk
+    Makefile
+    subdirs
+
+The code for an application typcially consists of two parts: shared and
+target-specific. The shared code will be at the top folder for the application.
+While the target-specific information will be under a target folder. As an
+example, the blink_raw application has shared code here:
+
+    applications/blink_raw/
+        main.cxx
+        targets/freertos.armv7m.mbed-1768/
+            hw_init.cxx
+
+The idea is that you can have target-specific (platform-specific) code that
+allows customizing the shared code for different platforms.
+
+@subsection application_build Building a Sample
+
+Generally when you build a sample, you'll want to do so from a single target
+directory, as that will build faster and only build what you need. Here we're
+going to build the Linux versions so you can run them without needing a
+specific board.
+
+@section grid_connect GridConnect Protocol
+
+Some of the sample applications use a protocol referred to here as the
+GridConnect protocol. This is an ASCII protocol that is used by USB-to-CAN
+interfaces sold by [GridConnect](http://gridconnect.com/).
+
+A normal CAN message has the following format:
+
+:X <_Identifier_> <N> <_Data-0_><_Data-1_>...<_Data-7_>;
+
+These messages are sent within a single network (such as a CAN network or over
+TCP) as binary. But if you're using one of the GridConnect devices, their
+I/O format is text. Here is an actual example:
+
+    :X19545415N0502010202000000;
+
+The ID is 19545415. LCC uses 29-bit CAN identifiers. The data bytes are encoded
+as HEX.
+
+You can also have messages that contains no extra data. For example:
+
+    :X17050415N;
+
+A couple of the sample applications output this format to the console in order
+to display the traffic. But, again, the actual CAN/TCP messages will be
+binary messages.
+
+@section application_list Applications
+
+This section contains a brief description of the sample applications to help you
+get up to speed. They're listed in order in which you might want to tackle them
+rather than alphabetical order.
+
+@subsection hub_application Hub
+
+The hub application will run from the command line and it's a great place to
+start with working on an LCC application. You can send CAN packets to the hub
+over TCP and it will display the packets, and also forward them to any others
+programs listening on the same port. This application knows about CAN packets,
+but nothing about LCC. It will forward all CAN packets, regardless of their
+format.
+
+In addition, you can connect this application to an actual USB-to-CAN interface
+in order to have packets flow between the LCC bus and programs running on your
+desktop computer.
+
+As mentioned above in the @ref application_folders section, you should typically
+build samples from within a platform-specific folder. For example:
+
+    cd ~/openmrn/applications/hub/targets/linux.x86
+    make
+    ./hub -h
+
+This will build the application, and then show you the options for the hub
+application. You can run the hub application without any parameters to start
+capturing and displaying CAN traffic over TCP. The next application,
+async_blink, will send out such traffic.
+
+@subsection async_blink_application Async Blink
+
+This is a more involved application, and is a good place to start with LCC. This
+application can be run from the command line, or it can be hosted on a
+micro controller to act as a very simple node.
+
+This node sends out a "blink" event every second.
+
+The Node ID is defined at the target level rather than the shared level. For
+example, if you look at the linux.x86 target folder, you'll find the following
+in the **NodeId.cxx** file:
+
+*   extern const openlcb::NodeID NODE_ID;
+*   const openlcb::NodeID NODE_ID = 0x050101011410ULL;
+
+* **Note:** Node IDs are required to be unique, so you must obtain your own ID
+before you ship anything using code you built with OpenMRN.
+
+@section application_with_jmri Using JMRI's OpenLCB support
+
+The two samples above both work on Linux using TCP traffic on port 12021. This
+is the same port that JMRI can use, which means you can use JMRI to interact
+with both the sample applications, and applications you write. In other words,
+you can start writing and testing the LCC aspects of your application without
+and actual device.
+
+Why is this useful? In general, desktop develop is faster than embedded
+development, as you're delaing with software that is running locally on a much
+faster machine. As mentioned in @ref application_folders, you can easily create
+two versions of an application that share a certain amount of code. So that
+means you can share your LCC code between a desktop application and an embedded
+application.
+
+@subsection jmri_adding_openlcb Adding OpenLCB
+
+In order to beging using JMRI with OpenLCB, assuming you have it installed,
+you'll need to add an OpenLCB connection to JMRI, following these steps:
+
+- Open the **Edit** menu and click **Preferences**.
+- Under **Connections** click the + tab to the right of your existing connection
+- Select **OpenLCB** under **System manufacturer**
+- Under **System connection**, select **CAN Simulation** to use the TCB simulator
+- Click **Save** and restart JMRI
+
+@subsection jmri_hub OpenLCB Hub and Traffic Monitor
+
+Once you've added an OpenLCB connection to JMRI, an **OpenLCB** menu will
+appear after you restart JMRI. One option on this menu is to start a hub. This
+hub acts very much like the hub application described above.
+
+JMRI also has a traffic montior, which knows about the LCC protocol and
+therefore will provide you more information about LCC packets.
+
+You can learm more here: [Hardware Support: OpenLCB](http://jmri.sourceforge.net/help/en/html/hardware/openlcb/index.shtml)
+
+Now try running @ref async_blink_application. You'll see some high-level traffic.
+You can also open the **Configure Nodes** tool in JMRI. This won't show much
+information for the @ref async_blink_application because it doesn't contain
+any configuration information.
+
+*/

--- a/doc/build_system.dox
+++ b/doc/build_system.dox
@@ -340,7 +340,10 @@ to it from different places), applications that are placed elsewhere in the
 filesystem need to set `OPENMRNPATH` explicitly or in the user startup script
 (e.g., in `~/.bashrc` writing `export OPENMRNPATH=~/openmrn`).
 
-@note When setting the path in a Makefile, you cannot use `~` to refer to your home directory. `~` is a bash expansion, and make does not perform bash expansion before setting variables. If needed, always refer to your home directory as `$``(HOME)`. Example: {@code OPENMRNPATH=$(realpath $(HOME)/openmrn)}
+@note When setting the path in a Makefile, you cannot use `~` to refer to your
+home directory. `~` is a bash expansion, and make does not perform bash
+expansion before setting variables. If needed, always refer to your home
+directory as `$``(HOME)`. Example: {@code OPENMRNPATH=$(realpath $(HOME)/openmrn)}
 
 Similar to how the `OPENMRNPATH` variable is used to find the OpenMRN
 distribution, we also use a variable called `APP_PATH` to find the top-level of
@@ -465,7 +468,8 @@ Compiling certain parts of OpenMRN, certain applications, certain device
 drivers and middleware requires specific dependencies to be present. These
 dependencies may be toolchains (compilers, linkers, etc for the host or
 cross-compilingfor the target), source code for certain libraries (such as XML
-parser or FreeRTOS), various MCU vendor middlewares or tools for debugging or flashing microcontrollers (OpenOCD for example).
+parser or FreeRTOS), various MCU vendor middlewares or tools for debugging or
+flashing microcontrollers (OpenOCD for example).
 
 @subsection dep_lookup Dependency lookup process
 
@@ -499,9 +503,16 @@ directory and the build proceeds to other targets/dirs. At the same time a
 warning message is printed, pointing out what dependency was missing:
 
 @{code
-** Ignoring target freertos.armv7m, because the following libraries are not installed: STM32CUBEF3PATH. This is not an error, so please do not report as a bug. If you care about target freertos.armv7m, make sure the quoted libraries are installed. For most libraries you can check /usr/local/google/home/bracz/train/openlcb/openmrn/etc/path.mk to see where we looked for these dependencies.}
+** Ignoring target freertos.armv7m, because the following libraries are not
+installed: STM32CUBEF3PATH. This is not an error, so please do not report as a
+bug. If you care about target freertos.armv7m, make sure the quoted libraries
+are installed. For most libraries you can check
+/usr/local/google/home/bracz/train/openlcb/openmrn/etc/path.mk to see where we
+looked for these dependencies.}
 
-The list of dependencies for a given directory are listed in the DEPS variable, so in the above directory there was a line in the Makefile or in the included `helper.mk` files that said: {@code DEPS += STM32CUBEF3PATH}
+The list of dependencies for a given directory are listed in the DEPS variable,
+so in the above directory there was a line in the Makefile or in the included
+`helper.mk` files that said: {@code DEPS += STM32CUBEF3PATH}
 
 @subsection dep_location_versioning Dependency location and versioning
 

--- a/src/utils/GridConnectHub.hxx
+++ b/src/utils/GridConnectHub.hxx
@@ -105,7 +105,8 @@ public:
 
 /** Create this port for a CAN hub and all packets will be written to stdout in
  * gridconnect format. */
-class GcPacketPrinter {
+class GcPacketPrinter
+{
 public:
     /// constructor
     ///


### PR DESCRIPTION
This is definitely a work in progress, but I wanted to get this written down while it was still fresh in my mind. I'm planning on adding some more about async_blink. and I'll be working on a page about creating a new application outside of the OpenMRN branch, referencing the new build documentation. As part of this change, I'm using a numeric prefix to dox names since doxygen uses alphabetical order within the HTML index.