### PR TITLE
prevent multiple datagrams from interleaving

### DIFF
--- a/src/openlcb/DatagramCan.cxx
+++ b/src/openlcb/DatagramCan.cxx
@@ -52,13 +52,15 @@ long long DATAGRAM_RESPONSE_TIMEOUT_NSEC = SEC_TO_NSEC(3);
 /// The base class of AddressedCanMessageWriteFlow is responsible for the
 /// discovery and address resolution of the destination node.
 class CanDatagramClient : public DatagramClient,
-                          public AddressedCanMessageWriteFlow
+                          public AddressedCanMessageWriteFlow,
+                          public LinkedObject<CanDatagramClient>
 {
 public:
     CanDatagramClient(IfCan *iface)
         : AddressedCanMessageWriteFlow(iface)
         , listener_(this)
         , isSleeping_(0)
+        , sendPending_(0)
     {
         /** This flow does not use the incoming queue that we inherited from
          * AddressedCanMessageWriteFlow. We skip the wait state.
@@ -77,13 +79,37 @@ public:
         }
         HASSERT(b->data()->mti == Defs::MTI_DATAGRAM);
         result_ = OPERATION_PENDING;
-        register_handlers();
         reset_message(b, priority);
-        /// @TODO(balazs.racz) this will not work for loopback messages because
-        /// it calls transfer_message().
-        start_flow(STATE(addressed_entry));
+        start_flow(STATE(acquire_srcdst_lock));
     }
 
+    Action acquire_srcdst_lock()
+    {
+        // First check if there is another datagram client sending a datagram
+        // to the same target node.
+        {
+            AtomicHolder h(&LinkedObject<CanDatagramClient>::headMu_);
+            for (CanDatagramClient* c = LinkedObject<CanDatagramClient>::head_;
+                 c;
+                 c = c->LinkedObject<CanDatagramClient>::link_next()) {
+                // this will catch c == this.
+                if (!c->sendPending_) continue;
+                if (c->nmsg()->src.id != nmsg()->src.id) continue; 
+                if (!async_if()->matching_node(c->nmsg()->dst, nmsg()->dst))
+                    continue;
+                // Now: there is another datagram client sending a datagram to
+                // this destination. We need to wait for that transaction to
+                // complete.
+                c->waitingClients_.push_front(this);
+                return wait();
+            }
+        }
+        register_handlers();
+        /// @TODO(balazs.racz) this will not work for loopback messages because
+        /// it calls transfer_message().
+        return call_immediately(STATE(addressed_entry));
+    }
+    
     Action send_to_local_node() OVERRIDE
     {
         return allocate_and_call(async_if()->dispatcher(),
@@ -126,6 +152,7 @@ private:
     {
         hasResponse_ = 0;
         isSleeping_ = 0;
+        sendPending_ = 1;
         if_can()->dispatcher()->register_handler(&listener_, MTI_1, MASK_1);
         if_can()->dispatcher()->register_handler(&listener_, MTI_2, MASK_2);
         if_can()->dispatcher()->register_handler(&listener_, MTI_3, MASK_3);
@@ -204,6 +231,7 @@ private:
     Action timeout_looking_for_dst() OVERRIDE
     {
         result_ |= PERMANENT_ERROR | DST_NOT_FOUND;
+        unregister_response_handler();
         return call_immediately(STATE(datagram_finalize));
     }
 
@@ -224,10 +252,19 @@ private:
         if_can()->dispatcher()->unregister_handler(&listener_, MTI_1, MASK_1);
         if_can()->dispatcher()->unregister_handler(&listener_, MTI_2, MASK_2);
         if_can()->dispatcher()->unregister_handler(&listener_, MTI_3, MASK_3);
+        sendPending_ = 0;
+        if (!waitingClients_.empty()) {
+            CanDatagramClient* c = static_cast<CanDatagramClient*>(waitingClients_.pop_front());
+            // Hands off all waiting clients to c.
+            HASSERT(c->waitingClients_.empty());
+            std::swap(waitingClients_, c->waitingClients_);
+            c->notify();
+        }
     }
 
     Action datagram_finalize()
     {
+        HASSERT(!sendPending_);
         HASSERT(result_ & OPERATION_PENDING);
         result_ &= ~OPERATION_PENDING;
         release();
@@ -396,8 +433,17 @@ private:
     }
 
     ReplyListener listener_;
+    /// List of other datagram clients that are trying to send to the same
+    /// target node. We need to wake up one of this list when we are done
+    /// sending.
+    TypedQueue<Executable> waitingClients_;
+    /// 1 when we are in the sleep call waiting for the datagram Ack or Reject
+    /// message.
     unsigned isSleeping_ : 1;
     unsigned hasResponse_ : 1;
+    /// 1 when we have the handlers registered. During this time we have
+    /// exclusive lock on the specific src/dst node pair.
+    unsigned sendPending_ : 1;
 };
 
 /** Frame handler that assembles incoming datagram fragments into a single

--- a/src/openlcb/DatagramCan.cxxtest
+++ b/src/openlcb/DatagramCan.cxxtest
@@ -336,10 +336,10 @@ TEST_F(AsyncRawDatagramTest, MultiFrameIntermixedDst)
     wait();
 }
 
-class MockDatagramHandler : public DatagramHandlerFlow
+class MockDatagramHandler : public DefaultDatagramHandler
 {
 public:
-    MockDatagramHandler() : DatagramHandlerFlow(&g_service)
+    MockDatagramHandler(DatagramService* srv) : DefaultDatagramHandler(srv)
     {
     }
 
@@ -348,13 +348,13 @@ public:
     Action entry() OVERRIDE
     {
         handle_datagram(message()->data());
-        return release_and_exit();
+        return respond_ok(0);
     }
 };
 
 TEST_F(AsyncDatagramTest, DispatchTest)
 {
-    StrictMock<MockDatagramHandler> dg;
+    StrictMock<MockDatagramHandler> dg(&datagram_support_);
     datagram_support_.registry()->insert(nullptr, 0x30, &dg);
     EXPECT_CALL(
         dg, handle_datagram(Pointee(AllOf(
@@ -521,6 +521,34 @@ TEST_F(AsyncDatagramTest, SendByAddressCacheMiss)
     run_x([this, &h]() {
         EXPECT_EQ(0x210U, ifCan_->remote_aliases()->lookup(h.id));
     });
+}
+
+TEST_F(AsyncDatagramTest, SendLoopback)
+{
+    StrictMock<MockDatagramHandler> dg(&datagram_support_);
+    datagram_support_.registry()->insert(nullptr, 0x30, &dg);
+    EXPECT_CALL(dg, handle_datagram(Pointee(
+                        AllOf(Field(&IncomingDatagram::src,
+                                  Field(&NodeHandle::id, node_->node_id())),
+                            Field(&IncomingDatagram::dst, node_),
+                            // Field(&IncomingDatagram::payload, NotNull()),
+                            Field(&IncomingDatagram::payload,
+                                  IsBufferValueString("01234567")) //,
+                            ))));
+    wait();
+    
+    DatagramClient *c = datagram_support_.client_allocator()->next_blocking();
+    NodeHandle h{node_->node_id(), 0};
+
+    auto *b = ifCan_->dispatcher()->alloc();
+    b->data()->reset(Defs::MTI_DATAGRAM, node_->node_id(), h,
+                     string_to_buffer("01234567"));
+    b->set_done(get_notifiable());
+    c->write_datagram(b);
+    wait();
+    wait_for_notification();
+    // Releases client.
+    datagram_support_.client_allocator()->insert(c);
 }
 
 TEST_F(AsyncDatagramTest, ResponseOKWithCode)

--- a/src/openlcb/DatagramCan.cxxtest
+++ b/src/openlcb/DatagramCan.cxxtest
@@ -559,6 +559,48 @@ TEST_F(AsyncDatagramTest, ResponseOKPendingReply)
     EXPECT_TRUE(c->result() & (DatagramClient::OK_REPLY_PENDING));
 }
 
+TEST_F(AsyncDatagramTest, MultipleDatagramsInterleaved)
+{
+    DatagramClient *c = datagram_support_.client_allocator()->next_blocking();
+    DatagramClient *c2 = datagram_support_.client_allocator()->next_blocking();
+    NodeHandle h{0, 0x77C};
+    clear_expect(true);
+    expect_packet(":X1A77C22AN3031323334353637;");
+    auto *b = ifCan_->dispatcher()->alloc();
+    BarrierNotifiable* bn = get_notifiable();
+    b->set_done(bn);
+    b->data()->reset(Defs::MTI_DATAGRAM, node_->node_id(), h,
+                     string_to_buffer("01234567"));
+    c->write_datagram(b);
+
+    wait();
+
+    SyncNotifiable n2;
+    BarrierNotifiable bn2(&n2);
+
+    b = ifCan_->dispatcher()->alloc();
+    b->set_done(&bn2);
+    b->data()->reset(Defs::MTI_DATAGRAM, node_->node_id(), h,
+                     string_to_buffer("89012345"));
+    c2->write_datagram(b);
+
+    wait();
+    usleep(200);
+    
+    clear_expect(true);
+
+    send_packet_and_expect_response(":X19A2877CN022A00;",
+        ":X1A77C22AN3839303132333435;"); // Received OK, second DG sent.
+    wait();
+    EXPECT_TRUE(bn->is_done());
+    EXPECT_FALSE(bn2.is_done());
+    wait_for_notification();
+
+    send_packet(":X19A2877CN022A00;");
+    wait();
+    EXPECT_TRUE(bn2.is_done());
+}
+
 TEST_F(AsyncDatagramTest, Rejected)
 {
     DatagramClient *c = datagram_support_.client_allocator()->next_blocking();

--- a/src/openlcb/MemoryConfigClient.cxxtest
+++ b/src/openlcb/MemoryConfigClient.cxxtest
@@ -35,12 +35,10 @@
 #include "openlcb/MemoryConfigClient.hxx"
 #include "openlcb/DatagramCan.hxx"
 
-#include "utils/async_if_test_helper.hxx"
+#include "utils/async_datagram_test_helper.hxx"
 
 namespace openlcb
 {
-
-Pool* const g_incoming_datagram_allocator = mainBufferPool;
 
 static const NodeID TWO_NODE_ID = 0x02010d0000ddULL;
 
@@ -97,5 +95,29 @@ TEST_F(MemoryConfigClientTest, readall)
     EXPECT_EQ(0, memcmp(&dataContents_[0], b->data()->payload.data(), dataContents_.size()));
 }
 
+
+class MemoryConfigLocalClientTest : public AsyncDatagramTest {
+protected:
+    MemoryConfigHandler memCfg_{&datagram_support_, node_, 3};
+
+    std::array<uint8_t, 231> dataContents_;
+    ReadWriteMemoryBlock srvSpace_{&dataContents_[0], (unsigned)dataContents_.size()};
+
+    MemoryConfigClient client_{node_, &memCfg_};
+};
+
+TEST_F(MemoryConfigLocalClientTest, readfromlocal)
+{
+    // In this test we read from the local node, to test that the
+    // service-client interaction is without any deadlock.
+    memCfg_.registry()->insert(node_, 0x52, &srvSpace_);
+
+    expect_any_packet();
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::READ,
+                         NodeHandle(node_->node_id()), 0x52);
+    EXPECT_EQ(0, b->data()->resultCode);
+    ASSERT_EQ(dataContents_.size(), b->data()->payload.size());
+    EXPECT_EQ(0, memcmp(&dataContents_[0], b->data()->payload.data(), dataContents_.size()));
+}
 
 } // namespace openlcb

--- a/src/openlcb/MemoryConfigClient.cxxtest
+++ b/src/openlcb/MemoryConfigClient.cxxtest
@@ -98,6 +98,10 @@ TEST_F(MemoryConfigClientTest, readall)
 
 class MemoryConfigLocalClientTest : public AsyncDatagramTest {
 protected:
+    ~MemoryConfigLocalClientTest() {
+        wait();
+    }
+
     MemoryConfigHandler memCfg_{&datagram_support_, node_, 3};
 
     std::array<uint8_t, 231> dataContents_;


### PR DESCRIPTION
Checks in the datagram sender whether there is already a pending datagram for a given src/dst pair, and waits until that datagram gets ack/nack-ed before sending out a second datagram.
This is necessary for standards compliance and also needed for performing a datagram based interaction with localhost (e.g. memory config read).
Misc fixes:
- Makes the MemoryConfigHandler be able to hand off reply datagrams to a MemoryConfigClient even while the server flow is busy. This is needed for a localhost query to successfully complete.

Tested:
- adds unittest for localhost datagram
- adds unittest for sending two interleaved datagrams to a remote client
- adds unittest for exercising the MemoryConfigClient against localhost to download a memory space stringed into many datagrams.