### PR TITLE
Moves the addresstype enum away from 0

### DIFF
--- a/src/dcc/Defs.hxx
+++ b/src/dcc/Defs.hxx
@@ -42,7 +42,7 @@ namespace dcc {
 enum class TrainAddressType
 {
     /// DCC packets with short address (1..127)
-    DCC_SHORT_ADDRESS,
+    DCC_SHORT_ADDRESS = 1,
     /// DCC packets with long address (128..~10000)
     DCC_LONG_ADDRESS,
     /// Marklin-motorola packets. Addresses 1..80 are supported.


### PR DESCRIPTION
 so that we can debug problems easier.

This value is not exposed outside of a binary (and never saved), so recompiling is enough.