### PR TITLE
C++ upgrade fix

### DIFF
--- a/src/executor/StateFlow.cxxtest
+++ b/src/executor/StateFlow.cxxtest
@@ -516,7 +516,7 @@ TEST_F(StateFlowPipeTest, TestReadSingle)
     EXPECT_FALSE(bnOut_.is_done());
     ASSERT_EQ(2, write(fdSend_, sndBuf_, 2));
     outOfTestState_.wait_for_notification();
-    EXPECT_EQ(3, flow.selectHelper_.remaining_);
+    EXPECT_EQ(3u, flow.selectHelper_.remaining_);
     EXPECT_EQ(std::vector<char>(sndBuf_, sndBuf_ + 2),
         std::vector<char>(recvBuf_, recvBuf_ + 2));
 }
@@ -534,12 +534,12 @@ TEST_F(StateFlowPipeTest, TestReadRepeated)
     usleep(50000);
     wait_for_main_executor();
     // Still not exited wait
-    EXPECT_EQ(3, flow.selectHelper_.remaining_);
+    EXPECT_EQ(3u, flow.selectHelper_.remaining_);
     EXPECT_FALSE(bnOut_.is_done());
     // Write the rest
     ASSERT_EQ(7, write(fdSend_, sndBuf_ + 2, 7));
     outOfTestState_.wait_for_notification();
-    EXPECT_EQ(0, flow.selectHelper_.remaining_);
+    EXPECT_EQ(0u, flow.selectHelper_.remaining_);
     EXPECT_EQ(std::vector<char>(sndBuf_, sndBuf_ + 4),
         std::vector<char>(recvBuf_, recvBuf_ + 4));
 }
@@ -557,12 +557,12 @@ TEST_F(StateFlowPipeTest, TestReadRepeatedWithTimedHelper)
     usleep(50000);
     wait_for_main_executor();
     // Still not exited wait
-    EXPECT_EQ(3, flow.timedSelectHelper_.remaining_);
+    EXPECT_EQ(3u, flow.timedSelectHelper_.remaining_);
     EXPECT_FALSE(bnOut_.is_done());
     // Write the rest
     ASSERT_EQ(7, write(fdSend_, sndBuf_ + 2, 7));
     outOfTestState_.wait_for_notification();
-    EXPECT_EQ(0, flow.timedSelectHelper_.remaining_);
+    EXPECT_EQ(0u, flow.timedSelectHelper_.remaining_);
     EXPECT_EQ(std::vector<char>(sndBuf_, sndBuf_ + 4),
         std::vector<char>(recvBuf_, recvBuf_ + 4));
 }
@@ -582,12 +582,12 @@ TEST_F(StateFlowPipeTest, TestReadWithTimeoutLongTimeout)
     usleep(50000);
     wait_for_main_executor();
     // Still not exited wait
-    EXPECT_EQ(3, flow.timedSelectHelper_.remaining_);
+    EXPECT_EQ(3u, flow.timedSelectHelper_.remaining_);
     EXPECT_FALSE(bnOut_.is_done());
     // Write the rest
     ASSERT_EQ(7, write(fdSend_, sndBuf_ + 2, 7));
     outOfTestState_.wait_for_notification();
-    EXPECT_EQ(0, flow.timedSelectHelper_.remaining_);
+    EXPECT_EQ(0u, flow.timedSelectHelper_.remaining_);
     EXPECT_EQ(std::vector<char>(sndBuf_, sndBuf_ + 4),
         std::vector<char>(recvBuf_, recvBuf_ + 4));
 }
@@ -609,7 +609,7 @@ TEST_F(StateFlowPipeTest, TestReadWithTimeoutShortTimeout)
     ASSERT_LT(MSEC_TO_NSEC(69), elapsed);
     ASSERT_GT(MSEC_TO_NSEC(500), elapsed);
     EXPECT_TRUE(bnOut_.is_done());
-    EXPECT_EQ(3, flow.timedSelectHelper_.remaining_);
+    EXPECT_EQ(3u, flow.timedSelectHelper_.remaining_);
     EXPECT_EQ(std::vector<char>(sndBuf_, sndBuf_ + 2),
         std::vector<char>(recvBuf_, recvBuf_ + 2));
 }
@@ -624,7 +624,7 @@ TEST_F(StateFlowPipeTest, TestReadWithTimeoutZeroTimeout)
     usleep(50000);
     EXPECT_TRUE(bnOut_.is_done());
     outOfTestState_.wait_for_notification();
-    EXPECT_EQ(5, flow.timedSelectHelper_.remaining_);
+    EXPECT_EQ(5u, flow.timedSelectHelper_.remaining_);
 }
 
 TEST_F(StateFlowPipeTest, TestReadWithTimeoutZeroTimeoutReadyData)
@@ -638,7 +638,7 @@ TEST_F(StateFlowPipeTest, TestReadWithTimeoutZeroTimeoutReadyData)
     inTestState_.wait_for_notification();
     outOfTestState_.wait_for_notification();
     long long elapsed = OSTime::get_monotonic() - t_start;
-    EXPECT_EQ(3, flow.timedSelectHelper_.remaining_);
+    EXPECT_EQ(3u, flow.timedSelectHelper_.remaining_);
     EXPECT_EQ(std::vector<char>(sndBuf_, sndBuf_ + 2),
         std::vector<char>(recvBuf_, recvBuf_ + 2));
     LOG(INFO, "elapsed time %lld usec", elapsed / 1000);

--- a/src/openlcb/AliasCache.cxxtest
+++ b/src/openlcb/AliasCache.cxxtest
@@ -61,7 +61,7 @@ TEST(AliasCacheTest, constructor)
     aliasCache->for_each(alias_callback, (void*)0xDEADBEEF);
     
     EXPECT_EQ(count, 0);
-    EXPECT_EQ(2, aliasCache->size());
+    EXPECT_EQ(2u, aliasCache->size());
 
     aliasCache->add(101, 10);
     aliasCache->for_each(alias_callback, (void*)0xDEADBEEF);

--- a/src/openlcb/Bootloader.cxxtest
+++ b/src/openlcb/Bootloader.cxxtest
@@ -46,7 +46,7 @@ public:
 
 static MockBootloaderHAL *g_mock_bootloader_hal = nullptr;
 
-#define FLASH_SIZE 13 * 1024
+#define FLASH_SIZE 13 * 1024u
 static uint8_t virtual_flash[FLASH_SIZE];
 #define APP_HEADER_OFFSET 131 * 4
 

--- a/src/openlcb/BootloaderDg.cxxtest
+++ b/src/openlcb/BootloaderDg.cxxtest
@@ -44,7 +44,7 @@ public:
 
 static MockBootloaderHAL *g_mock_bootloader_hal = nullptr;
 
-#define FLASH_SIZE 13 * 1024
+#define FLASH_SIZE 13 * 1024u
 static uint8_t virtual_flash[FLASH_SIZE];
 #define APP_HEADER_OFFSET 131 * 4
 

--- a/src/openlcb/ConfigRenderer.cxxtest
+++ b/src/openlcb/ConfigRenderer.cxxtest
@@ -245,7 +245,7 @@ TEST(CdiRender, Render)
 </cdi>
 )data";
     EXPECT_EQ(kExpectedTestNodeCdi, s);
-    EXPECT_EQ(1, cfg.testseg().e2().offset());
+    EXPECT_EQ(1u, cfg.testseg().e2().offset());
 }
 
 CDI_GROUP(OtherSegment, Name("testseg"), Description("test seg desc"),
@@ -299,7 +299,7 @@ TEST(CdiRender, RenderIdent)
 </cdi>
 )data";
     EXPECT_EQ(kExpectedTestNodeCdi, s);
-    EXPECT_EQ(34, cfg.testseg().e2().offset());
+    EXPECT_EQ(34u, cfg.testseg().e2().offset());
 }
 
 } // namespace

--- a/src/openlcb/ConfigRepresentation.cxxtest
+++ b/src/openlcb/ConfigRepresentation.cxxtest
@@ -60,31 +60,31 @@ CDI_GROUP_END();
 
 TEST(GroupConfig, LengthAndOffsetsAreCorrect)
 {
-    EXPECT_EQ(25, TestNodeConfig::size());
-    EXPECT_EQ(3, TestGroup::size());
-    EXPECT_EQ(9, TestNodeConfig::TestRepeat::size());
+    EXPECT_EQ(25u, TestNodeConfig::size());
+    EXPECT_EQ(3u, TestGroup::size());
+    EXPECT_EQ(9u, TestNodeConfig::TestRepeat::size());
     TestNodeConfig cfg(11);
-    EXPECT_EQ(4, sizeof(cfg));
+    EXPECT_EQ(4u, sizeof(cfg));
 
-    EXPECT_EQ(11, cfg.offset());
+    EXPECT_EQ(11u, cfg.offset());
 
-    EXPECT_EQ(11, cfg.version().offset());
-    EXPECT_EQ(12, cfg.test_short().offset());
-    EXPECT_EQ(14, cfg.test64().offset());
-    EXPECT_EQ(22, cfg.test32().offset());
+    EXPECT_EQ(11u, cfg.version().offset());
+    EXPECT_EQ(12u, cfg.test_short().offset());
+    EXPECT_EQ(14u, cfg.test64().offset());
+    EXPECT_EQ(22u, cfg.test32().offset());
 
-    EXPECT_EQ(26, cfg.testgroup().offset());
+    EXPECT_EQ(26u, cfg.testgroup().offset());
 
-    EXPECT_EQ(26, cfg.testgroup().entry<0>().offset());
-    EXPECT_EQ(26, cfg.testgroup().entry<0>().e1().offset());
-    EXPECT_EQ(27, cfg.testgroup().entry<0>().e2().offset());
+    EXPECT_EQ(26u, cfg.testgroup().entry<0>().offset());
+    EXPECT_EQ(26u, cfg.testgroup().entry<0>().e1().offset());
+    EXPECT_EQ(27u, cfg.testgroup().entry<0>().e2().offset());
 
-    EXPECT_EQ(29, cfg.testgroup().entry<1>().offset());
+    EXPECT_EQ(29u, cfg.testgroup().entry<1>().offset());
 
-    EXPECT_EQ(29, cfg.testgroup().entry<1>().e1().offset());
-    EXPECT_EQ(33, cfg.testgroup().entry<2>().e2().offset());
+    EXPECT_EQ(29u, cfg.testgroup().entry<1>().e1().offset());
+    EXPECT_EQ(33u, cfg.testgroup().entry<2>().e2().offset());
 
-    EXPECT_EQ(35, cfg.last().offset());
+    EXPECT_EQ(35u, cfg.last().offset());
 }
 
 CDI_GROUP(HoleTestGroup);
@@ -97,12 +97,12 @@ CDI_GROUP_END();
 TEST(GroupConfig, WithHoles)
 {
     HoleTestGroup cfg(17);
-    EXPECT_EQ(18, HoleTestGroup::size());
-    EXPECT_EQ(18, cfg.size());
-    EXPECT_EQ(17, cfg.version().offset());
-    EXPECT_EQ(18, cfg.blocked().offset());
-    EXPECT_EQ(23, cfg.event().offset());
-    EXPECT_EQ(31, cfg.last().offset());
+    EXPECT_EQ(18u, HoleTestGroup::size());
+    EXPECT_EQ(18u, cfg.size());
+    EXPECT_EQ(17u, cfg.version().offset());
+    EXPECT_EQ(18u, cfg.blocked().offset());
+    EXPECT_EQ(23u, cfg.event().offset());
+    EXPECT_EQ(31u, cfg.last().offset());
 }
 
 CDI_GROUP(IoBoardSegment, Segment(MemoryConfigDefs::SPACE_CONFIG),
@@ -130,20 +130,20 @@ TEST(FullCdi, SegmentOffset)
     EXPECT_EQ(-2, def.group_opts().segment());
 
     EXPECT_EQ(INT_MAX, def.ident().group_opts().offset());
-    EXPECT_EQ(0, def.ident().group_opts().get_segment_offset());
-    EXPECT_EQ(0, def.ident().offset());
+    EXPECT_EQ(0u, def.ident().group_opts().get_segment_offset());
+    EXPECT_EQ(0u, def.ident().offset());
     EXPECT_EQ(1000, def.ident().group_opts().segment());
     EXPECT_EQ(1000, def.acdi().group_opts().segment());
 
-    EXPECT_EQ(1, def.userinfo().offset());
+    EXPECT_EQ(1u, def.userinfo().offset());
     EXPECT_EQ(0xFB, def.userinfo().group_opts().segment());
-    EXPECT_EQ(1, def.userinfo().name().offset());
+    EXPECT_EQ(1u, def.userinfo().name().offset());
 
     EXPECT_EQ(128, def.seg().group_opts().offset());
-    EXPECT_EQ(128, def.seg().offset());
+    EXPECT_EQ(128u, def.seg().offset());
 
-    EXPECT_EQ(128, def.seg().first().offset());
-    EXPECT_EQ(0, def.seg2().first().offset());
+    EXPECT_EQ(128u, def.seg().first().offset());
+    EXPECT_EQ(0u, def.seg2().first().offset());
 }
 
 TempDir dir;
@@ -287,11 +287,11 @@ CDI_GROUP_END();
 
 TEST(Test2GroupTest, Offsets) {
     TestGroup grp(11);
-    EXPECT_EQ(13, TestGroup::size());
-    EXPECT_EQ(11, grp.testi8().offset());
-    EXPECT_EQ(12, grp.testi32().offset());
-    EXPECT_EQ(16, grp.testi64().offset());
-    EXPECT_EQ(24, grp.end_offset());
+    EXPECT_EQ(13u, TestGroup::size());
+    EXPECT_EQ(11u, grp.testi8().offset());
+    EXPECT_EQ(12u, grp.testi32().offset());
+    EXPECT_EQ(16u, grp.testi64().offset());
+    EXPECT_EQ(24u, grp.end_offset());
 }
 
 } // namespace test2

--- a/src/openlcb/DatagramCan.cxxtest
+++ b/src/openlcb/DatagramCan.cxxtest
@@ -973,7 +973,7 @@ public:
         {
             DIE("Unexpected notification from the datagram client.");
         }
-        if (!clientFlow_->result() & DatagramClient::OPERATION_SUCCESS)
+        if (!(clientFlow_->result() & DatagramClient::OPERATION_SUCCESS))
         {
             LOG(WARNING, "Error sending response datagram for PingPong: %x",
                 clientFlow_->result());

--- a/src/openlcb/IfCan.cxxtest
+++ b/src/openlcb/IfCan.cxxtest
@@ -144,7 +144,7 @@ TEST_F(AsyncNodeTest, NodeIdLookupLocal)
     
     auto b = invoke_flow(&lflow, node_, NodeHandle(0, 0x22A));
     EXPECT_EQ(0, b->data()->resultCode);
-    EXPECT_EQ(0x02010d000003, b->data()->handle.id);
+    EXPECT_EQ(0x02010d000003U, b->data()->handle.id);
 }
 
 TEST_F(AsyncNodeTest, NodeIdLookupRemoteMissing)
@@ -153,7 +153,7 @@ TEST_F(AsyncNodeTest, NodeIdLookupRemoteMissing)
     
     auto b = invoke_flow(&lflow, node_, NodeHandle(0, 0x882));
     EXPECT_EQ(0x2030, b->data()->resultCode);
-    EXPECT_EQ(0, b->data()->handle.id);
+    EXPECT_EQ(0u, b->data()->handle.id);
 }
 
 TEST_F(AsyncNodeTest, NodeIdLookupRemoteFound)
@@ -163,7 +163,7 @@ TEST_F(AsyncNodeTest, NodeIdLookupRemoteFound)
     expect_packet(":X1948822AN0882;").WillOnce(::testing::InvokeWithoutArgs([this](){ send_packet(":X19170882N010203040506;"); }));
     auto b = invoke_flow(&lflow, node_, NodeHandle(0, 0x882));
     EXPECT_EQ(0, b->data()->resultCode);
-    EXPECT_EQ(0x010203040506, b->data()->handle.id);
+    EXPECT_EQ(0x010203040506u, b->data()->handle.id);
 }
 
 TEST_F(AsyncNodeTest, NodeIdLookupRemoteFake)
@@ -173,7 +173,7 @@ TEST_F(AsyncNodeTest, NodeIdLookupRemoteFake)
     expect_packet(":X1948822AN0882;").WillOnce(::testing::InvokeWithoutArgs([this](){ send_packet(":X19170662N010203040506;"); }));
     auto b = invoke_flow(&lflow, node_, NodeHandle(0, 0x882));
     EXPECT_EQ(0x2030, b->data()->resultCode);
-    EXPECT_EQ(0, b->data()->handle.id);
+    EXPECT_EQ(0u, b->data()->handle.id);
 }
 
 class AsyncMessageCanTests : public AsyncIfTest

--- a/src/openlcb/RoutingLogic.cxxtest
+++ b/src/openlcb/RoutingLogic.cxxtest
@@ -41,35 +41,35 @@ TEST(RangeToBitCountTest, simple) {
     EventId e;
     e = 0b11100;
     EXPECT_EQ(2, event_range_to_bit_count(&e));
-    EXPECT_EQ(0b11100, e);
+    EXPECT_EQ(0b11100u, e);
 
     e = 0b11101;
     EXPECT_EQ(1, event_range_to_bit_count(&e));
-    EXPECT_EQ(0b11100, e);
+    EXPECT_EQ(0b11100u, e);
 
     e = 0b11101111;
     EXPECT_EQ(4, event_range_to_bit_count(&e));
-    EXPECT_EQ(0b11100000, e);
+    EXPECT_EQ(0b11100000u, e);
 
     e = 0x50FFFFFFFF;
     EXPECT_EQ(32, event_range_to_bit_count(&e));
-    EXPECT_EQ(0x5000000000, e);
+    EXPECT_EQ(0x5000000000u, e);
 
     e = 0x8000000000000000;
     EXPECT_EQ(63, event_range_to_bit_count(&e));
-    EXPECT_EQ(0x8000000000000000, e);
+    EXPECT_EQ(0x8000000000000000u, e);
 
     e = 0x7FFFFFFFFFFFFFFF;
     EXPECT_EQ(63, event_range_to_bit_count(&e));
-    EXPECT_EQ(0, e);
+    EXPECT_EQ(0u, e);
 
     e = 0xFFFFFFFFFFFFFFFF;
     EXPECT_EQ(64, event_range_to_bit_count(&e));
-    EXPECT_EQ(0, e);
+    EXPECT_EQ(0u, e);
 
     e = 0;
     EXPECT_EQ(64, event_range_to_bit_count(&e));
-    EXPECT_EQ(0, e);
+    EXPECT_EQ(0u, e);
 }
 
 class RoutingLogicTest : public ::testing::Test {

--- a/src/openlcb/TractionThrottle.cxxtest
+++ b/src/openlcb/TractionThrottle.cxxtest
@@ -160,7 +160,7 @@ TEST_F(ThrottleTest, SendAssignRelease)
     wait();
     EXPECT_EQ(0, flow.response()->resultCode);
     actual_ctrl_id = trainNode_->get_controller().id;
-    EXPECT_EQ(0, actual_ctrl_id);
+    EXPECT_EQ(0u, actual_ctrl_id);
 
     wait();
 }
@@ -341,7 +341,7 @@ TEST_F(ThrottleClientTest, SendConsistQry)
     EXPECT_EQ(0, b->data()->resultCode);
     EXPECT_EQ(1, b->data()->consistCount);
     EXPECT_EQ(0xff, b->data()->consistIndex);
-    EXPECT_EQ(0, b->data()->dst);
+    EXPECT_EQ(0u, b->data()->dst);
 
     b = invoke_flow(
         &throttle_, TractionThrottleCommands::CONSIST_ADD, n2, 0x42);
@@ -368,7 +368,7 @@ TEST_F(ThrottleClientTest, SendConsistQry)
     EXPECT_EQ(0, b->data()->resultCode);
     EXPECT_EQ(2, b->data()->consistCount);
     EXPECT_EQ(0xff, b->data()->consistIndex);
-    EXPECT_EQ(0, b->data()->dst);
+    EXPECT_EQ(0u, b->data()->dst);
 }
 
 TEST_F(ThrottleClientTest, SendSelfConsist)

--- a/src/openlcb/Velocity.cxxtest
+++ b/src/openlcb/Velocity.cxxtest
@@ -32,6 +32,8 @@
  * @date 15 September 2013
  */
 
+#include <math.h>
+
 #include "os/os.h"
 #include "gtest/gtest.h"
 #include "openlcb/Velocity.hxx"
@@ -41,8 +43,8 @@ using namespace openlcb;
 
 TEST(NMRAnetVelocityTest, size)
 {
-    EXPECT_EQ(4, sizeof(Velocity));
-    EXPECT_EQ(2, sizeof(float16_t));
+    EXPECT_EQ(4u, sizeof(Velocity));
+    EXPECT_EQ(2u, sizeof(float16_t));
 }
 
 TEST(NMRAnetVelocityTest, constructor_int)

--- a/src/utils/EEPROMEmuTest.hxx
+++ b/src/utils/EEPROMEmuTest.hxx
@@ -101,18 +101,18 @@ public:
 
 private:
     void flash_erase(unsigned sector) override {
-        ASSERT_LE(0, sector);
+        ASSERT_LE(0u, sector);
         ASSERT_GT(EELEN / SECTOR_SIZE, sector);
         void* address = &foo::__eeprom_start[sector * SECTOR_SIZE];
         memset(address, 0xff, SECTOR_SIZE);
     }
 
     void flash_program(unsigned sector, unsigned block, uint32_t *data, uint32_t byte_count) override {
-        ASSERT_LE(0, sector);
+        ASSERT_LE(0u, sector);
         ASSERT_GT(EELEN / SECTOR_SIZE, sector);
-        ASSERT_LE(0, block);
+        ASSERT_LE(0u, block);
         ASSERT_GT(SECTOR_SIZE/BLOCK_SIZE, block);
-        ASSERT_EQ(0, byte_count % BLOCK_SIZE);
+        ASSERT_EQ(0u, byte_count % BLOCK_SIZE);
         uint8_t* address = &foo::__eeprom_start[sector * SECTOR_SIZE + block * BLOCK_SIZE];
         memcpy(address, data, byte_count);
     }
@@ -133,7 +133,7 @@ TEST(EepromStaticTest, assertions) {
 
     ASSERT_EQ(p1, p2);
     ASSERT_EQ(p1 + EELEN, e1);
-    ASSERT_EQ(0, p1 % 4); // alignment
+    ASSERT_EQ(0u, p1 % 4); // alignment
 }
 
 /// Test fixture class for testing the EEPROM emulation.
@@ -194,7 +194,7 @@ protected:
 
 #define EXPECT_AT(ofs, PAYLOAD) { string p(PAYLOAD); string ret(p.size(), 0); ee()->read(ofs, &ret[0], p.size()); EXPECT_EQ(p, ret); }
 
-#define EXPECT_SLOT(block_number, address, payload) { EXPECT_EQ(address, block_address(block_number)); EXPECT_EQ(string(payload), block_data(block_number)); }
+#define EXPECT_SLOT(block_number, address, payload) { EXPECT_EQ((unsigned)address, block_address(block_number)); EXPECT_EQ(string(payload), block_data(block_number)); }
 
     static constexpr unsigned eeprom_size = 1000; ///< test eeprom size
     std::unique_ptr<MyEEPROM> e; ///< EEPROM under test.
@@ -204,7 +204,7 @@ protected:
 TEST_F(EepromTest, create) {
     create();
     EXPECT_EQ(0, e->activeSector_);
-    EXPECT_EQ(8, e->sector_count());
+    EXPECT_EQ(8u, e->sector_count());
     EXPECT_EQ((uint32_t*)&__eeprom_start, e->block(0, 0));
     EXPECT_EQ((uint32_t*)&foo::__eeprom_start[4*1024], e->block(1, 0));
 }

--- a/src/utils/OpenSSLAesCcm.hxx
+++ b/src/utils/OpenSSLAesCcm.hxx
@@ -73,8 +73,8 @@ void CCMEncrypt(const std::string &aes_key, const std::string &iv,
     const std::string &auth_data, const std::string &plain, std::string *cipher,
     std::string *tag)
 {
-    ASSERT_EQ(32, aes_key.size());
-    ASSERT_EQ(11, iv.size());
+    ASSERT_EQ(32u, aes_key.size());
+    ASSERT_EQ(11u, iv.size());
 
     EVP_CIPHER_CTX *ctx;
     ctx = EVP_CIPHER_CTX_new();
@@ -107,7 +107,7 @@ void CCMEncrypt(const std::string &aes_key, const std::string &iv,
     LOG(INFO, "encupdate: in=%d, ret=%d", (int)plain.size(), outlen);
     cipher->resize(outlen);
     // CCM always outputs the same number of bytes than the input.
-    ASSERT_EQ(plain.size(), outlen);
+    ASSERT_EQ((int)plain.size(), outlen);
     int ret = -1;
     ASSERT_EQ(1, EVP_EncryptFinal_ex(ctx, (uint8_t *)&((*cipher)[0]), &ret));
     ASSERT_EQ(0, ret);

--- a/src/utils/StoredBitSet.cxxtest
+++ b/src/utils/StoredBitSet.cxxtest
@@ -49,7 +49,7 @@ public:
 TEST(ShadowedBitSetSingleTest, size)
 {
     TestBitSet s1(375, 13);
-    EXPECT_EQ(375, s1.size());
+    EXPECT_EQ(375u, s1.size());
     EXPECT_EQ(29, s1.num_cells());
 }
 
@@ -210,20 +210,20 @@ TEST_P(BitSetMultiTest, get_multi_small)
     s_.set_bit(1, false);
     s_.set_bit(2, true);
     s_.set_bit(3, true);
-    EXPECT_EQ(13, s_.get_multi(0, 4));
-    EXPECT_EQ(5, s_.get_multi(0, 3));
-    EXPECT_EQ(1, s_.get_multi(0, 2));
-    EXPECT_EQ(1, s_.get_multi(0, 1));
+    EXPECT_EQ(13u, s_.get_multi(0, 4));
+    EXPECT_EQ(5u, s_.get_multi(0, 3));
+    EXPECT_EQ(1u, s_.get_multi(0, 2));
+    EXPECT_EQ(1u, s_.get_multi(0, 1));
 
-    EXPECT_EQ(0, s_.get_multi(1, 1));
-    EXPECT_EQ(2, s_.get_multi(1, 2));
-    EXPECT_EQ(6, s_.get_multi(1, 3));
-    EXPECT_EQ(6, s_.get_multi(1, 4));
-    EXPECT_EQ(6, s_.get_multi(1, 5));
+    EXPECT_EQ(0u, s_.get_multi(1, 1));
+    EXPECT_EQ(2u, s_.get_multi(1, 2));
+    EXPECT_EQ(6u, s_.get_multi(1, 3));
+    EXPECT_EQ(6u, s_.get_multi(1, 4));
+    EXPECT_EQ(6u, s_.get_multi(1, 5));
 
-    EXPECT_EQ(1, s_.get_multi(2, 1));
-    EXPECT_EQ(3, s_.get_multi(2, 2));
-    EXPECT_EQ(3, s_.get_multi(2, 3));
+    EXPECT_EQ(1u, s_.get_multi(2, 1));
+    EXPECT_EQ(3u, s_.get_multi(2, 2));
+    EXPECT_EQ(3u, s_.get_multi(2, 3));
 }
 
 TEST_P(BitSetMultiTest, set_multi_mask)
@@ -236,10 +236,10 @@ TEST_P(BitSetMultiTest, set_multi_mask)
     {
         ASSERT_FALSE(HasFailure());
         SCOPED_TRACE(i);
-        EXPECT_EQ(0b11111111, s_.get_multi(i - 1, 8));
+        EXPECT_EQ(0b11111111u, s_.get_multi(i - 1, 8));
         s_.set_multi(i, 6, 0b010100);
         expect_all_one(i, 6);
-        EXPECT_EQ(0b10101001, s_.get_multi(i - 1, 8));
+        EXPECT_EQ(0b10101001u, s_.get_multi(i - 1, 8));
         s_.set_multi(i, 6, 0b111111);
         expect_all_one();
     }
@@ -254,12 +254,12 @@ TEST_P(BitSetMultiTest, set_multi_small)
         SCOPED_TRACE(i);
         s_.set_multi(i, 6, 0b110111);
         expect_all_zero(i, 6);
-        EXPECT_EQ(0b110111, s_.get_multi(i, 6));
+        EXPECT_EQ(0b110111u, s_.get_multi(i, 6));
         s_.set_multi(i, 6, 0);
 
         s_.set_multi(i, 6, 0b110111);
         s_.set_multi(i + 1, 4, 0);
-        EXPECT_EQ(0b100001, s_.get_multi(i, 6));
+        EXPECT_EQ(0b100001u, s_.get_multi(i, 6));
 
         s_.set_multi(i, 6, 0);
         expect_all_zero();

--- a/src/utils/macros.cxxtest
+++ b/src/utils/macros.cxxtest
@@ -36,20 +36,20 @@ TEST(CrashTest, Crashed) {
 
 TEST(ArraySize, Singles) {
     static const uint32_t foo_32[1] = {1};
-    EXPECT_EQ(1, ARRAYSIZE(foo_32));
+    EXPECT_EQ(1u, ARRAYSIZE(foo_32));
     static const int16_t foo_16[1] = {2};
-    EXPECT_EQ(1, ARRAYSIZE(foo_16));
+    EXPECT_EQ(1u, ARRAYSIZE(foo_16));
     static const uint8_t foo_8[1] = {3};
-    EXPECT_EQ(1, ARRAYSIZE(foo_8));
+    EXPECT_EQ(1u, ARRAYSIZE(foo_8));
 }
 
 TEST(ArraySize, Multiples) {
     static const uint32_t foo_32[3] = {3,4,5};
-    EXPECT_EQ(3, ARRAYSIZE(foo_32));
+    EXPECT_EQ(3u, ARRAYSIZE(foo_32));
     static const int16_t foo_16[5] = {5,4,3,2,1};
-    EXPECT_EQ(5, ARRAYSIZE(foo_16));
+    EXPECT_EQ(5u, ARRAYSIZE(foo_16));
     static const uint8_t foo_8[7] = {1,2,3,4,5,6,7};
-    EXPECT_EQ(7, ARRAYSIZE(foo_8));
+    EXPECT_EQ(7u, ARRAYSIZE(foo_8));
 }
 
 int appl_main(int argc, char* argv[]) {


### PR DESCRIPTION
Fixes compilation errors due to newer G++ versions being strict about comparing signed vs unsigned integers.
