### PR TITLE
Fixes to event registry bugs

### DIFF
--- a/src/openlcb/DccAccyProducer.cxx
+++ b/src/openlcb/DccAccyProducer.cxx
@@ -41,5 +41,6 @@ namespace openlcb
 uninitialized<BitRangeNonAuthoritativeEventP> DccAccyProducer::eventProducer_;
 uninitialized<std::vector<DccAccyProducer*>> DccAccyProducer::instances_;
 OSThreadOnce DccAccyProducer::once_(DccAccyProducer::once_routine);
+Atomic DccAccyProducer::instancesLock_;
 
 } // namespace openlcb

--- a/src/openlcb/DccAccyProducer.hxx
+++ b/src/openlcb/DccAccyProducer.hxx
@@ -133,7 +133,7 @@ public:
         , bn_()
     {
         once_.once();
-        AtomicHolder h(this);
+        AtomicHolder h(&instancesLock_);
         if (instances_->empty())
         {
             uint32_t max_address = MAX_ADDRESS;
@@ -148,7 +148,7 @@ public:
     /// Destructor.  Remove "this" instance from @ref instances_ vector
     ~DccAccyProducer()
     {
-        AtomicHolder h(this);
+        AtomicHolder h(&instancesLock_);
         for (unsigned i = 0; i < instances_->size(); ++i)
         {
             if (instances_->at(i) == this)
@@ -250,6 +250,9 @@ private:
     /// Vector of all the subscribers to the DCC accessory address Well-Known
     /// Event ID Range
     static uninitialized<std::vector<DccAccyProducer*>> instances_;
+
+    /// This lock protects the instances_ vector;
+    static Atomic instancesLock_;
 
     /// one time execution helper
     static OSThreadOnce once_;

--- a/src/openlcb/EventHandlerContainer.cxx
+++ b/src/openlcb/EventHandlerContainer.cxx
@@ -69,7 +69,9 @@ void TreeEventHandlers::unregister_handler(EventHandler *handler)
         }
     }
     if (found)
+    {
         return;
+    }
     DIE("tried to unregister a handler that was not registered");
 }
 

--- a/src/openlcb/EventHandlerContainer.cxxtest
+++ b/src/openlcb/EventHandlerContainer.cxxtest
@@ -336,7 +336,7 @@ public:
         handlers_.register_handler(EventRegistryEntry(h(n), eventid), mask);
     }
 
-private:
+protected:
     EventReport report_;
     TreeEventHandlers handlers_;
     std::unique_ptr<EventIterator> iter_;
@@ -390,6 +390,34 @@ TEST_F(TreeEventHandlerTest, MultiLookup)
     EXPECT_THAT(get_all_matching(0x3FF, 0),
                 ElementsAre(h(1), h(3), h(5), h(15)));
     EXPECT_THAT(get_all_matching(0x3FE, 0), ElementsAre(h(3), h(5), h(15)));
+}
+
+TEST_F(TreeEventHandlerTest, Erase)
+{
+    add_handler(1, 32, 0);
+    add_handler(1, 33, 0);
+    add_handler(1, 34, 0);
+    add_handler(2, 48, 0);
+    add_handler(3, 48, 0);
+    add_handler(4, 48, 0);
+    add_handler(5, 48, 0);
+    add_handler(6, 64, 0);
+    // bug: if this one is the last it will cause a lot more additional entries
+    // to be deleted from the tail.
+    add_handler(1, 96, 0);
+    EXPECT_THAT(get_all_matching(32, 0), ElementsAre(h(1)));
+    EXPECT_THAT(get_all_matching(33, 0), ElementsAre(h(1)));
+    EXPECT_THAT(get_all_matching(34, 0), ElementsAre(h(1)));
+    EXPECT_THAT(get_all_matching(35, 0), ElementsAre());
+    EXPECT_THAT(get_all_matching(48, 0), ElementsAre(h(2), h(3), h(4), h(5)));
+    EXPECT_THAT(get_all_matching(64, 0), ElementsAre(h(6)));
+    handlers_.unregister_handler(h(1));
+    EXPECT_THAT(get_all_matching(32, 0), ElementsAre());
+    EXPECT_THAT(get_all_matching(33, 0), ElementsAre());
+    EXPECT_THAT(get_all_matching(34, 0), ElementsAre());
+    EXPECT_THAT(get_all_matching(35, 0), ElementsAre());
+    EXPECT_THAT(get_all_matching(48, 0), ElementsAre(h(2), h(3), h(4), h(5)));
+    EXPECT_THAT(get_all_matching(64, 0), ElementsAre(h(6)));
 }
 
 } // namespace openlcb

--- a/src/utils/SortedListMap.cxxtest
+++ b/src/utils/SortedListMap.cxxtest
@@ -1,0 +1,129 @@
+#include "utils/test_main.hxx"
+
+#include "utils/SortedListMap.hxx"
+
+#include <initializer_list>
+#include <vector>
+
+using ::testing::ElementsAre;
+
+class SortedListMapTest : public ::testing::Test
+{
+protected:
+    std::vector<int> elements()
+    {
+        std::vector<int> r;
+        for (auto it = map_.begin(); it != map_.end(); ++it)
+        {
+            r.push_back(*it);
+        }
+        return r;
+    }
+
+    void add(std::initializer_list<int> l)
+    {
+        for (int e : l)
+        {
+            int p = e;
+            map_.insert(std::move(p));
+        }
+    }
+
+    SortedListSet<int, std::less<int>> map_;
+};
+
+TEST_F(SortedListMapTest, create)
+{
+}
+
+TEST_F(SortedListMapTest, add_size)
+{
+    map_.insert(3);
+    map_.insert(5);
+    map_.insert(9);
+    EXPECT_EQ(3, map_.size());
+
+    EXPECT_THAT(elements(), ElementsAre(3, 5, 9));
+
+    map_.insert(2);
+    EXPECT_EQ(4, map_.size());
+    EXPECT_THAT(elements(), ElementsAre(2, 3, 5, 9));
+}
+
+TEST_F(SortedListMapTest, sort)
+{
+    map_.insert(9);
+    map_.insert(3);
+    map_.insert(5);
+    map_.insert(2);
+    EXPECT_THAT(elements(), ElementsAre(2, 3, 5, 9));
+}
+
+TEST_F(SortedListMapTest, sort2)
+{
+    add({9, 3, 5, 2});
+    EXPECT_THAT(elements(), ElementsAre(2, 3, 5, 9));
+}
+
+TEST_F(SortedListMapTest, erase)
+{
+    add({9, 3, 5, 2});
+    EXPECT_THAT(elements(), ElementsAre(2, 3, 5, 9));
+    EXPECT_EQ(4, map_.size());
+    EXPECT_EQ(4, map_.end() - map_.begin());
+    auto old_e = map_.end();
+    map_.erase(map_.begin() + 2);
+    auto new_e = map_.end();
+    EXPECT_NE(old_e, new_e);
+    EXPECT_EQ(3, map_.size());
+    EXPECT_EQ(3, new_e - map_.begin());
+    EXPECT_THAT(elements(), ElementsAre(2, 3, 9));
+
+    map_.clear();
+    EXPECT_EQ(0, map_.size());
+    EXPECT_THAT(elements(), ElementsAre());
+}
+
+TEST_F(SortedListMapTest, erase_last)
+{
+    add({9, 3, 5, 2});
+    EXPECT_THAT(elements(), ElementsAre(2, 3, 5, 9));
+    EXPECT_EQ(4, map_.size());
+    EXPECT_EQ(4, map_.end() - map_.begin());
+    auto old_e = map_.end();
+    map_.erase(map_.begin() + 3);
+    auto new_e = map_.end();
+    EXPECT_NE(old_e, new_e);
+    EXPECT_EQ(3, map_.size());
+    EXPECT_EQ(3, new_e - map_.begin());
+    EXPECT_THAT(elements(), ElementsAre(2, 3, 5));
+}
+
+TEST_F(SortedListMapTest, duplicate)
+{
+    add({9, 3, 5, 5, 5, 2});
+    EXPECT_THAT(elements(), ElementsAre(2, 3, 5, 5, 5, 9));
+    auto pp = map_.equal_range(5);
+    std::vector<int> v(pp.first, pp.second);
+    EXPECT_THAT(v, ElementsAre(5, 5, 5));
+
+    map_.erase(pp.first, pp.second);
+    // We do it purposefully in separate lines as begin() is doing some cache
+    // refresh internally.
+    auto new_e = map_.end();
+    auto new_b = map_.begin();
+    EXPECT_EQ(3, map_.size());
+    EXPECT_EQ(3, new_e - new_b);
+    EXPECT_THAT(elements(), ElementsAre(2, 3, 9));
+}
+
+TEST_F(SortedListMapTest, find)
+{
+    add({9, 3, 5, 2});
+    auto it = map_.find(5);
+    ASSERT_NE(map_.end(), it);
+    EXPECT_EQ(5, *it);
+
+    it = map_.find(7);
+    EXPECT_EQ(map_.end(), it);
+}

--- a/src/utils/SortedListMap.hxx
+++ b/src/utils/SortedListMap.hxx
@@ -37,6 +37,8 @@
 #include <vector>
 #include <algorithm>
 
+#include "utils/macros.h"
+
 /// An mostly std::set<> compatible class that stores the internal data in a
 /// sorted vector. Has low memory overhead; insertion cost is pretty high and
 /// lookup cost is logarithmic. Useful when a few insertions happen (for
@@ -127,7 +129,17 @@ public:
     /// Removes an entry from the vector, pointed by an iterator.
     void erase(const iterator &it)
     {
+        HASSERT(sortedCount_ > 0);
         container_.erase(it);
+        --sortedCount_;
+    }
+
+    /// Removes a sequence of entries from the vector, pointed by a pair of
+    /// iterators.
+    void erase(const iterator &it_b, const iterator& it_e)
+    {
+        container_.erase(it_b, it_e);
+        lazy_init(); // will set sortedCount_.
     }
 
     /// Removes all entries.
@@ -135,7 +147,7 @@ public:
         container_.clear();
         sortedCount_ = 0;
     }
-    
+
 private:
     /// Reestablishes sorted order in case anything was inserted or removed.
     void lazy_init()


### PR DESCRIPTION
Fixes major bugs in event registry and DccAccyProducer:
- the SortedListMap helper class got into an invalid state after an erase() was called
- the event registry unregister_handler was using an inappropriate algorithm for iterating and erasing entries. This has resulted various side effects; sometimes multiple registrations were not all removed; sometimes the registration of someone else was removed.
- the DccAccyProducer had incorrect locking for the shared static data structures.

Added unit tests for the SortedListMap class and coverage for the unregistration from the event registry.