### PR TITLE
API additions for ESTOP and programming mode

### DIFF
--- a/src/dcc/Packet.cxxtest
+++ b/src/dcc/Packet.cxxtest
@@ -300,7 +300,7 @@ void packet_processor_notify_update(PacketSource *source, unsigned code)
     g_update_loop->send_update(source, code);
 }
 
-void packet_processor_add_refresh_source(PacketSource *source)
+void packet_processor_add_refresh_source(PacketSource *source, unsigned priority)
 {
     HASSERT(g_update_loop);
     g_update_loop->register_source(source);

--- a/src/dcc/SimpleUpdateLoop.hxx
+++ b/src/dcc/SimpleUpdateLoop.hxx
@@ -66,8 +66,10 @@ public:
     ~SimpleUpdateLoop();
 
     /** Adds a new refresh source to the background refresh packets. */
-    void add_refresh_source(dcc::PacketSource *source) OVERRIDE
+    void add_refresh_source(
+        dcc::PacketSource *source, unsigned priority) OVERRIDE
     {
+        /// @todo implement priority refresh.
         AtomicHolder h(this);
         refreshSources_.push_back(source);
     }

--- a/src/dcc/UpdateLoop.cxx
+++ b/src/dcc/UpdateLoop.cxx
@@ -42,8 +42,10 @@ void packet_processor_notify_update(PacketSource* source, unsigned code) {
 }
 
 /** Adds a new refresh source to the background refresh loop. */
-void packet_processor_add_refresh_source(PacketSource* source) {
-  Singleton<UpdateLoopBase>::instance()->add_refresh_source(source);
+void packet_processor_add_refresh_source(
+    PacketSource *source, unsigned priority)
+{
+    Singleton<UpdateLoopBase>::instance()->add_refresh_source(source, priority);
 }
 
 /** Removes a refresh source from the background refresh loop. */

--- a/src/dcc/UpdateLoop.hxx
+++ b/src/dcc/UpdateLoop.hxx
@@ -51,8 +51,13 @@ class PacketSource;
  * the get_next_packet callback. It should not be zero.*/
 void packet_processor_notify_update(PacketSource *source, unsigned code);
 
-/** Adds a new refresh source to the background refresh loop. */
-void packet_processor_add_refresh_source(PacketSource *source);
+/** Adds a new refresh source to the background refresh loop.
+ * @param source is the packet source to add
+ * @param priority represents the packet source priority. If at least
+ * EXCLUSIVE_MIN_PRIORITY, then all packet slots will be assigned to this
+ * packet source, effectively stopping all background refresh. Only the largest
+ * priority will receive slots, until it gets unregistered. */
+void packet_processor_add_refresh_source(PacketSource *source, unsigned priority = 0);
 
 /** Removes a refresh source from the background refresh loop. */
 void packet_processor_remove_refresh_source(PacketSource *source);
@@ -69,8 +74,16 @@ class UpdateLoopBase : public Singleton<UpdateLoopBase>
 public:
     virtual ~UpdateLoopBase();
     virtual void notify_update(PacketSource *source, unsigned code) = 0;
-    virtual void add_refresh_source(PacketSource *source) = 0;
+    virtual void add_refresh_source(
+        PacketSource *source, unsigned priority = 0) = 0;
     virtual void remove_refresh_source(PacketSource *source) = 0;
+
+    /// Priority value for exclusive sources.
+    static constexpr unsigned EXCLUSIVE_MIN_PRIORITY = 0x100;
+    /// Priority value to be used for service mode programming source.
+    static constexpr unsigned PROGRAMMING_PRIORITY = 0x108;
+    /// Priority value to be used for global emergency stop packet source.
+    static constexpr unsigned ESTOP_PRIORITY = 0x110;
 };
 
 } // namespace dcc


### PR DESCRIPTION
Adds an API for registering packet update sources that take over the entire update loop.
This can be used to implement program track CV programming as well as an estop mode where only broadcast estop packets are sent out.