### PR TITLE
Minor updates to dcc packet printer

### DIFF
--- a/src/dcc/DccDebug.cxx
+++ b/src/dcc/DccDebug.cxx
@@ -49,7 +49,6 @@ string packet_to_string(const DCCPacket &pkt)
     if (pkt.packet_header.is_marklin)
     {
         options += "[marklin]";
-        return options;
     }
     else
     {
@@ -71,6 +70,13 @@ string packet_to_string(const DCCPacket &pkt)
     if (!pkt.dlc)
     {
         return options + " no payload";
+    }
+    if (pkt.packet_header.is_marklin) {
+        for (unsigned i = 0; i < pkt.dlc; ++i)
+        {
+            options += StringPrintf(" 0x%02x", pkt.payload[i]);
+        }
+        return options;
     }
     unsigned ofs = 0;
     bool is_idle_packet = false;

--- a/src/dcc/DccDebug.cxxtest
+++ b/src/dcc/DccDebug.cxxtest
@@ -131,7 +131,7 @@ TEST(DccDebug, marklin)
     pkt.start_mm_packet();
     pkt.add_mm_address(MMAddress(13), true);
     pkt.add_mm_speed(2);
-    EXPECT_EQ("[marklin]", packet_to_string(pkt));
+    EXPECT_EQ("[marklin][repeat 2 times] 0x03 0xf3 0xf0", packet_to_string(pkt));
 }
 
 } // namespace

--- a/src/dcc/PacketSource.hxx
+++ b/src/dcc/PacketSource.hxx
@@ -58,6 +58,38 @@ public:
     virtual void get_next_packet(unsigned code, Packet* packet) = 0;
 };
 
+/// Abstract class that is a packet source but not a TrainImpl. Provides dummy
+/// implementations for the TrainImpl interface virtual functions.
+class NonTrainPacketSource : public PacketSource
+{
+private:
+    void set_speed(SpeedType speed) override
+    {
+    }
+    SpeedType get_speed() override
+    {
+        return SpeedType();
+    }
+    void set_emergencystop() override
+    {
+    }
+    void set_fn(uint32_t address, uint16_t value) override
+    {
+    }
+    uint16_t get_fn(uint32_t address) override
+    {
+        return 0;
+    }
+    uint32_t legacy_address() override
+    {
+        return 0;
+    }
+    dcc::TrainAddressType legacy_address_type() override
+    {
+        return dcc::TrainAddressType::DCC_SHORT_ADDRESS;
+    }
+};
+
 }  // namespace dcc
 
 


### PR DESCRIPTION
Adds some printout for the marklin packets.
Adds an intermediate packet source class for non trainImpl classes.