### PR TITLE
Event invalidation race condition fix

### DIFF
--- a/src/openlcb/EventService.cxx
+++ b/src/openlcb/EventService.cxx
@@ -76,7 +76,8 @@ StateFlowBase::Action EventCallerFlow::entry()
 StateFlowBase::Action EventCallerFlow::perform_call()
 {
     EventHandlerCall *c = message()->data();
-    if (c->epoch != EventRegistry::instance()->get_epoch()) {
+    if (c->epoch != EventRegistry::instance()->get_epoch())
+    {
         // Event registry was invalidated since this call was scheduled. Ignore.
         return call_immediately(STATE(call_done));
     }
@@ -322,7 +323,8 @@ void InlineEventIteratorFlow::no_more_matches()
 
 StateFlowBase::Action InlineEventIteratorFlow::perform_call()
 {
-    if (eventRegistryEpoch_ != eventService_->impl()->registry->get_epoch()) {
+    if (eventRegistryEpoch_ != eventService_->impl()->registry->get_epoch())
+    {
         // Will restart iteration.
         return call_immediately(STATE(iterate_next));
     }

--- a/src/openlcb/EventServiceImpl.hxx
+++ b/src/openlcb/EventServiceImpl.hxx
@@ -58,12 +58,14 @@ struct EventHandlerCall
     const EventRegistryEntry *registry_entry;
     EventReport *rep;
     EventHandlerFunction fn;
-    void reset(const EventRegistryEntry *entry, EventReport *rep,
-               EventHandlerFunction fn)
+    unsigned epoch;
+    void reset(const EventRegistryEntry *entry, unsigned epoch,
+        EventReport *rep, EventHandlerFunction fn)
     {
         this->registry_entry = entry;
         this->rep = rep;
         this->fn = fn;
+        this->epoch = epoch;
     }
 };
 


### PR DESCRIPTION
Records the epoch when enqueueing an event handler call, and terminates the call if the event registry was invalidated inbetween.

This facility was already in place for the iterator accesses, but was not in effect for the asynchronous event calls.
