### PR TITLE
MemoryConfigClient: read segment-offset-size

### DIFF
--- a/src/openlcb/CDIUtils.hxx
+++ b/src/openlcb/CDIUtils.hxx
@@ -435,6 +435,16 @@ public:
             HASSERT(info);
             return address_ + info->offset_from_parent;
         }
+
+        /// Gets the size of a child (number of bytes occupied).
+        unsigned get_child_size(const XMLNode *child) const
+        {
+            HASSERT(child->father == node_);
+            NodeInfo *info;
+            get_userinfo(&info, child);
+            HASSERT(info);
+            return info->size;
+        }
     };
 
 private:

--- a/src/openlcb/MemoryConfigClient.cxxtest
+++ b/src/openlcb/MemoryConfigClient.cxxtest
@@ -95,6 +95,27 @@ TEST_F(MemoryConfigClientTest, readall)
     EXPECT_EQ(0, memcmp(&dataContents_[0], b->data()->payload.data(), dataContents_.size()));
 }
 
+TEST_F(MemoryConfigClientTest, readpart)
+{
+    expect_any_packet();
+    auto b = invoke_flow(&clientTwo_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(TEST_NODE_ID), 0x51, 34, 73);
+    EXPECT_EQ(0, b->data()->resultCode);
+    ASSERT_EQ(73u, b->data()->payload.size());
+    EXPECT_EQ(0, memcmp(&dataContents_[34], b->data()->payload.data(),
+                     b->data()->payload.size()));
+}
+
+TEST_F(MemoryConfigClientTest, readsmallpart)
+{
+    expect_any_packet();
+    auto b = invoke_flow(&clientTwo_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(TEST_NODE_ID), 0x51, 34, 14);
+    EXPECT_EQ(0, b->data()->resultCode);
+    ASSERT_EQ(14u, b->data()->payload.size());
+    EXPECT_EQ(0, memcmp(&dataContents_[34], b->data()->payload.data(),
+                     b->data()->payload.size()));
+}
 
 class MemoryConfigLocalClientTest : public AsyncDatagramTest {
 protected:

--- a/src/openlcb/MemoryConfigClient.hxx
+++ b/src/openlcb/MemoryConfigClient.hxx
@@ -333,8 +333,6 @@ private:
     BarrierNotifiable bn_;
     /// Next byte to read from the memory space.
     size_t offset_;
-    /// How many bytes are left to read.
-    size_t bytesLeft_;
     /// timing helper
     StateFlowTimer timer_{this};
     /// The data that came back from reading.


### PR DESCRIPTION
Adds a feature to the MemoryConfigClient to read a part of a memory space.
Also add a helper function to get a CDI element's size.