### PR TITLE
Bugfix for loopback memory config read

### DIFF
--- a/src/openlcb/MemoryConfig.hxx
+++ b/src/openlcb/MemoryConfig.hxx
@@ -511,24 +511,27 @@ public:
         size_t len = message->data()->payload.size();
         const uint8_t *bytes = (const uint8_t *)message->data()->payload.data();
         uint8_t cmd = ((len >= 2) && (client_ != nullptr)) ? bytes[1] : 0;
+        bool is_client_command = false;
+        if ((cmd < 0x80) && (cmd & 0x10))
+        {
+            is_client_command = true;
+        }
         switch (cmd)
         {
-            case MemoryConfigDefs::COMMAND_WRITE_REPLY:
-            case MemoryConfigDefs::COMMAND_WRITE_FAILED:
-            case MemoryConfigDefs::COMMAND_WRITE_STREAM_REPLY:
-            case MemoryConfigDefs::COMMAND_WRITE_STREAM_FAILED:
-            case MemoryConfigDefs::COMMAND_READ_REPLY:
-            case MemoryConfigDefs::COMMAND_READ_FAILED:
             case MemoryConfigDefs::COMMAND_OPTIONS_REPLY:
             case MemoryConfigDefs::COMMAND_INFORMATION_REPLY:
             case MemoryConfigDefs::COMMAND_LOCK_REPLY:
             case MemoryConfigDefs::COMMAND_UNIQUE_ID_REPLY:
             {
-                client_->send(message, priority);
-                return;
+                is_client_command = true;
             }
             default:
                 break;
+        }
+        if (is_client_command)
+        {
+            client_->send(message, priority);
+            return;
         }
         DatagramHandlerFlow::send(message, priority);
     }

--- a/src/openlcb/MemoryConfig.hxx
+++ b/src/openlcb/MemoryConfig.hxx
@@ -64,6 +64,8 @@ struct MemoryConfigDefs {
         COMMAND_MASK              = 0xFC,
         COMMAND_FLAG_MASK         = 0x03, /**< mask for special memory space flags */
         COMMAND_PRESENT_MASK      = 0x01, /**< mask for address space present bit */
+        COMMAND_REPLY_BIT_FOR_RW  = 0x10, /**< This bit is present in REPLY commands for read-write commands. */
+
         COMMAND_WRITE             = 0x00, /**< command to write data to address space */
         COMMAND_WRITE_UNDER_MASK  = 0x08, /**< command to write data under mask */
         COMMAND_WRITE_REPLY       = 0x10, /**< reply to write data to address space */
@@ -75,6 +77,7 @@ struct MemoryConfigDefs {
         COMMAND_READ_REPLY        = 0x50, /**< reply to read data from address space */
         COMMAND_READ_FAILED       = 0x58, /**< failed to read data from address space */
         COMMAND_READ_STREAM       = 0x60, /**< command to read data using a stream */
+        COMMAND_MAX_FOR_RW        = 0x80, /**< command <= this value have fixed bit arrangement. */
         COMMAND_OPTIONS           = 0x80,
         COMMAND_OPTIONS_REPLY     = 0x82,
         COMMAND_INFORMATION       = 0x84,
@@ -512,10 +515,14 @@ public:
         const uint8_t *bytes = (const uint8_t *)message->data()->payload.data();
         uint8_t cmd = ((len >= 2) && (client_ != nullptr)) ? bytes[1] : 0;
         bool is_client_command = false;
-        if ((cmd < 0x80) && (cmd & 0x10))
+        // To recognize replies for read & write commands, we need to look at a
+        // bit.
+        if ((cmd < MemoryConfigDefs::COMMAND_MAX_FOR_RW) &&
+            (cmd & MemoryConfigDefs::COMMAND_REPLY_BIT_FOR_RW))
         {
             is_client_command = true;
         }
+        // For the rest of the commands we can enumerate which are replies.
         switch (cmd)
         {
             case MemoryConfigDefs::COMMAND_OPTIONS_REPLY:

--- a/src/openlcb/MemoryConfigClient.cxxtest
+++ b/src/openlcb/MemoryConfigClient.cxxtest
@@ -117,6 +117,13 @@ TEST_F(MemoryConfigClientTest, readsmallpart)
                      b->data()->payload.size()));
 }
 
+TEST_F(MemoryConfigClientTest, unsolicited)
+{
+    expect_any_packet();
+    send_packet(":1AFF2123N2050112233;");
+    wait();
+}
+
 class MemoryConfigLocalClientTest : public AsyncDatagramTest {
 protected:
     ~MemoryConfigLocalClientTest() {
@@ -143,6 +150,24 @@ TEST_F(MemoryConfigLocalClientTest, readfromlocal)
     EXPECT_EQ(0, b->data()->resultCode);
     ASSERT_EQ(dataContents_.size(), b->data()->payload.size());
     EXPECT_EQ(0, memcmp(&dataContents_[0], b->data()->payload.data(), dataContents_.size()));
+}
+
+TEST_F(MemoryConfigLocalClientTest, readfromlocalspecialspace)
+{
+    // In this test we read from the local node, to test that the
+    // service-client interaction is without any deadlock. We use a special
+    // space number (0xFD to 0xFF) to regression test a bug in the request
+    // routing.
+    memCfg_.registry()->insert(
+        node_, MemoryConfigDefs::SPACE_CONFIG, &srvSpace_);
+
+    expect_any_packet();
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::READ,
+        NodeHandle(node_->node_id()), MemoryConfigDefs::SPACE_CONFIG);
+    EXPECT_EQ(0, b->data()->resultCode);
+    ASSERT_EQ(dataContents_.size(), b->data()->payload.size());
+    EXPECT_EQ(0, memcmp(&dataContents_[0], b->data()->payload.data(),
+                     dataContents_.size()));
 }
 
 } // namespace openlcb

--- a/src/openlcb/MemoryConfigClient.cxxtest
+++ b/src/openlcb/MemoryConfigClient.cxxtest
@@ -120,6 +120,8 @@ TEST_F(MemoryConfigClientTest, readsmallpart)
 TEST_F(MemoryConfigClientTest, unsolicited)
 {
     expect_any_packet();
+    // Tests that we don't crash if no client is registered and an unsolicited
+    // response packet shows up.
     send_packet(":1AFF2123N2050112233;");
     wait();
 }
@@ -157,7 +159,8 @@ TEST_F(MemoryConfigLocalClientTest, readfromlocalspecialspace)
     // In this test we read from the local node, to test that the
     // service-client interaction is without any deadlock. We use a special
     // space number (0xFD to 0xFF) to regression test a bug in the request
-    // routing.
+    // routing. The bug was that responses for those space numbers were not
+    // routed to the client.
     memCfg_.registry()->insert(
         node_, MemoryConfigDefs::SPACE_CONFIG, &srvSpace_);
 


### PR DESCRIPTION
Fixes a bug in MemoryConfig message routing client that prevented addressing localhost when the target space was one of the special space numbers and the command byte had its low bits modified.