### PR TITLE
MemoryConfigClient: write support

### DIFF
--- a/src/openlcb/MemoryConfig.cxxtest
+++ b/src/openlcb/MemoryConfig.cxxtest
@@ -105,6 +105,55 @@ using testing::DoAll;
 using testing::WithArgs;
 using testing::SetArgPointee;
 
+TEST(MemoryConfigDefsTest, datagram_address_and_space)
+{
+    auto dg = MemoryConfigDefs::write_datagram(0x51, 0x33445566, "abcd");
+    EXPECT_EQ(0x51u, MemoryConfigDefs::get_space(dg));
+    EXPECT_EQ(0x33445566u, MemoryConfigDefs::get_address(dg));
+    EXPECT_EQ('a', MemoryConfigDefs::payload_bytes(
+                       dg)[MemoryConfigDefs::get_payload_offset(dg)]);
+
+    dg = MemoryConfigDefs::read_datagram(0x42, 0x11223344, 10);
+    EXPECT_EQ(0x42u, MemoryConfigDefs::get_space(dg));
+    EXPECT_EQ(0x11223344u, MemoryConfigDefs::get_address(dg));
+    EXPECT_EQ(10u, MemoryConfigDefs::payload_bytes(
+                       dg)[MemoryConfigDefs::get_payload_offset(dg)]);
+}
+
+TEST(MemoryConfigDefsTest, datagram_space_for_special_spaces)
+{
+    auto dg = MemoryConfigDefs::write_datagram(0xFD, 0x33445566, "abcd");
+    EXPECT_EQ(0xFDu, MemoryConfigDefs::get_space(dg));
+    EXPECT_EQ('a', MemoryConfigDefs::payload_bytes(
+                       dg)[MemoryConfigDefs::get_payload_offset(dg)]);
+
+    dg = MemoryConfigDefs::read_datagram(0xFE, 0x11223344, 10);
+    EXPECT_EQ(0xFEu, MemoryConfigDefs::get_space(dg));
+    EXPECT_EQ(10u, MemoryConfigDefs::payload_bytes(
+                       dg)[MemoryConfigDefs::get_payload_offset(dg)]);
+}
+
+TEST(MemoryConfigDefsTest, datagram_min_size)
+{
+    auto dg = MemoryConfigDefs::write_datagram(0xFD, 0x33445566, "a");
+    EXPECT_TRUE(MemoryConfigDefs::payload_min_length_check(dg, 0));
+    dg.pop_back();
+    EXPECT_TRUE(MemoryConfigDefs::payload_min_length_check(dg, 0));
+    dg.pop_back();
+    EXPECT_FALSE(MemoryConfigDefs::payload_min_length_check(dg, 0));
+
+    dg = MemoryConfigDefs::read_datagram(0x13, 0x11223344, 10);
+    EXPECT_TRUE(MemoryConfigDefs::payload_min_length_check(dg, 1));
+    dg.pop_back();
+    EXPECT_FALSE(MemoryConfigDefs::payload_min_length_check(dg, 1));
+
+    dg.clear();
+    EXPECT_FALSE(MemoryConfigDefs::payload_min_length_check(dg, 0));
+
+    dg = "\x20\x00\x01\x02\x03";
+    EXPECT_FALSE(MemoryConfigDefs::payload_min_length_check(dg, 0));
+}
+
 TEST_F(MemoryConfigTest, MockMemoryConfigRead)
 {
     memoryOne_.registry()->insert(node_, 0x27, &space);

--- a/src/openlcb/MemoryConfig.hxx
+++ b/src/openlcb/MemoryConfig.hxx
@@ -156,9 +156,11 @@ struct MemoryConfigDefs {
         return space > SPACE_SPECIAL;
     }
 
-    static DatagramPayload write_datagram(uint8_t space, uint32_t offset) {
+    static DatagramPayload write_datagram(
+        uint8_t space, uint32_t offset, const string &data = "")
+    {
         DatagramPayload p;
-        p.reserve(7);
+        p.reserve(7 + data.size());
         p.push_back(DatagramDefs::CONFIGURATION);
         p.push_back(COMMAND_WRITE);
         p.push_back(0xff & (offset >> 24));
@@ -170,6 +172,7 @@ struct MemoryConfigDefs {
         } else {
             p.push_back(space);
         }
+        p += data;
         return p;
     }
 
@@ -528,6 +531,8 @@ public:
             default:
                 break;
         }
+        LOG(VERBOSE, "MemoryConfig incoming cmd 0x%02x is_client %d", cmd,
+            is_client_command);
         if (is_client_command)
         {
             client_->send(message, priority);

--- a/src/openlcb/MemoryConfig.hxx
+++ b/src/openlcb/MemoryConfig.hxx
@@ -152,6 +152,8 @@ struct MemoryConfigDefs {
         ERROR_WRITE_TO_RO = Defs::ERROR_INVALID_ARGS | 0x0003,
     };
 
+    static constexpr unsigned MAX_DATAGRAM_RW_BYTES = 64;
+
     static bool is_special_space(uint8_t space) {
         return space > SPACE_SPECIAL;
     }
@@ -195,7 +197,77 @@ struct MemoryConfigDefs {
         p.push_back(length);
         return p;
     }
-    
+
+    /// @return true if the payload has minimum number of bytes you need in a
+    /// read or write datagram message to cover for the necessary fields
+    /// (command, offset, space).
+    /// @param payload is a datagram (read or write, request or response)
+    /// @param extra is the needed bytes after address and space, usually 0 for
+    /// write and 1 for read.
+    static bool payload_min_length_check(
+        const DatagramPayload &payload, unsigned extra)
+    {
+        auto *bytes = payload_bytes(payload);
+        size_t sz = payload.size();
+        if (sz < 6 + extra)
+        {
+            return false;
+        }
+        if (((bytes[1] & COMMAND_FLAG_MASK) == 0) && (sz < 7 + extra))
+        {
+            return false;
+        }
+        return true;
+    }
+
+    /// @return addressed memory space number.
+    /// @param payload is a read or write datagram request or response message
+    static uint8_t get_space(const DatagramPayload &payload)
+    {
+        auto *bytes = payload_bytes(payload);
+        if (bytes[1] & COMMAND_FLAG_MASK)
+        {
+            return COMMAND_MASK + (bytes[1] & COMMAND_FLAG_MASK);
+        }
+        return bytes[6];
+    }
+
+    static unsigned get_payload_offset(const DatagramPayload &payload)
+    {
+        auto *bytes = payload_bytes(payload);
+        if (bytes[1] & COMMAND_FLAG_MASK)
+        {
+            return 6;
+        }
+        else
+        {
+            return 7;
+        }
+    }
+
+    /// @param payload is a datagram read or write request or response
+    /// @return the address field from the datagram
+    static uint32_t get_address(const DatagramPayload &payload)
+    {
+        auto *bytes = payload_bytes(payload);
+        uint32_t a = bytes[2];
+        a <<= 8;
+        a |= bytes[3];
+        a <<= 8;
+        a |= bytes[4];
+        a <<= 8;
+        a |= bytes[5];
+        return a;
+    }
+
+    /// Type casts a DatagramPayload to an array of bytes.
+    /// @param payload datagram
+    /// @return byte array pointing to the same memory
+    static const uint8_t *payload_bytes(const DatagramPayload &payload)
+    {
+        return (uint8_t *)payload.data();
+    }
+
 private:
     /** Do not instantiate this class. */
     MemoryConfigDefs();

--- a/src/openlcb/MemoryConfigClient.cxxtest
+++ b/src/openlcb/MemoryConfigClient.cxxtest
@@ -117,6 +117,40 @@ TEST_F(MemoryConfigClientTest, readsmallpart)
                      b->data()->payload.size()));
 }
 
+TEST_F(MemoryConfigClientTest, writelarge)
+{
+    expect_any_packet();
+    string test_payload;
+    for (int i = 56; i < 56 + 75; ++i)
+    {
+        test_payload.push_back(i);
+    }
+    EXPECT_NE(0,
+        memcmp(&dataContents_[34], test_payload.data(), test_payload.size()));
+    auto b = invoke_flow(&clientTwo_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(TEST_NODE_ID), 0x51, 34, test_payload);
+    EXPECT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ(0,
+        memcmp(&dataContents_[34], test_payload.data(), test_payload.size()));
+}
+
+TEST_F(MemoryConfigClientTest, writesmall)
+{
+    expect_any_packet();
+    string test_payload;
+    for (int i = 56; i < 56 + 13; ++i)
+    {
+        test_payload.push_back(i);
+    }
+    EXPECT_NE(0,
+        memcmp(&dataContents_[34], test_payload.data(), test_payload.size()));
+    auto b = invoke_flow(&clientTwo_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(TEST_NODE_ID), 0x51, 34, test_payload);
+    EXPECT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ(0,
+        memcmp(&dataContents_[34], test_payload.data(), test_payload.size()));
+}
+
 TEST_F(MemoryConfigClientTest, unsolicited)
 {
     expect_any_packet();

--- a/src/openlcb/MemoryConfigClient.cxxtest
+++ b/src/openlcb/MemoryConfigClient.cxxtest
@@ -117,6 +117,8 @@ TEST_F(MemoryConfigClientTest, readsmallpart)
                      b->data()->payload.size()));
 }
 
+// Tests using the MemoryConfigClient to write a payload of more than one
+// datagram.
 TEST_F(MemoryConfigClientTest, writelarge)
 {
     expect_any_packet();
@@ -134,6 +136,8 @@ TEST_F(MemoryConfigClientTest, writelarge)
         memcmp(&dataContents_[34], test_payload.data(), test_payload.size()));
 }
 
+// Tests using the MemoryConfigClient to write a payload that fits into one
+// datagram.
 TEST_F(MemoryConfigClientTest, writesmall)
 {
     expect_any_packet();

--- a/src/openlcb/MemoryConfigClient.hxx
+++ b/src/openlcb/MemoryConfigClient.hxx
@@ -54,6 +54,11 @@ struct MemoryConfigClientRequest : public CallableFlowRequestBase
         READ_PART
     };
 
+    enum WriteCmd
+    {
+        WRITE
+    };
+
     /// Sets up a command to read an entire memory space.
     /// @param ReadCmd polymorphic matching arg; always set to READ.
     /// @param d is the destination node to query
@@ -85,6 +90,24 @@ struct MemoryConfigClientRequest : public CallableFlowRequestBase
         this->address = offset;
         this->size = size;
         payload.clear();
+    }
+
+    /// Sets up a command to read a part of a memory space.
+    /// @param WriteCmd polymorphic matching arg; always set to WRITE.
+    /// @param d is the destination node to query
+    /// @param space is the memory space to write to
+    /// @param offset if the address of the first byte to read
+    /// @param data is the data to write
+    void reset(
+        WriteCmd, NodeHandle d, uint8_t space, unsigned offset, string data)
+    {
+        reset_base();
+        cmd = CMD_WRITE;
+        memory_space = space;
+        dst = d;
+        this->address = offset;
+        this->size = size;
+        payload = std::move(data);
     }
 
     enum Command : uint8_t
@@ -121,6 +144,9 @@ private:
         case MemoryConfigClientRequest::CMD_READ_PART:
             return allocate_and_call(
                 STATE(do_read), dg_service()->client_allocator());
+        case MemoryConfigClientRequest::CMD_WRITE:
+            return allocate_and_call(
+                STATE(do_write), dg_service()->client_allocator());
         default: break;
         }
         return return_with_error(Defs::ERROR_UNIMPLEMENTED_SUBCMD);
@@ -270,7 +296,156 @@ private:
         cleanup_read();
         return return_ok();
     }
-    
+
+    Action do_write()
+    {
+        dgClient_ = full_allocation_result(dg_service()->client_allocator());
+        offset_ = request()->address;
+        payloadOffset_ = 0;
+        memoryConfigHandler_->set_client(&responseFlow_);
+        return call_immediately(STATE(send_next_write));
+    }
+
+    Action send_next_write()
+    {
+        return allocate_and_call(
+            dg_service()->iface()->dispatcher(), STATE(send_write_datagram));
+    }
+
+    Action send_write_datagram()
+    {
+        auto *b = get_allocation_result(dg_service()->iface()->dispatcher());
+        b->set_done(bn_.reset(this));
+        unsigned sz = request()->payload.size() - payloadOffset_;
+        if (sz > 64)
+            sz = 64;
+        writeLength_ = sz;
+        b->data()->reset(Defs::MTI_DATAGRAM, node_->node_id(), request()->dst,
+            MemoryConfigDefs::write_datagram(request()->memory_space, offset_,
+                             request()->payload.substr(payloadOffset_, sz)));
+        isWaitingForTimer_ = 0;
+        responseCode_ = DatagramClient::OPERATION_PENDING;
+        dgClient_->write_datagram(b);
+        return wait_and_call(STATE(write_complete));
+    }
+
+    Action write_complete()
+    {
+        if (!(dgClient_->result() & DatagramClient::OPERATION_SUCCESS))
+        {
+            // some error occurred.
+            return handle_write_error(dgClient_->result());
+        }
+        if (responseCode_ & DatagramClient::OPERATION_PENDING)
+        {
+            isWaitingForTimer_ = 1;
+            return sleep_and_call(
+                &timer_, SEC_TO_NSEC(3), STATE(write_response_timeout));
+        }
+        else
+        {
+            return call_immediately(STATE(write_response_timeout));
+        }
+    }
+
+    Action write_response_timeout()
+    {
+        if (responseCode_ & DatagramClient::OPERATION_PENDING)
+        {
+            return handle_write_error(Defs::OPENMRN_TIMEOUT);
+        }
+        size_t len = responsePayload_.size();
+        uint8_t *bytes = (uint8_t *)responsePayload_.data();
+        if (len < 6)
+        {
+            LOG(INFO, "Memory Config client: response datagram payload not "
+                      "long enough");
+            return handle_write_error(
+                Defs::ERROR_INVALID_ARGS_MESSAGE_TOO_SHORT);
+        }
+        unsigned ofs;
+        unsigned a = bytes[2];
+        a <<= 8;
+        a |= bytes[3];
+        a <<= 8;
+        a |= bytes[4];
+        a <<= 8;
+        a |= bytes[5];
+        uint8_t space = 0;
+        uint8_t cmd = bytes[1];
+        if (a != offset_)
+        {
+            return handle_write_error(Defs::ERROR_OUT_OF_ORDER);
+        }
+        if (cmd & 3)
+        {
+            ofs = 6;
+            space = 0xFC | (cmd & 3);
+        }
+        else
+        {
+            ofs = 7;
+            if (len < 7)
+            {
+                return handle_write_error(
+                    Defs::ERROR_INVALID_ARGS_MESSAGE_TOO_SHORT);
+            }
+            space = bytes[6];
+        }
+        if (space != request()->memory_space)
+        {
+            return handle_write_error(Defs::ERROR_OUT_OF_ORDER);
+        }
+        if ((cmd & ~3) == MemoryConfigDefs::COMMAND_WRITE_FAILED)
+        {
+            if (len < ofs + 2)
+            {
+                return handle_write_error(
+                    Defs::ERROR_INVALID_ARGS_MESSAGE_TOO_SHORT);
+            }
+            uint16_t error = bytes[ofs++];
+            error <<= 8;
+            error |= bytes[ofs];
+            return handle_write_error(error);
+        }
+        if ((cmd & ~3) != MemoryConfigDefs::COMMAND_WRITE_REPLY)
+        {
+            return handle_write_error(Defs::ERROR_UNIMPLEMENTED);
+        }
+        // write success.
+        offset_ += writeLength_;
+        payloadOffset_ += writeLength_;
+        if (payloadOffset_ >= request()->payload.size())
+        {
+            return call_immediately(STATE(finish_write));
+        }
+        return call_immediately(STATE(send_next_write));
+    }
+
+    Action handle_write_error(int error)
+    {
+        if (error == MemoryConfigDefs::ERROR_OUT_OF_BOUNDS)
+        {
+            return finish_write();
+        }
+        cleanup_write();
+        return return_with_error(error);
+    }
+
+    void cleanup_write()
+    {
+        responsePayload_.clear();
+        dg_service()->client_allocator()->typed_insert(dgClient_);
+        memoryConfigHandler_->clear_client(&responseFlow_);
+        dgClient_ = nullptr;
+    }
+
+    Action finish_write()
+    {
+        cleanup_write();
+        return return_ok();
+    }
+
     class ResponseFlow : public DefaultDatagramHandler
     {
     public:
@@ -300,6 +475,13 @@ private:
                 case MemoryConfigDefs::COMMAND_READ_REPLY:
                 case MemoryConfigDefs::COMMAND_READ_FAILED:
                 {
+                    if (parent_->request()->cmd !=
+                            MemoryConfigClientRequest::CMD_READ &&
+                        parent_->request()->cmd !=
+                            MemoryConfigClientRequest::CMD_READ_PART)
+                    {
+                        break;
+                    }
                     parent_->responseCode_ = 0;
                     message()->data()->payload.swap(parent_->responsePayload_);
                     if (parent_->isWaitingForTimer_)
@@ -308,6 +490,20 @@ private:
                     }
                     return respond_ok(0);
                 }
+                case MemoryConfigDefs::COMMAND_WRITE_REPLY:
+                case MemoryConfigDefs::COMMAND_WRITE_FAILED:
+                    if (parent_->request()->cmd !=
+                        MemoryConfigClientRequest::CMD_WRITE)
+                    {
+                        break;
+                    }
+                    parent_->responseCode_ = 0;
+                    message()->data()->payload.swap(parent_->responsePayload_);
+                    if (parent_->isWaitingForTimer_)
+                    {
+                        parent_->timer_.trigger();
+                    }
+                    return respond_ok(0);
             }
             return respond_reject(Defs::ERROR_UNIMPLEMENTED_SUBCMD);
         }
@@ -332,7 +528,11 @@ private:
     /// Notify helper.
     BarrierNotifiable bn_;
     /// Next byte to read from the memory space.
-    size_t offset_;
+    uint32_t offset_;
+    /// Next byte in the payload to write.
+    uint32_t payloadOffset_;
+    /// How many bytes we wrote in this datagram.
+    uint16_t writeLength_;
     /// timing helper
     StateFlowTimer timer_{this};
     /// The data that came back from reading.


### PR DESCRIPTION
Adds implementation for Memory Config write commands to the MemoryConfigClient library.