### PR TITLE
Fix E-OFF event name.

### DIFF
--- a/src/openlcb/Defs.hxx
+++ b/src/openlcb/Defs.hxx
@@ -211,6 +211,14 @@ struct Defs
         RESERVED_MASK           = 0x00000FFFFFFF
     };
 
+    /// Producing this event causes all operations to stop (usually by
+    /// turning off the command station power output).
+    static constexpr uint64_t EMERGENCY_OFF_EVENT = 0x010000000000FFFFULL;
+
+    /// Producing this event resumes all operations (usually by turning
+    /// power back on).
+    static constexpr uint64_t CLEAR_EMERGENCY_OFF_EVENT = 0x010000000000FFFEULL;
+
     /** Status of the pysical layer link */
     enum LinkStatus
     {

--- a/src/openlcb/Defs.hxx
+++ b/src/openlcb/Defs.hxx
@@ -211,12 +211,14 @@ struct Defs
         RESERVED_MASK           = 0x00000FFFFFFF
     };
 
-    /// Producing this event causes all operations to stop (usually by
-    /// turning off the command station power output).
+    /// Producing this event causes an Emergency Off (de-energize).  For
+    /// example, a DCC command station or booster may react to this by turning
+    /// off the command station or booster power output.
     static constexpr uint64_t EMERGENCY_OFF_EVENT = 0x010000000000FFFFULL;
 
-    /// Producing this event resumes all operations (usually by turning
-    /// power back on).
+    /// Producing this event clears an Emergency Off (energize).  For example,
+    /// a DCC command station or booster mauy react to this by restoring
+    /// track power.
     static constexpr uint64_t CLEAR_EMERGENCY_OFF_EVENT = 0x010000000000FFFEULL;
 
     /** Status of the pysical layer link */

--- a/src/openlcb/TractionDefs.cxx
+++ b/src/openlcb/TractionDefs.cxx
@@ -62,8 +62,6 @@ void speed_to_fp16(SpeedType speed, void *fp16) {
 
 const uint64_t TractionDefs::IS_TRAIN_EVENT;
 const uint64_t TractionDefs::IS_PROXY_EVENT;
-const uint64_t TractionDefs::EMERGENCY_STOP_EVENT;
-const uint64_t TractionDefs::CLEAR_EMERGENCY_STOP_EVENT;
 
 const uint64_t TractionDefs::NODE_ID_DC_BLOCK;
 const uint64_t TractionDefs::NODE_ID_DCC;

--- a/src/openlcb/TractionDefs.hxx
+++ b/src/openlcb/TractionDefs.hxx
@@ -76,14 +76,6 @@ struct TractionDefs {
     static const uint64_t IS_TRAIN_EVENT = 0x0101000000000303ULL;
     /// This event should be produced by traction proxy nodes.
     static const uint64_t IS_PROXY_EVENT = 0x0101000000000304ULL;
-    /// Producing this event causes all operations to stop (usually by turning
-    /// off the command station power output).
-    /// @TODO : there is a mistake in this constant. It should start with
-    /// 0100 by the standard (instead of 0101).
-    static const uint64_t EMERGENCY_STOP_EVENT = 0x010000000000FFFFULL;
-    /// Producing this event resumes all operations (usually by turning power
-    /// back on).
-    static const uint64_t CLEAR_EMERGENCY_STOP_EVENT = 0x010000000000FFFEULL;
     /// Base address of DCC accessory decoder well-known event range (active)
     static constexpr uint64_t ACTIVATE_BASIC_DCC_ACCESSORY_EVENT_BASE = 0x0101020000FF0000ULL;
     /// Base address of DCC accessory decoder well-known event range (inactive)


### PR DESCRIPTION
I intentionally left a new define for [CLEAR_]EMERGENCY_ESTOP_EVENT for now.  This will ensure that we flush out all the necessary changes before reintroducing that name back in the mix.