### PR TITLE
initial load fixes for config update flow

### DIFF
--- a/src/openlcb/ConfigUpdateFlow.cxx
+++ b/src/openlcb/ConfigUpdateFlow.cxx
@@ -58,7 +58,6 @@ int ConfigUpdateFlow::open_file(const char *path)
 void ConfigUpdateFlow::init_flow()
 {
     trigger_update();
-    isInitialLoad_ = 1;
 }
 
 void ConfigUpdateFlow::factory_reset()

--- a/src/openlcb/ConfigUpdateFlow.cxx
+++ b/src/openlcb/ConfigUpdateFlow.cxx
@@ -65,6 +65,11 @@ void ConfigUpdateFlow::factory_reset()
     for (auto it = listeners_.begin(); it != listeners_.end(); ++it) {
         it->factory_reset(fd_);
     }
+    for (auto it = pendingListeners_.begin(); it != pendingListeners_.end();
+         ++it)
+    {
+        it->factory_reset(fd_);
+    }
 }
 
 extern const char *const CONFIG_FILENAME __attribute__((weak)) = nullptr;

--- a/src/openlcb/ConfigUpdateFlow.cxxtest
+++ b/src/openlcb/ConfigUpdateFlow.cxxtest
@@ -66,22 +66,41 @@ TEST_F(ConfigUpdateFlowTest, CreateDestroy)
 {
 }
 
-TEST_F(ConfigUpdateFlowTest, CallListener)
+TEST_F(ConfigUpdateFlowTest, CallListenerWithInitial)
 {
-    updateFlow_.register_update_listener(&l1);
+    wait_for_main_executor();
     updateFlow_.TEST_set_fd(23);
+    EXPECT_CALL(l1, apply_configuration(23, true, _))
+        .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
+                        Return(ConfigUpdateListener::UPDATED)));
+    updateFlow_.register_update_listener(&l1);
+    wait_for_main_executor();
+    Mock::VerifyAndClear(&l1);
+
     EXPECT_CALL(l1, apply_configuration(23, false, _))
         .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
                         Return(ConfigUpdateListener::UPDATED)));
+
     updateFlow_.trigger_update();
     wait_for_main_executor();
 }
 
 TEST_F(ConfigUpdateFlowTest, CallMultipleListener)
 {
+    updateFlow_.TEST_set_fd(23);
+
+    EXPECT_CALL(l1, apply_configuration(23, true, _))
+        .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
+                        Return(ConfigUpdateListener::UPDATED)));
+    EXPECT_CALL(l2, apply_configuration(23, true, _))
+        .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
+                        Return(ConfigUpdateListener::UPDATED)));
+
     updateFlow_.register_update_listener(&l1);
     updateFlow_.register_update_listener(&l2);
-    updateFlow_.TEST_set_fd(23);
+    wait_for_main_executor();
+    Mock::VerifyAndClear(&l1);
+    Mock::VerifyAndClear(&l2);
 
     EXPECT_CALL(l1, apply_configuration(23, false, _))
         .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
@@ -89,29 +108,35 @@ TEST_F(ConfigUpdateFlowTest, CallMultipleListener)
     EXPECT_CALL(l2, apply_configuration(23, false, _))
         .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
                         Return(ConfigUpdateListener::UPDATED)));
+
     updateFlow_.trigger_update();
     wait_for_main_executor();
 }
 
 TEST_F(ConfigUpdateFlowTest, AsyncListenerCall)
 {
-    updateFlow_.register_update_listener(&l1);
-    updateFlow_.register_update_listener(&l2);
     updateFlow_.TEST_set_fd(17);
-
-    Notifiable* d = nullptr;
-    EXPECT_CALL(l2, apply_configuration(17, false, _))
-        .WillOnce(DoAll(SaveArg<2>(&d),
-                        Return(ConfigUpdateListener::RETRY)));
-    updateFlow_.trigger_update();
-    wait_for_main_executor();
-    // The second listener will not be called until the first reports done.
-    wait_for_main_executor();
-    // The first will also be called again as a retry.
-    EXPECT_CALL(l2, apply_configuration(17, false, _))
+    EXPECT_CALL(l1, apply_configuration(17, true, _))
         .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
                         Return(ConfigUpdateListener::UPDATED)));
+    EXPECT_CALL(l2, apply_configuration(17, true, _))
+        .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
+                        Return(ConfigUpdateListener::UPDATED)));
+    updateFlow_.register_update_listener(&l1);
+    updateFlow_.register_update_listener(&l2);
+    wait_for_main_executor();
+    Mock::VerifyAndClear(&l1);
+    Mock::VerifyAndClear(&l2);
+
+    Notifiable* d = nullptr;
     EXPECT_CALL(l1, apply_configuration(17, false, _))
+        .WillOnce(DoAll(SaveArg<2>(&d),
+                        Return(ConfigUpdateListener::UPDATED)));
+    updateFlow_.trigger_update();
+    wait_for_main_executor();
+    Mock::VerifyAndClear(&l1);
+    // The second will also be called now.
+    EXPECT_CALL(l2, apply_configuration(17, false, _))
         .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
                         Return(ConfigUpdateListener::UPDATED)));
     d->notify();
@@ -120,12 +145,26 @@ TEST_F(ConfigUpdateFlowTest, AsyncListenerCall)
 
 TEST_F(ConfigUpdateFlowTest, InitialLoad)
 {
+    updateFlow_.~ConfigUpdateFlow();
+    // This code simulates what happens during startup in a real
+    // binary. Specifically, the executor is not running yet when things get
+    // registered.
+    BlockExecutor block(nullptr);
+    new (&updateFlow_) ConfigUpdateFlow(ifCan_.get());
+    updateFlow_.open_file("/dev/zero");
+    updateFlow_.init_flow();
     updateFlow_.register_update_listener(&l1);
     EXPECT_CALL(l1, apply_configuration(::testing::Gt(0), true, _))
         .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
                         Return(ConfigUpdateListener::UPDATED)));
-    updateFlow_.open_file("/dev/zero");
-    updateFlow_.init_flow();
+    block.release_block();
+    wait_for_main_executor();
+    Mock::VerifyAndClear(&l1);
+
+    EXPECT_CALL(l1, apply_configuration(::testing::Gt(0), false, _))
+        .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
+                        Return(ConfigUpdateListener::UPDATED)));
+    updateFlow_.trigger_update();
     wait_for_main_executor();
 }
 

--- a/src/openlcb/ConfigUpdateFlow.hxx
+++ b/src/openlcb/ConfigUpdateFlow.hxx
@@ -85,7 +85,6 @@ public:
     {
         AtomicHolder h(this);
         nextRefresh_ = listeners_.begin();
-        isInitialLoad_ = 0;
         needsReboot_ = 0;
         needsReInit_ = 0;
         if (is_state(exit().next_state()))
@@ -97,20 +96,30 @@ public:
     void register_update_listener(ConfigUpdateListener *listener) OVERRIDE
     {
         AtomicHolder h(this);
-        listeners_.push_front(listener);
+        pendingListeners_.push_front(listener);
+        if (is_state(exit().next_state()))
+        {
+            start_flow(STATE(do_initial_load));
+        }
     }
 
     void unregister_update_listener(ConfigUpdateListener *listener) OVERRIDE
     {
         AtomicHolder h(this);
-        auto it = listeners_.begin();
-        while (it != listeners_.end() && it.operator->() != listener)
+        for (auto it = listeners_.begin(); it != listeners_.end(); ++it)
         {
-            ++it;
+            if (it.operator->() == listener)
+            {
+                listeners_.erase(it);
+            }
         }
-        if (it != listeners_.end())
+        for (auto it = pendingListeners_.begin(); it != pendingListeners_.end();
+             ++it)
         {
-            listeners_.erase(it);
+            if (it.operator->() == listener)
+            {
+                pendingListeners_.erase(it);
+            }
         }
         // We invalidated the iterators due to the erase.
         nextRefresh_ = listeners_.begin();
@@ -124,37 +133,28 @@ private:
             AtomicHolder h(this);
             if (nextRefresh_ == listeners_.end())
             {
-                /// TODO(balazs.racz) apply the changes reported.
-                if (needsReboot_) {
-#ifdef __FreeRTOS__
-                    reboot();
-#endif                    
-                }
-                if (needsReInit_) {
-                    // Takes over ownership of itself, will delete when done.
-                    new ReinitAllNodes(static_cast<If*>(service()));
-                }
-                return exit();
+                return call_immediately(STATE(do_initial_load));
             }
             l = nextRefresh_.operator->();
         }
+        ++nextRefresh_;
+        return call_listener(l, false);
+    }
+
+    Action call_listener(ConfigUpdateListener *l, bool is_initial)
+    {
         if (fd_ < 0)
         {
             DIE("CONFIG_FILENAME not specified, or init() was not called, but "
                 "there are configuration listeners.");
         }
         ConfigUpdateListener::UpdateAction action =
-            l->apply_configuration(fd_, isInitialLoad_, n_.reset(this));
+            l->apply_configuration(fd_, is_initial, n_.reset(this));
         switch (action)
         {
             case ConfigUpdateListener::UPDATED:
             {
                 break;
-            }
-            case ConfigUpdateListener::RETRY:
-            {
-                // Will call ourselves again.
-                return wait();
             }
             case ConfigUpdateListener::REINIT_NEEDED:
             {
@@ -167,18 +167,54 @@ private:
                 break;
             }
         }
-        ++nextRefresh_;
         return wait();
+    }
+
+    Action do_initial_load()
+    {
+        ConfigUpdateListener *l = nullptr;
+        {
+            AtomicHolder h(this);
+            if (!pendingListeners_.empty())
+            {
+                l = pendingListeners_.pop_front();
+                listeners_.push_front(l);
+            }
+        }
+        if (!l) {
+            return apply_action();
+        }
+        return call_listener(l, true);
+    }
+
+    Action apply_action()
+    {
+        /// TODO(balazs.racz) apply the changes reported.
+        if (needsReboot_)
+        {
+#ifdef __FreeRTOS__
+            reboot();
+#endif
+        }
+        if (needsReInit_)
+        {
+            // Takes over ownership of itself, will delete when done.
+            new ReinitAllNodes(static_cast<If *>(service()));
+        }
+        return exit();
     }
 
     typedef TypedQueue<ConfigUpdateListener> queue_type;
     /// All registered update listeners. Protected by Atomic *this.
     queue_type listeners_;
+    /// All listeners that have not yet been added to listeners_ and their
+    /// initial load needs to be called.
+    queue_type pendingListeners_;
     /// Where are we in the refresh cycle.
     typename queue_type::iterator nextRefresh_;
-    /// are we in initial load?
-    unsigned isInitialLoad_ : 1;
+    /// did anybody request a reboot to happen?
     unsigned needsReboot_ : 1;
+    /// did anybody request a node reinit to happen?
     unsigned needsReInit_ : 1;
     int fd_;
     BarrierNotifiable n_;

--- a/src/utils/ConfigUpdateListener.hxx
+++ b/src/utils/ConfigUpdateListener.hxx
@@ -57,8 +57,6 @@ public:
     {
         /// No additional step is necessary.
         UPDATED = 0,
-        /// The call needs to be re-tried.
-        RETRY,
         /// Need to perform application-level reinitialization. (In case of
         /// OpenLCB this means an identify all events procedure is needed.)
         REINIT_NEEDED,


### PR DESCRIPTION
Config Update Flow fixes:
- removes RETRY from the API, because it is not used anywhere.
- puts the newly registered listeners into a pending queue.
  Listeners move from the pending queue to the updated queue
  when the initial load call is done on them.
- automatically invokes initial load on newly registered components,
  even if that registration occurs at run time as opposed to static
  initialization time.
- stops keeping track of isInitialLoad.

This makes sure that when a new component is created from another component,
they will still get the correct initial load callback.