### PR TITLE
Fixes CC32xx SPI driver to avoid fifo overflow during polled tx-rx.

### DIFF
--- a/src/freertos_drivers/ti/CC32xxSPI.hxx
+++ b/src/freertos_drivers/ti/CC32xxSPI.hxx
@@ -174,8 +174,8 @@ private:
 
         do
         {
-            /* fill TX FIFO */
-            if (tx_len)
+            /* fill TX FIFO but make sure we don't fill it to overflow */
+            if (tx_len && (rx_len - tx_len < 32))
             {
                 if (data_put_non_blocking(*tx_buf) != 0)
                 {


### PR DESCRIPTION
This is a workaround.