### PR TITLE
Add search path to OPENOCDSCRIPTSPATH to handle a openocd "install" u…

### DIFF
--- a/etc/path.mk
+++ b/etc/path.mk
@@ -483,6 +483,7 @@ SEARCHPATH := \
   /opt/openocd/default/openocd/tcl \
   /opt/openocd/default/tcl \
   /opt/openocd/default/scripts \
+  /opt/openocd/default/share/openocd/scripts \
   /usr/local/share/openocd/scripts \
   /usr/share/openocd/scripts \
 


### PR DESCRIPTION
…nder /opt/openocd/default structured like a openocd "install" under /usr or /usr/local.

This is the fix needed to get openocd to be properly picked up when symlinking /opt/openocd/default to ~/.arduino15/packages/arduino/tools/openocd/0.9.0-arduino/ -- eg using the version of openocd installed under the Arduino IDE.  In the case of Raspbian, the Linux ARM hosted ARM tools that come with the Arduino IDE are newer than the ones available in the Raspbian repository.
