### PR TITLE
Adds 23017 expander to Nucleo IO boards

### DIFF
--- a/applications/nucleo_io/targets/freertos.armv6m.st-stm32f091rc-nucleo-dev-board/config.hxx
+++ b/applications/nucleo_io/targets/freertos.armv6m.st-stm32f091rc-nucleo-dev-board/config.hxx
@@ -29,6 +29,8 @@ extern const SimpleNodeStaticValues SNIP_STATIC_DATA = {
 #define NUM_OUTPUTS 16
 #define NUM_INPUTS 1
 
+#define NUM_EXTBOARDS 0
+
 /// Declares a repeated group of a given base group and number of repeats. The
 /// ProducerConfig and ConsumerConfig groups represent the configuration layout
 /// needed by the ConfiguredProducer and ConfiguredConsumer classes, and come

--- a/applications/nucleo_io/targets/freertos.armv7m.st-stm32f303re-nucleo-dev-board/config.hxx
+++ b/applications/nucleo_io/targets/freertos.armv7m.st-stm32f303re-nucleo-dev-board/config.hxx
@@ -1,9 +1,9 @@
 #ifndef _APPLICATIONS_IO_BOARD_TARGET_CONFIG_HXX_
 #define _APPLICATIONS_IO_BOARD_TARGET_CONFIG_HXX_
 
+#include "openlcb/ConfigRepresentation.hxx"
 #include "openlcb/ConfiguredConsumer.hxx"
 #include "openlcb/ConfiguredProducer.hxx"
-#include "openlcb/ConfigRepresentation.hxx"
 #include "openlcb/MemoryConfig.hxx"
 #include "openlcb/MultiConfiguredPC.hxx"
 
@@ -29,6 +29,7 @@ extern const SimpleNodeStaticValues SNIP_STATIC_DATA = {
 
 #define NUM_OUTPUTS 16
 #define NUM_INPUTS 1
+#define NUM_EXTBOARDS 1
 
 /// Declares a repeated group of a given base group and number of repeats. The
 /// ProducerConfig and ConsumerConfig groups represent the configuration layout
@@ -44,7 +45,6 @@ using PortABProducers = RepeatedGroup<ProducerConfig, 16>;
 using PulseConsumers = RepeatedGroup<PulseConsumerConfig, 12>;
 
 using Ext0PC = RepeatedGroup<PCConfig, 32>;
-
 
 /// Modify this value every time the EEPROM needs to be cleared on the node
 /// after an update.
@@ -67,7 +67,10 @@ CDI_GROUP_ENTRY(direct_consumers, DirectConsumers, Name("Tortoise/Hi-Power outpu
 CDI_GROUP_ENTRY(servo_consumers, DirectConsumers, Name("Servo Pin outputs"), Description("Temporary solution to test servo output pins."), RepName("Line"));
 CDI_GROUP_ENTRY(portde_consumers, PortDEConsumers, Name("Port D/E outputs"), Description("Line 1-8 is port D, Line 9-16 is port E"), RepName("Line"));
 CDI_GROUP_ENTRY(portab_producers, PortABProducers, Name("Port A/B inputs"), Description("Line 1-8 is port A, Line 9-16 is port B"), RepName("Line"));
-CDI_GROUP_ENTRY(ext0_pc, Ext0PC, Name("Expansion board 0 lines"), Description("Line 1-8 is port Even/A, Line 9-16 is port Even/B, Line 17-24 is Odd/A, Line 25-32 is Odd/B"), RepName("Line"));
+CDI_GROUP_ENTRY(ext0_pc, Ext0PC, Name("Expansion board 0 lines"),
+    Description("Line 1-8 is port Even/A, Line 9-16 is port Even/B, Line 17-24 "
+                "is Odd/A, Line 25-32 is Odd/B"),
+    RepName("Line"));
 CDI_GROUP_END();
 
 /// This segment is only needed temporarily until there is program code to set

--- a/applications/nucleo_io/targets/freertos.armv7m.st-stm32f303re-nucleo-dev-board/config.hxx
+++ b/applications/nucleo_io/targets/freertos.armv7m.st-stm32f303re-nucleo-dev-board/config.hxx
@@ -5,6 +5,7 @@
 #include "openlcb/ConfiguredProducer.hxx"
 #include "openlcb/ConfigRepresentation.hxx"
 #include "openlcb/MemoryConfig.hxx"
+#include "openlcb/MultiConfiguredPC.hxx"
 
 namespace openlcb
 {
@@ -42,9 +43,12 @@ using PortABProducers = RepeatedGroup<ProducerConfig, 16>;
 
 using PulseConsumers = RepeatedGroup<PulseConsumerConfig, 12>;
 
+using Ext0PC = RepeatedGroup<PCConfig, 32>;
+
+
 /// Modify this value every time the EEPROM needs to be cleared on the node
 /// after an update.
-static constexpr uint16_t CANONICAL_VERSION = 0x1422;
+static constexpr uint16_t CANONICAL_VERSION = 0x1427;
 
 CDI_GROUP(NucleoGroup, Name("Nucleo peripherals"), Description("These are physically located on the nucleo CPU daughterboard."));
 CDI_GROUP_ENTRY(green_led, ConsumerConfig, Name("Nucleo user LED"), Description("Green led (LD2)."));
@@ -63,6 +67,7 @@ CDI_GROUP_ENTRY(direct_consumers, DirectConsumers, Name("Tortoise/Hi-Power outpu
 CDI_GROUP_ENTRY(servo_consumers, DirectConsumers, Name("Servo Pin outputs"), Description("Temporary solution to test servo output pins."), RepName("Line"));
 CDI_GROUP_ENTRY(portde_consumers, PortDEConsumers, Name("Port D/E outputs"), Description("Line 1-8 is port D, Line 9-16 is port E"), RepName("Line"));
 CDI_GROUP_ENTRY(portab_producers, PortABProducers, Name("Port A/B inputs"), Description("Line 1-8 is port A, Line 9-16 is port B"), RepName("Line"));
+CDI_GROUP_ENTRY(ext0_pc, Ext0PC, Name("Expansion board 0 lines"), Description("Line 1-8 is port Even/A, Line 9-16 is port Even/B, Line 17-24 is Odd/A, Line 25-32 is Odd/B"), RepName("Line"));
 CDI_GROUP_END();
 
 /// This segment is only needed temporarily until there is program code to set

--- a/boards/st-stm32f303re-nucleo-dev-board/HwInit.cxx
+++ b/boards/st-stm32f303re-nucleo-dev-board/HwInit.cxx
@@ -131,11 +131,13 @@ void setblink(uint32_t pattern)
     resetblink(pattern);
 }
 
-void i2c1_ev_interrupt_handler(void) {
+void i2c1_ev_interrupt_handler(void)
+{
     i2c1.event_interrupt_handler();
 }
 
-void i2c1_er_interrupt_handler(void) {
+void i2c1_er_interrupt_handler(void)
+{
     i2c1.error_interrupt_handler();
 }
 

--- a/boards/st-stm32f303re-nucleo-dev-board/HwInit.cxx
+++ b/boards/st-stm32f303re-nucleo-dev-board/HwInit.cxx
@@ -63,7 +63,7 @@ static Stm32Uart uart0("/dev/ser0", USART2, USART2_IRQn);
 static Stm32Can can0("/dev/can0");
 
 /** EEPROM emulation driver. The file size might be made bigger. */
-static Stm32EEPROMEmulation eeprom0("/dev/eeprom", 1900);
+static Stm32EEPROMEmulation eeprom0("/dev/eeprom", 4000);
 
 /** UART 0 serial driver instance */
 static Stm32I2C i2c1("/dev/i2c0", I2C1, I2C1_EV_IRQn, I2C1_ER_IRQn);
@@ -71,7 +71,7 @@ static Stm32I2C i2c1("/dev/i2c0", I2C1, I2C1_EV_IRQn, I2C1_ER_IRQn);
 /** How many bytes of flash should hold the entire dataset. Must be an integer
  * multiple of the minimum erase length (which is the flash page length, for
  * the STM32F0 it is 2 kbytes). The file size maximum is half this value. */
-const size_t EEPROMEmulation::SECTOR_SIZE = 4096;
+const size_t EEPROMEmulation::SECTOR_SIZE = 8192;
 
 Stm32PWMGroup servo_timer(TIM3, (configCPU_CLOCK_HZ * 6 / 1000 + 65535) / 65536,
                           configCPU_CLOCK_HZ * 6 / 1000);

--- a/boards/st-stm32f303re-nucleo-dev-board/HwInit.cxx
+++ b/boards/st-stm32f303re-nucleo-dev-board/HwInit.cxx
@@ -42,6 +42,7 @@
 #include "Stm32Uart.hxx"
 #include "Stm32Can.hxx"
 #include "Stm32SPI.hxx"
+#include "Stm32I2C.hxx"
 #include "Stm32EEPROMEmulation.hxx"
 #include "Stm32PWM.hxx"
 #include "hardware.hxx"
@@ -63,6 +64,9 @@ static Stm32Can can0("/dev/can0");
 
 /** EEPROM emulation driver. The file size might be made bigger. */
 static Stm32EEPROMEmulation eeprom0("/dev/eeprom", 1900);
+
+/** UART 0 serial driver instance */
+static Stm32I2C i2c1("/dev/i2c0", I2C1, I2C1_EV_IRQn, I2C1_ER_IRQn);
 
 /** How many bytes of flash should hold the entire dataset. Must be an integer
  * multiple of the minimum erase length (which is the flash page length, for
@@ -127,6 +131,13 @@ void setblink(uint32_t pattern)
     resetblink(pattern);
 }
 
+void i2c1_ev_interrupt_handler(void) {
+    i2c1.event_interrupt_handler();
+}
+
+void i2c1_er_interrupt_handler(void) {
+    i2c1.error_interrupt_handler();
+}
 
 /// TIM17 shares this interrupt with certain features of timer1
 void tim1_trg_com_interrupt_handler(void)
@@ -285,8 +296,17 @@ void hw_preinit(void)
     HAL_GPIO_Init(GPIOB, &gpio_init);
     gpio_init.Pin = GPIO_PIN_13;
     HAL_GPIO_Init(GPIOB, &gpio_init);
-    
-    
+
+    /* I2C1 pinmux on PB6 (SCL), and PB7 (SDA) */
+    gpio_init.Mode = GPIO_MODE_AF_OD;
+    gpio_init.Pull = GPIO_NOPULL;
+    gpio_init.Speed = GPIO_SPEED_FREQ_LOW;
+    gpio_init.Alternate = GPIO_AF4_I2C1;
+    gpio_init.Pin = GPIO_PIN_6;
+    HAL_GPIO_Init(GPIOB, &gpio_init);
+    gpio_init.Pin = GPIO_PIN_7;
+    HAL_GPIO_Init(GPIOB, &gpio_init);
+
     GpioInit::hw_init();
 
     // Switches over servo timer pins to timer mode.

--- a/src/freertos_drivers/common/MCP23017Gpio.hxx
+++ b/src/freertos_drivers/common/MCP23017Gpio.hxx
@@ -1,0 +1,325 @@
+/** \copyright
+ * Copyright (c) 2018, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file Stm32I2C.hxx
+ *
+ * This file implements an I2C device driver layer on top of the STM32 Cube
+ * middleware.
+ *
+ * @author Balazs Racz
+ * @date 28 Oct 2018
+ */
+
+#ifndef _FREERTOS_DRIVERS_COMMON_MCP23017GPIO_HXX_
+#define _FREERTOS_DRIVERS_COMMON_MCP23017GPIO_HXX_
+
+#include <fcntl.h>
+#include <unistd.h>
+#include "i2c.h"
+#include "i2c-dev.h"
+
+#include "executor/Executor.hxx"
+
+class MCP23017 {
+public:
+    // 50 Hz polling
+    static constexpr long long POLLING_DELAY = MSEC_TO_NSEC(20);
+
+    /// Constructor
+    /// @param a2 address bit 2
+    /// @param a1 address bit 1
+    /// @param a0 address bit 0
+    MCP23017(ExecutorBase* executor, bool a2, bool a1, bool a0)
+        : executor_(executor) {
+        unsigned num = 0;
+        if (a2) {
+            num |= 0b100;
+        }
+        if (a1) {
+            num |= 0b010;
+        }
+        if (a0) {
+            num |= 0b001;
+        }
+        i2cAddress_ = BASE_ADDRESS | num;
+    }
+
+    /// Initializes the device.
+    /// @param i2c_path is the path to the device driver of the i2c port.
+    void init(const char* i2c_path) {
+        int fd = ::open(i2c_path, O_RDWR);
+        HASSERT(fd >= 0);
+        init(fd);
+    }
+
+    /// Initializes the device.
+    /// @param i2c_fd is the file descriptor of the i2c port to use.
+    void init(int i2c_fd)
+    {
+        fd_ = i2c_fd;
+
+        dir_[0] = dir_[1] = 0xff;
+        dirty_ = DIRTY_DIR;
+        update_out();
+        update_in();
+
+        timer_.start(POLLING_DELAY);
+    }
+
+    enum {
+        PORTA = 0,
+        PORTB = 1,
+    };
+
+private:
+    DISALLOW_COPY_AND_ASSIGN(MCP23017);
+
+    friend class MCP23017Gpio;
+
+    enum Registers {
+        IODIRA = 0x0,
+        IODIRB = 0x1,
+        IPOLA = 0x2,
+        IPOLB = 0x3,
+        GPINTENA = 0x4,
+        GPINTENB = 0x5,
+        DEFVALA = 0x6,
+        DEFVALB = 0x7,
+        INTCONA = 0x8,
+        INTCONB = 0x9,
+        IOCON = 0xA,
+        GPPUA = 0xC,
+        GPPUB = 0xD,
+        INTFA = 0xE,
+        INTFB = 0xF,
+        INTCAPA = 0x10,
+        INTCAPB = 0x11,
+        RGPIOA = 0x12,
+        RGPIOB = 0x13,
+        OLATA = 0x14,
+        OLATB = 0x15
+    };
+
+    enum {
+        /// I2C address of the first device.
+        BASE_ADDRESS = 0b0100000,
+
+        DIRTY_DIR = 1,
+        DIRTY_LAT = 2,
+    };
+
+    /// Updates the output direction and latch registers if any of it is dirty.
+    void update_out()
+    {
+        if (dirty_ & DIRTY_DIR)
+        {
+            dirty_ &= ~DIRTY_DIR;
+            register_write(IODIRA, dir_, 2);
+        }
+        if (dirty_ & DIRTY_LAT)
+        {
+            dirty_ &= ~DIRTY_LAT;
+            register_write(OLATA, lat_, 2);
+        }
+    }
+
+    /// Updates input registers.
+    void update_in()
+    {
+        register_read(RGPIOA, gpio_, 2);
+    }
+
+    /// Writes one or more (sequential) registers in the MCP23017.
+    /// @param reg starting register offset.
+    /// @param data payload to write
+    /// @param len number of bytes to write.
+    /// Returns when the write is complete.
+    void register_write(uint8_t reg, const uint8_t* data, uint16_t len) {
+        uint8_t dat[3];
+        dat[0] = reg;
+        dat[1] = data[0];
+        if (len > 1) {
+            dat[2] = data[1];
+        }
+        HASSERT(len <= 2);
+        struct i2c_msg msgs[] =
+        {
+            {
+                .addr = i2cAddress_,
+                .flags = 0,
+                .len = (uint16_t)(len + 1),
+                .buf = dat
+            }
+        };
+
+        struct i2c_rdwr_ioctl_data ioctl_data =
+            {.msgs = msgs, .nmsgs = ARRAYSIZE(msgs)};
+
+        ::ioctl(fd_, I2C_RDWR, &ioctl_data);
+    }
+
+    /// Reads one or more (sequential) registers in the MCP23017.
+    /// @param reg starting register offset.
+    /// @param data where to write payload
+    /// @param len number of registers to read.
+    /// Returns when the read is complete.
+    void register_read(uint8_t reg, uint8_t* data, uint16_t len) {
+        struct i2c_msg msgs[] =
+        {
+            {
+                .addr = i2cAddress_,
+                .flags = 0,
+                .len = 1,
+                .buf = &reg
+            },
+            {
+                .addr = i2cAddress_,
+                .flags = I2C_M_RD,
+                .len = len,
+                .buf = data
+            }
+        };
+
+        struct i2c_rdwr_ioctl_data ioctl_data =
+            {.msgs = msgs, .nmsgs = ARRAYSIZE(msgs)};
+
+        ::ioctl(fd_, I2C_RDWR, &ioctl_data);
+    }
+
+    class RefreshTimer : public ::Timer {
+    public:
+        RefreshTimer(MCP23017 *parent)
+            : ::Timer(parent->executor_->active_timers())
+            , parent_(parent)
+        {
+        }
+
+        long long timeout() override
+        {
+            parent_->update_out();
+            parent_->update_in();
+            return RESTART;
+        };
+
+    private:
+        MCP23017* parent_;
+    };
+
+    /// Executor. We will be blocking this for the I2C IO.
+    ExecutorBase* executor_;
+    /// Timer instance to schedule work on the executor.
+    RefreshTimer timer_{this};
+    /// I2C port file descriptor.
+    int fd_;
+    /// Address of this particular device on the I2C port.
+    uint8_t i2cAddress_;
+
+    /// Bit mask of registers that need updating.
+    uint8_t dirty_ = 0;
+
+    /// Shadow of the direction registers.
+    uint8_t dir_[2];
+    /// Shadow of the input registers.
+    uint8_t gpio_[2];
+    /// Shadow of the latch registers.
+    uint8_t lat_[2];
+};
+
+
+class MCP23017Gpio : public Gpio {
+public:
+    constexpr MCP23017Gpio(MCP23017 *const parent, unsigned port, unsigned pin)
+        : parent_(parent)
+        , port_(port)
+        , pinBit_(1 << pin)
+    {
+    }
+
+    void set() const override {
+        write(HIGH);
+    }
+
+    void clr() const override {
+        write(LOW);
+    }
+
+    void write(Value new_state) const override
+    {
+        bool old_state = !!(parent_->lat_[port_] & pinBit_);
+        if (new_state != old_state)
+        {
+            if (new_state)
+            {
+                parent_->lat_[port_] |= pinBit_;
+            }
+            else
+            {
+                parent_->lat_[port_] &= ~pinBit_;
+            }
+            parent_->dirty_ |= parent_->DIRTY_LAT;
+        }
+    }
+
+    Value read() const override
+    {
+        return (parent_->gpio_[port_] & pinBit_) ? HIGH : LOW;
+    }
+
+    void set_direction(Direction dir) const override
+    {
+        uint8_t desired = (dir == Direction::OUTPUT) ? 0 : pinBit_;
+        if (desired != ((parent_->dir_[port_] & pinBit_)))
+        {
+            parent_->dir_[port_] =
+                (parent_->dir_[port_] & (~pinBit_)) | desired;
+            parent_->dirty_ |= parent_->DIRTY_DIR;
+        }
+    }
+
+    Direction direction() const override
+    {
+        if (parent_->dir_[port_] & pinBit_)
+        {
+            return Direction::INPUT;
+        }
+        else
+        {
+            return Direction::OUTPUT;
+        }
+    }
+
+private:
+    DISALLOW_COPY_AND_ASSIGN(MCP23017Gpio);
+
+    MCP23017* const parent_;
+    /// 0 or 1 for portA/B
+    const uint8_t port_;
+    /// one bit that denotes the output pin.
+    const uint8_t pinBit_;
+};
+
+
+#endif // _FREERTOS_DRIVERS_COMMON_MCP23017GPIO_HXX_

--- a/src/freertos_drivers/st/Stm32I2C.cxx
+++ b/src/freertos_drivers/st/Stm32I2C.cxx
@@ -1,0 +1,263 @@
+/** \copyright
+ * Copyright (c) 2018, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file Stm32I2C.cxx
+ *
+ * This file implements an I2C device driver layer on top of the STM32 Cube
+ * middleware.
+ *
+ * @author Balazs Racz
+ * @date 28 Oct 2018
+ */
+
+#include "Stm32I2C.hxx"
+
+// @todo need adjust to F0 F1 etc.
+#include "stm32f3xx_ll_rcc.h"
+
+// Enables the clock and resets the I2C peripheral.
+static void i2c_reset(I2C_TypeDef *port)
+{
+    switch ((unsigned)port)
+    {
+        default:
+            DIE("Unknown I2C port requested.");
+#ifdef I2C1
+        case I2C1_BASE:
+            LL_RCC_SetI2CClockSource(LL_RCC_I2C1_CLKSOURCE_SYSCLK);
+            __HAL_RCC_I2C1_CLK_ENABLE();
+            __HAL_RCC_I2C1_FORCE_RESET();
+            __HAL_RCC_I2C1_RELEASE_RESET();
+            break;
+#endif
+#ifdef I2C2
+        case I2C2_BASE:
+            LL_RCC_SetI2CClockSource(LL_RCC_I2C2_CLKSOURCE_SYSCLK);
+            __HAL_RCC_I2C2_CLK_ENABLE();
+            __HAL_RCC_I2C2_FORCE_RESET();
+            __HAL_RCC_I2C2_RELEASE_RESET();
+            break;
+#endif
+#ifdef I2C3
+        case I2C3_BASE:
+            LL_RCC_SetI2CClockSource(LL_RCC_I2C3_CLKSOURCE_SYSCLK);
+            __HAL_RCC_I2C3_CLK_ENABLE();
+            __HAL_RCC_I2C3_FORCE_RESET();
+            __HAL_RCC_I2C3_RELEASE_RESET();
+            break;
+#endif
+#ifdef I2C4
+        case I2C4_BASE:
+            __HAL_RCC_I2C4_CONFIG(RCC_I2C4CLKSOURCE_SYSCLK);
+            __HAL_RCC_I2C4_CLK_ENABLE();
+            __HAL_RCC_I2C4_FORCE_RESET();
+            __HAL_RCC_I2C4_RELEASE_RESET();
+            break;
+#endif
+#ifdef I2C5
+        case I2C5_BASE:
+            __HAL_RCC_I2C5_CONFIG(RCC_I2C5CLKSOURCE_SYSCLK);
+            __HAL_RCC_I2C5_CLK_ENABLE();
+            __HAL_RCC_I2C5_FORCE_RESET();
+            __HAL_RCC_I2C5_RELEASE_RESET();
+            break;
+#endif
+#ifdef I2C6
+        case I2C6_BASE:
+            __HAL_RCC_I2C6_CONFIG(RCC_I2C6CLKSOURCE_SYSCLK);
+            __HAL_RCC_I2C6_CLK_ENABLE();
+            __HAL_RCC_I2C6_FORCE_RESET();
+            __HAL_RCC_I2C6_RELEASE_RESET();
+            break;
+#endif
+#ifdef I2C7
+        case I2C7_BASE:
+            __HAL_RCC_I2C7_CONFIG(RCC_I2C7CLKSOURCE_SYSCLK);
+            __HAL_RCC_I2C7_CLK_ENABLE();
+            __HAL_RCC_I2C7_FORCE_RESET();
+            __HAL_RCC_I2C7_RELEASE_RESET();
+            break;
+#endif
+#ifdef I2C8
+        case I2C8_BASE:
+            __HAL_RCC_I2C8_CONFIG(RCC_I2C8CLKSOURCE_SYSCLK);
+            __HAL_RCC_I2C8_CLK_ENABLE();
+            __HAL_RCC_I2C8_FORCE_RESET();
+            __HAL_RCC_I2C8_RELEASE_RESET();
+            break;
+#endif
+    }
+}
+
+// This timing is assuming 72 MHz main clock, the I2C module being clocked from
+// the main clock, and gives 400 kHz clock (fast mode).
+#define I2C_TIMING      (__LL_I2C_CONVERT_TIMINGS(8, 0x3, 0x3, 0x3, 0x9))
+
+/** Constructor.
+ * @param name name of this device instance in the file system
+ * @param port hardware instance of this device, e.g. I2C1
+ * @param ev_interrupt event interrupt vector number
+ * @param er_interrupt error interrupt vector number
+ */
+Stm32I2C::Stm32I2C(const char *name, I2C_TypeDef *port, uint32_t ev_interrupt,
+    uint32_t er_interrupt)
+    : I2C(name)
+{
+    i2c_reset(port);
+    memset(&i2cHandle_, 0, sizeof(i2cHandle_));
+
+    i2cHandle_.Instance = port;
+
+    i2cHandle_.Init.Timing = I2C_TIMING;
+    i2cHandle_.Init.OwnAddress1 = 0;
+    i2cHandle_.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
+    i2cHandle_.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+    i2cHandle_.Init.OwnAddress2 = 0xFF;
+    i2cHandle_.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+    i2cHandle_.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
+
+    HASSERT(HAL_I2C_Init(&i2cHandle_) == HAL_OK);
+
+    /* Enable the Analog I2C Filter */
+    HAL_I2CEx_ConfigAnalogFilter(&i2cHandle_, I2C_ANALOGFILTER_ENABLE);
+
+    // We save the object pointer in order to get back to *this in the callback
+    // routines. This field of the Init structure is not used after the Init
+    // call above.
+    i2cHandle_.Init.Timing = (uint32_t)this;
+
+    NVIC_SetPriority((IRQn_Type)ev_interrupt, configKERNEL_INTERRUPT_PRIORITY);
+    HAL_NVIC_EnableIRQ((IRQn_Type)ev_interrupt);
+    NVIC_SetPriority((IRQn_Type)er_interrupt, configKERNEL_INTERRUPT_PRIORITY);
+    HAL_NVIC_EnableIRQ((IRQn_Type)er_interrupt);
+    //HASSERT(update_configuration() == 0);
+}
+
+int Stm32I2C::transfer(struct i2c_msg *msg, bool stop)
+{
+    int bytes = msg->len;
+    // The slave address is set with an 8-bit value where bit 0 (R/nW) is
+    // ignored. We shift the address left for this reason.
+
+    // We kill the previous state information because we don't want the driver
+    // to optimize away the restart condition.
+    i2cHandle_.PreviousState = 0;
+    error_ = 0;
+
+    if (msg->flags & I2C_M_RD)
+    {
+        /* this is a read transfer */
+        uint32_t xfer_options;
+        if (stop)
+        {
+            xfer_options = I2C_FIRST_AND_LAST_FRAME;
+        } else {
+            xfer_options = I2C_FIRST_FRAME;
+        }
+
+        if (HAL_I2C_Master_Sequential_Receive_IT(&i2cHandle_,
+                (uint16_t)msg->addr << 1, (uint8_t *)msg->buf, bytes,
+                xfer_options) != HAL_OK)
+        {
+            return -EIO;
+        }
+    }
+    else
+    {
+        /* this is a write transfer */
+        uint32_t xfer_options;
+        if (stop)
+        {
+            xfer_options = I2C_FIRST_AND_LAST_FRAME;
+        } else {
+            xfer_options = I2C_FIRST_FRAME;
+        }
+        if (HAL_I2C_Master_Sequential_Transmit_IT(&i2cHandle_,
+                (uint16_t)msg->addr << 1, (uint8_t *)msg->buf, bytes,
+                xfer_options) != HAL_OK)
+        {
+            return -EIO;
+        }
+    }
+
+    sem.wait();
+
+    return error_ < 0 ? error_ : bytes;
+}
+
+
+Stm32I2C* dev_from_handle(I2C_HandleTypeDef *hi2c) {
+    return (Stm32I2C*)hi2c->Init.Timing;
+}
+
+void Stm32I2C::complete_from_isr() {
+    int woken = 0;
+    sem.post_from_isr(&woken);
+    os_isr_exit_yield_test(woken);
+}
+
+void Stm32I2C::error_from_isr() {
+    auto error = i2cHandle_.ErrorCode;
+
+    if (error & HAL_I2C_ERROR_ARLO)
+    {
+        error_ = -EAGAIN;
+    }
+    else if (error & HAL_I2C_ERROR_AF)
+    {
+        error_ = -ENOENT;
+    }
+    else if (error & HAL_I2C_ERROR_TIMEOUT)
+    {
+        error_ = -ETIMEDOUT;
+    }
+    else
+    {
+        error_ = -EIO;
+    }
+
+    complete_from_isr();
+}
+
+// =============== Callbacks from driver ===============
+
+extern "C" {
+
+void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c) {
+    dev_from_handle(hi2c)->complete_from_isr();
+}
+
+void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c) {
+    dev_from_handle(hi2c)->complete_from_isr();
+}
+
+void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c)
+{
+    dev_from_handle(hi2c)->error_from_isr();
+}
+
+
+}

--- a/src/freertos_drivers/st/Stm32I2C.cxx
+++ b/src/freertos_drivers/st/Stm32I2C.cxx
@@ -114,7 +114,7 @@ static void i2c_reset(I2C_TypeDef *port)
 
 // This timing is assuming 72 MHz main clock, the I2C module being clocked from
 // the main clock, and gives 400 kHz clock (fast mode).
-#define I2C_TIMING      (__LL_I2C_CONVERT_TIMINGS(8, 0x3, 0x3, 0x3, 0x9))
+#define I2C_TIMING (__LL_I2C_CONVERT_TIMINGS(8, 0x3, 0x3, 0x3, 0x9))
 
 /** Constructor.
  * @param name name of this device instance in the file system
@@ -147,13 +147,12 @@ Stm32I2C::Stm32I2C(const char *name, I2C_TypeDef *port, uint32_t ev_interrupt,
     // We save the object pointer in order to get back to *this in the callback
     // routines. This field of the Init structure is not used after the Init
     // call above.
-    i2cHandle_.Init.Timing = (uint32_t)this;
+    i2cHandle_.Init.Timing = (uint32_t) this;
 
     NVIC_SetPriority((IRQn_Type)ev_interrupt, configKERNEL_INTERRUPT_PRIORITY);
     HAL_NVIC_EnableIRQ((IRQn_Type)ev_interrupt);
     NVIC_SetPriority((IRQn_Type)er_interrupt, configKERNEL_INTERRUPT_PRIORITY);
     HAL_NVIC_EnableIRQ((IRQn_Type)er_interrupt);
-    //HASSERT(update_configuration() == 0);
 }
 
 int Stm32I2C::transfer(struct i2c_msg *msg, bool stop)
@@ -174,7 +173,9 @@ int Stm32I2C::transfer(struct i2c_msg *msg, bool stop)
         if (stop)
         {
             xfer_options = I2C_FIRST_AND_LAST_FRAME;
-        } else {
+        }
+        else
+        {
             xfer_options = I2C_FIRST_FRAME;
         }
 
@@ -192,7 +193,9 @@ int Stm32I2C::transfer(struct i2c_msg *msg, bool stop)
         if (stop)
         {
             xfer_options = I2C_FIRST_AND_LAST_FRAME;
-        } else {
+        }
+        else
+        {
             xfer_options = I2C_FIRST_FRAME;
         }
         if (HAL_I2C_Master_Sequential_Transmit_IT(&i2cHandle_,
@@ -208,18 +211,20 @@ int Stm32I2C::transfer(struct i2c_msg *msg, bool stop)
     return error_ < 0 ? error_ : bytes;
 }
 
-
-Stm32I2C* dev_from_handle(I2C_HandleTypeDef *hi2c) {
-    return (Stm32I2C*)hi2c->Init.Timing;
+Stm32I2C *dev_from_handle(I2C_HandleTypeDef *hi2c)
+{
+    return (Stm32I2C *)hi2c->Init.Timing;
 }
 
-void Stm32I2C::complete_from_isr() {
+void Stm32I2C::complete_from_isr()
+{
     int woken = 0;
     sem.post_from_isr(&woken);
     os_isr_exit_yield_test(woken);
 }
 
-void Stm32I2C::error_from_isr() {
+void Stm32I2C::error_from_isr()
+{
     auto error = i2cHandle_.ErrorCode;
 
     if (error & HAL_I2C_ERROR_ARLO)
@@ -246,11 +251,13 @@ void Stm32I2C::error_from_isr() {
 
 extern "C" {
 
-void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c) {
+void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
     dev_from_handle(hi2c)->complete_from_isr();
 }
 
-void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c) {
+void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
     dev_from_handle(hi2c)->complete_from_isr();
 }
 
@@ -258,6 +265,4 @@ void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c)
 {
     dev_from_handle(hi2c)->error_from_isr();
 }
-
-
 }

--- a/src/freertos_drivers/st/Stm32I2C.hxx
+++ b/src/freertos_drivers/st/Stm32I2C.hxx
@@ -36,9 +36,7 @@
 #ifndef _FREERTOS_DRIVERS_ST_STM32I2C_HXX_
 #define _FREERTOS_DRIVERS_ST_STM32I2C_HXX_
 
-
 #include "I2C.hxx"
-
 
 #if defined(STM32F072xB) || defined(STM32F091xC)
 #include "stm32f0xx_hal_conf.h"
@@ -49,7 +47,6 @@
 #else
 #error Dont know what STM32 chip you have.
 #endif
-
 
 /** Specialization of I2C driver for STM32 devices.
  */
@@ -62,7 +59,8 @@ public:
      * @param ev_interrupt event interrupt vector number
      * @param er_interrupt error interrupt vector number
      */
-    Stm32I2C(const char *name, I2C_TypeDef *port, uint32_t ev_interrupt, uint32_t er_interrupt);
+    Stm32I2C(const char *name, I2C_TypeDef *port, uint32_t ev_interrupt,
+        uint32_t er_interrupt);
 
     /** Destructor.
      */
@@ -71,12 +69,14 @@ public:
     }
 
     /// Call this function from the specific i2c interrupt routine in HwInit.
-    void event_interrupt_handler() {
+    void event_interrupt_handler()
+    {
         HAL_I2C_EV_IRQHandler(&i2cHandle_);
     }
 
     /// Call this function from the specific i2c interrupt routine in HwInit.
-    void error_interrupt_handler() {
+    void error_interrupt_handler()
+    {
         HAL_I2C_ER_IRQHandler(&i2cHandle_);
     }
 
@@ -109,7 +109,5 @@ private:
 
     DISALLOW_COPY_AND_ASSIGN(Stm32I2C);
 };
-
-
 
 #endif // _FREERTOS_DRIVERS_ST_STM32I2C_HXX_

--- a/src/freertos_drivers/st/Stm32I2C.hxx
+++ b/src/freertos_drivers/st/Stm32I2C.hxx
@@ -1,0 +1,115 @@
+/** \copyright
+ * Copyright (c) 2018, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file Stm32I2C.hxx
+ *
+ * This file implements an I2C device driver layer on top of the STM32 Cube
+ * middleware.
+ *
+ * @author Balazs Racz
+ * @date 28 Oct 2018
+ */
+
+#ifndef _FREERTOS_DRIVERS_ST_STM32I2C_HXX_
+#define _FREERTOS_DRIVERS_ST_STM32I2C_HXX_
+
+
+#include "I2C.hxx"
+
+
+#if defined(STM32F072xB) || defined(STM32F091xC)
+#include "stm32f0xx_hal_conf.h"
+#elif defined(STM32F103xB)
+#include "stm32f1xx_hal_conf.h"
+#elif defined(STM32F303xC) || defined(STM32F303xE)
+#include "stm32f3xx_hal_conf.h"
+#else
+#error Dont know what STM32 chip you have.
+#endif
+
+
+/** Specialization of I2C driver for STM32 devices.
+ */
+class Stm32I2C : public I2C
+{
+public:
+    /** Constructor.
+     * @param name name of this device instance in the file system
+     * @param port hardware instance of this device, e.g. I2C1
+     * @param ev_interrupt event interrupt vector number
+     * @param er_interrupt error interrupt vector number
+     */
+    Stm32I2C(const char *name, I2C_TypeDef *port, uint32_t ev_interrupt, uint32_t er_interrupt);
+
+    /** Destructor.
+     */
+    ~Stm32I2C()
+    {
+    }
+
+    /// Call this function from the specific i2c interrupt routine in HwInit.
+    void event_interrupt_handler() {
+        HAL_I2C_EV_IRQHandler(&i2cHandle_);
+    }
+
+    /// Call this function from the specific i2c interrupt routine in HwInit.
+    void error_interrupt_handler() {
+        HAL_I2C_ER_IRQHandler(&i2cHandle_);
+    }
+
+    /// Internal. This function is called from the complete ISR callback.
+    inline void complete_from_isr();
+    /// Internal. This function is called from the error ISR callback.
+    inline void error_from_isr();
+
+private:
+    void enable() override {} /**< function to enable device */
+    void disable() override {} /**< function to disable device */
+
+    /** Method to transmit/receive the data.
+     * @param msg message to transact.
+     * @param stop produce a stop condition at the end of the transfer
+     * @return bytes transfered upon success, -errno upon failure
+     */
+    int transfer(struct i2c_msg *msg, bool stop) override;
+
+    /// Stm32 HAL device structure.
+    I2C_HandleTypeDef i2cHandle_;
+    /// Pending transfer error field.
+    int error_;
+    /// Semaphore to wakeup task level from ISR
+    OSSem sem;
+
+    /** Default constructor.
+     */
+    Stm32I2C();
+
+    DISALLOW_COPY_AND_ASSIGN(Stm32I2C);
+};
+
+
+
+#endif // _FREERTOS_DRIVERS_ST_STM32I2C_HXX_

--- a/src/freertos_drivers/st/stm32f3xx_hal_conf.h
+++ b/src/freertos_drivers/st/stm32f3xx_hal_conf.h
@@ -288,6 +288,7 @@
 
 #ifdef HAL_I2C_MODULE_ENABLED
  #include "stm32f3xx_hal_i2c.h"
+ #include "stm32f3xx_ll_i2c.h"
 #endif /* HAL_I2C_MODULE_ENABLED */
 
 #ifdef HAL_I2S_MODULE_ENABLED

--- a/src/openlcb/MultiConfiguredPC.hxx
+++ b/src/openlcb/MultiConfiguredPC.hxx
@@ -36,11 +36,12 @@
 #ifndef _OPENLCB_MULTICONFIGUREDPC_HXX_
 #define _OPENLCB_MULTICONFIGUREDPC_HXX_
 
-#include "openlcb/EventHandlerTemplates.hxx"
 #include "openlcb/ConfigRepresentation.hxx"
+#include "openlcb/EventHandlerTemplates.hxx"
+#include "openlcb/RefreshLoop.hxx"
 #include "utils/ConfigUpdateListener.hxx"
 #include "utils/ConfigUpdateService.hxx"
-#include "openlcb/RefreshLoop.hxx"
+#include "utils/format_utils.hxx"
 
 namespace openlcb
 {
@@ -49,38 +50,13 @@ static const char PC_ACTION_MAP[] =
     "<relation><property>0</property><value>Output</value></relation>"
     "<relation><property>1</property><value>Input</value></relation>";
 
-/// CDI Configuration for a @ref ConfiguredConsumer.
-CDI_GROUP(PCConfig);
+CDI_GROUP(PCLineConfig);
 /// Allows the user to assign a name for this output.
 CDI_GROUP_ENTRY(description, StringConfigEntry<20>, //
-                Name("Description"), Description("User name of this output."));
-
-enum class ActionConfig : public uint8_t {
-    OUTPUT = 0,
-    INPUT = 1
-};
-
-CDI_GROUP_ENTRY(action, Uint8ConfigEntry, Default(1), MapValues(PC_ACTION_MAP), Name("Configuration"), MinValue(0), MaxValue(1));
-
-/// Configures the debounce parameter.
-CDI_GROUP_ENTRY(
-    debounce, Uint8ConfigEntry, Name("Debounce parameter"),
-    Default(3),
-    Description("Used for inputs only. Amount of time to wait for the input to stabilize before "
-                "producing the event. Unit is 30 msec of time. Usually a value "
-                "of 2-3 works well in a non-noisy environment. In high noise "
-                "(train wheels for example) a setting between 8 -- 15 makes "
-                "for a slower response time but a more stable "
-                "signal.\nFormally, the parameter tells how many times of "
-                "tries, each 30 msec apart, the input must have the same value "
-                "in order for that value to be accepted and the event "
-                "transition produced."),
-    Default(3));
-
+    Name("Description"), Description("User name of this line."));
 
 /// Specifies the event ID to set the output to ON.
 CDI_GROUP_ENTRY(event_on, EventConfigEntry, //
-    Offset(1), //  We save a byte to spare here for pulse outputs.
     Name("Event On"),
     Description("This event ID will turn the output on / be produced when the "
                 "input goes on."));
@@ -91,13 +67,46 @@ CDI_GROUP_ENTRY(event_off, EventConfigEntry, //
                 "input goes off."));
 CDI_GROUP_END();
 
+/// CDI Configuration for a @ref ConfiguredConsumer.
+CDI_GROUP(PCConfig);
+enum class ActionConfig : uint8_t
+{
+    OUTPUT = 0,
+    INPUT = 1
+};
 
+CDI_GROUP_ENTRY(action, Uint8ConfigEntry, Default(1), MapValues(PC_ACTION_MAP),
+    Name("Configuration"));
+
+/// Configures the debounce parameter.
+CDI_GROUP_ENTRY(debounce, Uint8ConfigEntry, Name("Debounce parameter"),
+    Default(3),
+    Description("Used for inputs only. Amount of time to wait for the input to "
+                "stabilize before "
+                "producing the event. Unit is 30 msec of time. Usually a value "
+                "of 2-3 works well in a non-noisy environment. In high noise "
+                "(train wheels for example) a setting between 8 -- 15 makes "
+                "for a slower response time but a more stable "
+                "signal.\nFormally, the parameter tells how many times of "
+                "tries, each 30 msec apart, the input must have the same value "
+                "in order for that value to be accepted and the event "
+                "transition produced."),
+    Default(3));
+
+CDI_GROUP_ENTRY(unused, EmptyGroup<1>);
+// We factor out the description, and event on/off to a separate group to give
+// JMRI a chance to render the make turnout/make sensor buttons.
+CDI_GROUP_ENTRY(pc, PCLineConfig);
+CDI_GROUP_END();
 
 class MultiConfiguredPC : public ConfigUpdateListener,
-                          private SimpleEventHandler
+                          private SimpleEventHandler,
+                          private Polling,
+                          private Notifiable
 {
 public:
     typedef PCConfig config_entry_type;
+    typedef QuiesceDebouncer debouncer_type;
 
     /// Usage: ```
     ///
@@ -106,7 +115,7 @@ public:
     /// TDRV3_Pin::instance(), TDRV4_Pin::instance(),
     /// };
     /// openlcb::MultiConfiguredPC direct_pc(stack.node(),
-    ///    kDirectGpio, ARRAYSIZE(kDirectGpio), cfg.seg().direct_consumers());
+    ///    kDirectGpio, ARRAYSIZE(kDirectGpio), cfg.seg().direct_pc());
     /// ```
     ///
     /// @param node is the OpenLCB node object from the stack.
@@ -116,8 +125,8 @@ public:
     /// @param config is the repeated group object from the configuration space
     /// that represents the locations of the events.
     template <unsigned N>
-    __attribute__((noinline)) MultiConfiguredPC(Node *node,
-        const Gpio *const *pins, unsigned size,
+    __attribute__((noinline))
+    MultiConfiguredPC(Node *node, const Gpio *const *pins, unsigned size,
         const RepeatedGroup<config_entry_type, N> &config)
         : node_(node)
         , pins_(pins)
@@ -128,17 +137,69 @@ public:
         HASSERT(size == N);
         ConfigUpdateService::instance()->register_update_listener(this);
         producedEvents_ = new EventId[size * 2];
+        std::allocator<debouncer_type> alloc;
+        debouncers_ = alloc.allocate(size_);
+        for (unsigned i = 0; i < size_; ++i)
+        {
+            alloc.construct(debouncers_ + i, 3);
+        }
     }
 
     ~MultiConfiguredPC()
     {
         do_unregister();
         ConfigUpdateService::instance()->unregister_update_listener(this);
-        delete [] producedEvents_;
+        delete[] producedEvents_;
+        std::allocator<debouncer_type> alloc;
+        for (unsigned i = 0; i < size_; ++i)
+        {
+            alloc.destroy(debouncers_ + i);
+        }
+        alloc.deallocate(debouncers_, size_);
     }
 
-    UpdateAction apply_configuration(int fd, bool initial_load,
-                                     BarrierNotifiable *done) OVERRIDE
+    /// @return the instance to give to the RefreshLoop object.
+    Polling *polling()
+    {
+        return this;
+    }
+
+    /// Call from the refresh loop.
+    void poll_33hz(WriteHelper *helper, Notifiable *done) override
+    {
+        nextPinToPoll_ = 0;
+        pollingHelper_ = helper;
+        pollingDone_ = done;
+        this->notify();
+    }
+
+    /// Asynchronous callback when the previous polling message has left via
+    /// the bus. Used as a poor man's iterative state machine.
+    void notify() override
+    {
+        for (; nextPinToPoll_ < size_; ++nextPinToPoll_)
+        {
+            auto i = nextPinToPoll_;
+            if (pins_[i]->direction() == Gpio::Direction::OUTPUT)
+            {
+                continue;
+            }
+            if (debouncers_[i].update_state(pins_[i]->is_set()))
+            {
+                // Pin flipped.
+                ++nextPinToPoll_; // avoid infinite loop.
+                auto event = producedEvents_[2 * i +
+                    (debouncers_[i].current_state() ? 1 : 0)];
+                pollingHelper_->WriteAsync(node_, Defs::MTI_EVENT_REPORT,
+                    WriteHelper::global(), eventid_to_buffer(event), this);
+                return;
+            }
+        }
+        pollingDone_->notify();
+    }
+
+    UpdateAction apply_configuration(
+        int fd, bool initial_load, BarrierNotifiable *done) OVERRIDE
     {
         AutoNotify n(done);
 
@@ -155,20 +216,28 @@ public:
         for (unsigned i = 0; i < size_; ++i)
         {
             const config_entry_type cfg_ref(grp_ref.entry(i));
-            uint8_t action = cfg_ref.action().read(fd);
-            if (action == PCConfig::ActionConfig::OUTPUT) {
-                pins_[i]->set_direction(Gpio::Direction::OUTPUT);
-            } else {
-                pins_[i]->set_direction(Gpio::Direction::INPUT);
-            }
-            EventId cfg_event_on = cfg_ref.event_on().read(fd);
-            EventId cfg_event_off = cfg_ref.event_off().read(fd);
+            EventId cfg_event_on = cfg_ref.pc().event_on().read(fd);
+            EventId cfg_event_off = cfg_ref.pc().event_off().read(fd);
             EventRegistry::instance()->register_handler(
                 EventRegistryEntry(this, cfg_event_off, i * 2), 0);
-            producedEvents_[i * 2] = cfg_event_off;
             EventRegistry::instance()->register_handler(
                 EventRegistryEntry(this, cfg_event_on, i * 2 + 1), 0);
-            producedEvents_[i * 2 + 1] = cfg_event_on;
+            uint8_t action = cfg_ref.action().read(fd);
+            if (action == (uint8_t)PCConfig::ActionConfig::OUTPUT)
+            {
+                pins_[i]->set_direction(Gpio::Direction::OUTPUT);
+                producedEvents_[i * 2] = 0;
+                producedEvents_[i * 2 + 1] = 0;
+            }
+            else
+            {
+                uint8_t param = cfg_ref.debounce().read(fd);
+                pins_[i]->set_direction(Gpio::Direction::INPUT);
+                debouncers_[i].reset_options(param);
+                debouncers_[i].initialize(pins_[i]->read());
+                producedEvents_[i * 2] = cfg_event_off;
+                producedEvents_[i * 2 + 1] = cfg_event_on;
+            }
         }
         return REINIT_NEEDED; // Causes events identify.
     }
@@ -178,8 +247,9 @@ public:
         RepeatedGroup<config_entry_type, UINT_MAX> grp_ref(offset_.offset());
         for (unsigned i = 0; i < size_; ++i)
         {
-            grp_ref.entry(i).description().write(fd, "");
+            grp_ref.entry(i).pc().description().write(fd, "");
             CDI_FACTORY_RESET(grp_ref.entry(i).action);
+            CDI_FACTORY_RESET(grp_ref.entry(i).debounce);
         }
     }
 
@@ -194,15 +264,14 @@ public:
             string v(basename);
             v.push_back(' ');
             char buf[10];
-            unsigned_integer_to_buffer(i+1, buf);
+            unsigned_integer_to_buffer(i + 1, buf);
             v += buf;
-            grp_ref.entry(i).description().write(fd, v);
+            grp_ref.entry(i).pc().description().write(fd, v);
         }
     }
 
     void handle_identify_global(const EventRegistryEntry &registry_entry,
-                              EventReport *event, BarrierNotifiable *done)
-        override
+        EventReport *event, BarrierNotifiable *done) override
     {
         AutoNotify an(done);
         if (event->dst_node && event->dst_node != node_)
@@ -210,16 +279,18 @@ public:
             return;
         }
         unsigned pin = registry_entry.user_arg >> 1;
-        if (pins_[pin]->direction() == Gpio::Direction::INPUT) {
+        if (pins_[pin]->direction() == Gpio::Direction::INPUT)
+        {
             SendProducerIdentified(registry_entry, done);
-        } else {
+        }
+        else
+        {
             SendConsumerIdentified(registry_entry, done);
         }
     }
 
     void handle_identify_consumer(const EventRegistryEntry &registry_entry,
-                                  EventReport *event, BarrierNotifiable *done)
-        override
+        EventReport *event, BarrierNotifiable *done) override
     {
         AutoNotify an(done);
         if (event->event != registry_entry.event)
@@ -227,14 +298,14 @@ public:
             return;
         }
         unsigned pin = registry_entry.user_arg >> 1;
-        if (pins_[pin]->direction() == Gpio::Direction::OUTPUT) {
+        if (pins_[pin]->direction() == Gpio::Direction::OUTPUT)
+        {
             SendConsumerIdentified(registry_entry, done);
         }
     }
 
     void handle_identify_producer(const EventRegistryEntry &registry_entry,
-                                  EventReport *event, BarrierNotifiable *done)
-        override
+        EventReport *event, BarrierNotifiable *done) override
     {
         AutoNotify an(done);
         if (event->event != registry_entry.event)
@@ -242,14 +313,14 @@ public:
             return;
         }
         unsigned pin = registry_entry.user_arg >> 1;
-        if (pins_[pin]->direction() == Gpio::Direction::INPUT) {
+        if (pins_[pin]->direction() == Gpio::Direction::INPUT)
+        {
             SendProducerIdentified(registry_entry, done);
         }
     }
 
-
     void handle_event_report(const EventRegistryEntry &registry_entry,
-                           EventReport *event, BarrierNotifiable *done) override
+        EventReport *event, BarrierNotifiable *done) override
     {
         AutoNotify an(done);
         if (event->event != registry_entry.event)
@@ -264,10 +335,8 @@ public:
         }
     }
 
-
-
 private:
-    /// Removed registration of this event handler from the global event
+    /// Removes registration of this event handler from the global event
     /// registry.
     void do_unregister()
     {
@@ -276,50 +345,58 @@ private:
 
     /// Sends out a ConsumerIdentified message for the given registration
     /// entry.
-    void SendConsumerIdentified(const EventRegistryEntry &registry_entry,
-                                BarrierNotifiable *done)
+    void SendConsumerIdentified(
+        const EventRegistryEntry &registry_entry, BarrierNotifiable *done)
     {
         Defs::MTI mti = Defs::MTI_CONSUMER_IDENTIFIED_VALID;
         unsigned b1 = pins_[registry_entry.user_arg >> 1]->is_set() ? 1 : 0;
-        unsigned b2 = registry_entry.user_arg & 1;  // on or off event?
+        unsigned b2 = registry_entry.user_arg & 1; // on or off event?
         if (b1 ^ b2)
         {
             mti++; // INVALID
         }
         event_write_helper3.WriteAsync(node_, mti, WriteHelper::global(),
-                                       eventid_to_buffer(registry_entry.event),
-                                       done->new_child());
+            eventid_to_buffer(registry_entry.event), done->new_child());
     }
 
     /// Sends out a ProducerIdentified message for the given registration
     /// entry.
-    void SendProducerIdentified(const EventRegistryEntry &registry_entry,
-                                BarrierNotifiable *done)
+    void SendProducerIdentified(
+        const EventRegistryEntry &registry_entry, BarrierNotifiable *done)
     {
         Defs::MTI mti = Defs::MTI_PRODUCER_IDENTIFIED_VALID;
         unsigned b1 = pins_[registry_entry.user_arg >> 1]->is_set() ? 1 : 0;
-        unsigned b2 = registry_entry.user_arg & 1;  // on or off event?
+        unsigned b2 = registry_entry.user_arg & 1; // on or off event?
         if (b1 ^ b2)
         {
             mti++; // INVALID
         }
         event_write_helper4.WriteAsync(node_, mti, WriteHelper::global(),
-                                       eventid_to_buffer(registry_entry.event),
-                                       done->new_child());
+            eventid_to_buffer(registry_entry.event), done->new_child());
     }
 
-    /// virtual node to export the consumer on
+    // Variables used for asynchronous state during the polling loop.
+    /// Which pin to next check when polling.
+    unsigned nextPinToPoll_;
+    /// Write helper to use for producing messages during the polling loop.
+    WriteHelper *pollingHelper_;
+    /// Notifiable to call when the polling loop is done.
+    Notifiable *pollingDone_;
+
+    /// virtual node to export the consumer / producer on.
     Node *node_;
-    /// array of all GPIO pins to use
+    /// Array of all GPIO pins to use. Externally owned.
     const Gpio *const *pins_;
-    /// number of GPIO pins to export
+    /// Number of GPIO pins to export.
     size_t size_;
     /// Offset in the configuration space for our configs.
     ConfigReference offset_;
-    /// Event IDs shadowing from the config file for producing them.
-    EventId* producedEvents_;
+    /// Event IDs shadowing from the config file for producing them. We own
+    /// this memory.
+    EventId *producedEvents_;
+    /// One debouncer per pin, created for produced pins. We own this memory.
+    debouncer_type *debouncers_;
 };
-
 
 }
 

--- a/src/openlcb/MultiConfiguredPC.hxx
+++ b/src/openlcb/MultiConfiguredPC.hxx
@@ -281,11 +281,11 @@ public:
         unsigned pin = registry_entry.user_arg >> 1;
         if (pins_[pin]->direction() == Gpio::Direction::INPUT)
         {
-            SendProducerIdentified(registry_entry, done);
+            SendProducerIdentified(registry_entry, event, done);
         }
         else
         {
-            SendConsumerIdentified(registry_entry, done);
+            SendConsumerIdentified(registry_entry, event, done);
         }
     }
 
@@ -300,7 +300,7 @@ public:
         unsigned pin = registry_entry.user_arg >> 1;
         if (pins_[pin]->direction() == Gpio::Direction::OUTPUT)
         {
-            SendConsumerIdentified(registry_entry, done);
+            SendConsumerIdentified(registry_entry, event, done);
         }
     }
 
@@ -315,7 +315,7 @@ public:
         unsigned pin = registry_entry.user_arg >> 1;
         if (pins_[pin]->direction() == Gpio::Direction::INPUT)
         {
-            SendProducerIdentified(registry_entry, done);
+            SendProducerIdentified(registry_entry, event, done);
         }
     }
 
@@ -345,8 +345,8 @@ private:
 
     /// Sends out a ConsumerIdentified message for the given registration
     /// entry.
-    void SendConsumerIdentified(
-        const EventRegistryEntry &registry_entry, BarrierNotifiable *done)
+    void SendConsumerIdentified(const EventRegistryEntry &registry_entry,
+        EventReport *event, BarrierNotifiable *done)
     {
         Defs::MTI mti = Defs::MTI_CONSUMER_IDENTIFIED_VALID;
         unsigned b1 = pins_[registry_entry.user_arg >> 1]->is_set() ? 1 : 0;
@@ -355,14 +355,15 @@ private:
         {
             mti++; // INVALID
         }
-        event_write_helper3.WriteAsync(node_, mti, WriteHelper::global(),
-            eventid_to_buffer(registry_entry.event), done->new_child());
+        event->event_write_helper<3>()->WriteAsync(node_, mti,
+            WriteHelper::global(), eventid_to_buffer(registry_entry.event),
+            done->new_child());
     }
 
     /// Sends out a ProducerIdentified message for the given registration
     /// entry.
-    void SendProducerIdentified(
-        const EventRegistryEntry &registry_entry, BarrierNotifiable *done)
+    void SendProducerIdentified(const EventRegistryEntry &registry_entry,
+        EventReport *event, BarrierNotifiable *done)
     {
         Defs::MTI mti = Defs::MTI_PRODUCER_IDENTIFIED_VALID;
         unsigned b1 = pins_[registry_entry.user_arg >> 1]->is_set() ? 1 : 0;
@@ -371,8 +372,9 @@ private:
         {
             mti++; // INVALID
         }
-        event_write_helper4.WriteAsync(node_, mti, WriteHelper::global(),
-            eventid_to_buffer(registry_entry.event), done->new_child());
+        event->event_write_helper<4>()->WriteAsync(node_, mti,
+            WriteHelper::global(), eventid_to_buffer(registry_entry.event),
+            done->new_child());
     }
 
     // Variables used for asynchronous state during the polling loop.
@@ -397,7 +399,6 @@ private:
     /// One debouncer per pin, created for produced pins. We own this memory.
     debouncer_type *debouncers_;
 };
-
 }
 
 #endif // _OPENLCB_MULTICONFIGUREDPC_HXX_

--- a/src/openlcb/MultiConfiguredPC.hxx
+++ b/src/openlcb/MultiConfiguredPC.hxx
@@ -1,0 +1,326 @@
+/** \copyright
+ * Copyright (c) 2015, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file MultiConfiguredPC.hxx
+ *
+ * Producer-Consumer class that uses CDI configuration and many GPIO pins to
+ * export a multiple of configurable input or output pins.
+ *
+ * @author Balazs Racz
+ * @date 28 Oct 2018
+ */
+
+#ifndef _OPENLCB_MULTICONFIGUREDPC_HXX_
+#define _OPENLCB_MULTICONFIGUREDPC_HXX_
+
+#include "openlcb/EventHandlerTemplates.hxx"
+#include "openlcb/ConfigRepresentation.hxx"
+#include "utils/ConfigUpdateListener.hxx"
+#include "utils/ConfigUpdateService.hxx"
+#include "openlcb/RefreshLoop.hxx"
+
+namespace openlcb
+{
+
+static const char PC_ACTION_MAP[] =
+    "<relation><property>0</property><value>Output</value></relation>"
+    "<relation><property>1</property><value>Input</value></relation>";
+
+/// CDI Configuration for a @ref ConfiguredConsumer.
+CDI_GROUP(PCConfig);
+/// Allows the user to assign a name for this output.
+CDI_GROUP_ENTRY(description, StringConfigEntry<20>, //
+                Name("Description"), Description("User name of this output."));
+
+enum class ActionConfig : public uint8_t {
+    OUTPUT = 0,
+    INPUT = 1
+};
+
+CDI_GROUP_ENTRY(action, Uint8ConfigEntry, Default(1), MapValues(PC_ACTION_MAP), Name("Configuration"), MinValue(0), MaxValue(1));
+
+/// Configures the debounce parameter.
+CDI_GROUP_ENTRY(
+    debounce, Uint8ConfigEntry, Name("Debounce parameter"),
+    Default(3),
+    Description("Used for inputs only. Amount of time to wait for the input to stabilize before "
+                "producing the event. Unit is 30 msec of time. Usually a value "
+                "of 2-3 works well in a non-noisy environment. In high noise "
+                "(train wheels for example) a setting between 8 -- 15 makes "
+                "for a slower response time but a more stable "
+                "signal.\nFormally, the parameter tells how many times of "
+                "tries, each 30 msec apart, the input must have the same value "
+                "in order for that value to be accepted and the event "
+                "transition produced."),
+    Default(3));
+
+
+/// Specifies the event ID to set the output to ON.
+CDI_GROUP_ENTRY(event_on, EventConfigEntry, //
+    Offset(1), //  We save a byte to spare here for pulse outputs.
+    Name("Event On"),
+    Description("This event ID will turn the output on / be produced when the "
+                "input goes on."));
+/// Specifies the event ID to set the output to OFF.
+CDI_GROUP_ENTRY(event_off, EventConfigEntry, //
+    Name("Event Off"),
+    Description("This event ID will turn the output off / be produced when the "
+                "input goes off."));
+CDI_GROUP_END();
+
+
+
+class MultiConfiguredPC : public ConfigUpdateListener,
+                          private SimpleEventHandler
+{
+public:
+    typedef PCConfig config_entry_type;
+
+    /// Usage: ```
+    ///
+    /// constexpr const Gpio *const kDirectGpio[] = {
+    /// TDRV1_Pin::instance(), TDRV2_Pin::instance(),
+    /// TDRV3_Pin::instance(), TDRV4_Pin::instance(),
+    /// };
+    /// openlcb::MultiConfiguredPC direct_pc(stack.node(),
+    ///    kDirectGpio, ARRAYSIZE(kDirectGpio), cfg.seg().direct_consumers());
+    /// ```
+    ///
+    /// @param node is the OpenLCB node object from the stack.
+    /// @param pins is the list of pins represented by the Gpio* object
+    /// instances. Can be constant from FLASH space.
+    /// @param size is the length of the list of pins array.
+    /// @param config is the repeated group object from the configuration space
+    /// that represents the locations of the events.
+    template <unsigned N>
+    __attribute__((noinline)) MultiConfiguredPC(Node *node,
+        const Gpio *const *pins, unsigned size,
+        const RepeatedGroup<config_entry_type, N> &config)
+        : node_(node)
+        , pins_(pins)
+        , size_(N)
+        , offset_(config)
+    {
+        // Mismatched sizing of the GPIO array from the configuration array.
+        HASSERT(size == N);
+        ConfigUpdateService::instance()->register_update_listener(this);
+        producedEvents_ = new EventId[size * 2];
+    }
+
+    ~MultiConfiguredPC()
+    {
+        do_unregister();
+        ConfigUpdateService::instance()->unregister_update_listener(this);
+        delete [] producedEvents_;
+    }
+
+    UpdateAction apply_configuration(int fd, bool initial_load,
+                                     BarrierNotifiable *done) OVERRIDE
+    {
+        AutoNotify n(done);
+
+        if (!initial_load)
+        {
+            // There is no way to figure out what the previously registered
+            // eventid values were for the individual pins. Therefore we always
+            // unregister everything and register them anew. It also causes us
+            // to identify all. This is not a problem since apply_configuration
+            // is coming from a user action.
+            do_unregister();
+        }
+        RepeatedGroup<config_entry_type, UINT_MAX> grp_ref(offset_.offset());
+        for (unsigned i = 0; i < size_; ++i)
+        {
+            const config_entry_type cfg_ref(grp_ref.entry(i));
+            uint8_t action = cfg_ref.action().read(fd);
+            if (action == PCConfig::ActionConfig::OUTPUT) {
+                pins_[i]->set_direction(Gpio::Direction::OUTPUT);
+            } else {
+                pins_[i]->set_direction(Gpio::Direction::INPUT);
+            }
+            EventId cfg_event_on = cfg_ref.event_on().read(fd);
+            EventId cfg_event_off = cfg_ref.event_off().read(fd);
+            EventRegistry::instance()->register_handler(
+                EventRegistryEntry(this, cfg_event_off, i * 2), 0);
+            producedEvents_[i * 2] = cfg_event_off;
+            EventRegistry::instance()->register_handler(
+                EventRegistryEntry(this, cfg_event_on, i * 2 + 1), 0);
+            producedEvents_[i * 2 + 1] = cfg_event_on;
+        }
+        return REINIT_NEEDED; // Causes events identify.
+    }
+
+    void factory_reset(int fd) OVERRIDE
+    {
+        RepeatedGroup<config_entry_type, UINT_MAX> grp_ref(offset_.offset());
+        for (unsigned i = 0; i < size_; ++i)
+        {
+            grp_ref.entry(i).description().write(fd, "");
+            CDI_FACTORY_RESET(grp_ref.entry(i).action);
+        }
+    }
+
+    /// Factory reset helper function. Sets all names to something 1..N.
+    /// @param fd pased on from factory reset argument.
+    /// @param basename name of repeats.
+    void factory_reset_names(int fd, const char *basename)
+    {
+        RepeatedGroup<config_entry_type, UINT_MAX> grp_ref(offset_.offset());
+        for (unsigned i = 0; i < size_; ++i)
+        {
+            string v(basename);
+            v.push_back(' ');
+            char buf[10];
+            unsigned_integer_to_buffer(i+1, buf);
+            v += buf;
+            grp_ref.entry(i).description().write(fd, v);
+        }
+    }
+
+    void handle_identify_global(const EventRegistryEntry &registry_entry,
+                              EventReport *event, BarrierNotifiable *done)
+        override
+    {
+        AutoNotify an(done);
+        if (event->dst_node && event->dst_node != node_)
+        {
+            return;
+        }
+        unsigned pin = registry_entry.user_arg >> 1;
+        if (pins_[pin]->direction() == Gpio::Direction::INPUT) {
+            SendProducerIdentified(registry_entry, done);
+        } else {
+            SendConsumerIdentified(registry_entry, done);
+        }
+    }
+
+    void handle_identify_consumer(const EventRegistryEntry &registry_entry,
+                                  EventReport *event, BarrierNotifiable *done)
+        override
+    {
+        AutoNotify an(done);
+        if (event->event != registry_entry.event)
+        {
+            return;
+        }
+        unsigned pin = registry_entry.user_arg >> 1;
+        if (pins_[pin]->direction() == Gpio::Direction::OUTPUT) {
+            SendConsumerIdentified(registry_entry, done);
+        }
+    }
+
+    void handle_identify_producer(const EventRegistryEntry &registry_entry,
+                                  EventReport *event, BarrierNotifiable *done)
+        override
+    {
+        AutoNotify an(done);
+        if (event->event != registry_entry.event)
+        {
+            return;
+        }
+        unsigned pin = registry_entry.user_arg >> 1;
+        if (pins_[pin]->direction() == Gpio::Direction::INPUT) {
+            SendProducerIdentified(registry_entry, done);
+        }
+    }
+
+
+    void handle_event_report(const EventRegistryEntry &registry_entry,
+                           EventReport *event, BarrierNotifiable *done) override
+    {
+        AutoNotify an(done);
+        if (event->event != registry_entry.event)
+        {
+            return;
+        }
+        const Gpio *pin = pins_[registry_entry.user_arg >> 1];
+        if (pin->direction() == Gpio::Direction::OUTPUT)
+        {
+            const bool is_on = (registry_entry.user_arg & 1);
+            pin->write(is_on);
+        }
+    }
+
+
+
+private:
+    /// Removed registration of this event handler from the global event
+    /// registry.
+    void do_unregister()
+    {
+        EventRegistry::instance()->unregister_handler(this);
+    }
+
+    /// Sends out a ConsumerIdentified message for the given registration
+    /// entry.
+    void SendConsumerIdentified(const EventRegistryEntry &registry_entry,
+                                BarrierNotifiable *done)
+    {
+        Defs::MTI mti = Defs::MTI_CONSUMER_IDENTIFIED_VALID;
+        unsigned b1 = pins_[registry_entry.user_arg >> 1]->is_set() ? 1 : 0;
+        unsigned b2 = registry_entry.user_arg & 1;  // on or off event?
+        if (b1 ^ b2)
+        {
+            mti++; // INVALID
+        }
+        event_write_helper3.WriteAsync(node_, mti, WriteHelper::global(),
+                                       eventid_to_buffer(registry_entry.event),
+                                       done->new_child());
+    }
+
+    /// Sends out a ProducerIdentified message for the given registration
+    /// entry.
+    void SendProducerIdentified(const EventRegistryEntry &registry_entry,
+                                BarrierNotifiable *done)
+    {
+        Defs::MTI mti = Defs::MTI_PRODUCER_IDENTIFIED_VALID;
+        unsigned b1 = pins_[registry_entry.user_arg >> 1]->is_set() ? 1 : 0;
+        unsigned b2 = registry_entry.user_arg & 1;  // on or off event?
+        if (b1 ^ b2)
+        {
+            mti++; // INVALID
+        }
+        event_write_helper4.WriteAsync(node_, mti, WriteHelper::global(),
+                                       eventid_to_buffer(registry_entry.event),
+                                       done->new_child());
+    }
+
+    /// virtual node to export the consumer on
+    Node *node_;
+    /// array of all GPIO pins to use
+    const Gpio *const *pins_;
+    /// number of GPIO pins to export
+    size_t size_;
+    /// Offset in the configuration space for our configs.
+    ConfigReference offset_;
+    /// Event IDs shadowing from the config file for producing them.
+    EventId* producedEvents_;
+};
+
+
+}
+
+#endif // _OPENLCB_MULTICONFIGUREDPC_HXX_

--- a/src/utils/Buffer.cxx
+++ b/src/utils/Buffer.cxx
@@ -39,7 +39,8 @@ Pool* init_main_buffer_pool()
 {
     if (!mainBufferPool)
     {
-        mainBufferPool = new DynamicPool(Bucket::init(16, 32, 48, LARGEST_BUFFERPOOL_BUCKET, 0));
+        mainBufferPool = new DynamicPool(
+            Bucket::init(16, 32, 48, LARGEST_BUFFERPOOL_BUCKET, 0));
     }
     return mainBufferPool;
 }

--- a/src/utils/Debouncer.hxx
+++ b/src/utils/Debouncer.hxx
@@ -79,6 +79,14 @@ public:
     {
     }
 
+    /// Re-creates the debouncer with new options.
+    /// @param opts new options.
+    void reset_options(const Options &opts)
+    {
+        waitCount_ = opts;
+        initialize(currentState_);
+    }
+
     /// Initializes the debouncer. @param state is the externally forced state.
     void initialize(bool state)
     {

--- a/targets/freertos.armv7m/freertos_drivers/stm32cubef303x_28x_58x_98x/sources
+++ b/targets/freertos.armv7m/freertos_drivers/stm32cubef303x_28x_58x_98x/sources
@@ -64,5 +64,7 @@ CSRCS += stm32f3xx_hal.c \
 
 CXXSRCS += Stm32Can.cxx \
            Stm32Uart.cxx \
+           Stm32SPI.cxx \
+           Stm32I2C.cxx \
            Stm32EEPROMEmulation.cxx
 

--- a/targets/freertos.armv7m/freertos_drivers/stm32cubef303xe/sources
+++ b/targets/freertos.armv7m/freertos_drivers/stm32cubef303xe/sources
@@ -64,5 +64,6 @@ CSRCS += stm32f3xx_hal.c \
 CXXSRCS += Stm32Can.cxx \
            Stm32Uart.cxx \
            Stm32SPI.cxx \
+           Stm32I2C.cxx \
            Stm32EEPROMEmulation.cxx
 


### PR DESCRIPTION
- Adds an I2C driver for the STM32 MCUs
- adds a generic MCP23017 Gpio expander driver, and an Mcp23017Gpio object
- adds a MultiConfiguredPC class to somewhat efficiently export a large number of pins that can be both input or outputs, configured by the CDI
- instantiates all of this in the nucleo_io application for the F303.