### PR TITLE
Added LinuxGpio.h -- GPIO under Linux using the sysfs API

### DIFF
--- a/applications/hub/main.cxx
+++ b/applications/hub/main.cxx
@@ -63,11 +63,12 @@ const char *upstream_host = nullptr;
 bool timestamped = false;
 bool export_mdns = false;
 const char* mdns_name = "openmrn_hub";
+bool printpackets = false;
 
 void usage(const char *e)
 {
     fprintf(stderr, "Usage: %s [-p port] [-d device_path] [-u upstream_host] "
-                    "[-q upstream_port] [-m] [-n mdns_name] [-t]\n\n",
+                    "[-q upstream_port] [-m] [-n mdns_name] [-t] [-l]\n\n",
             e);
     fprintf(stderr, "GridConnect CAN HUB.\nListens to a specific TCP port, "
                     "reads CAN packets from the incoming connections using "
@@ -85,6 +86,8 @@ void usage(const char *e)
             "\t-q upstream_port   is the port number for the upstream hub.\n");
     fprintf(stderr,
             "\t-t prints timestamps for each packet.\n");
+    fprintf(stderr,
+            "\t-l print all packets.\n");
 #ifdef HAVE_AVAHI_CLIENT
     fprintf(stderr,
             "\t-m exports the current service on mDNS.\n");
@@ -97,7 +100,7 @@ void usage(const char *e)
 void parse_args(int argc, char *argv[])
 {
     int opt;
-    while ((opt = getopt(argc, argv, "hp:d:u:q:tmn:")) >= 0)
+    while ((opt = getopt(argc, argv, "hp:d:u:q:tlmn:")) >= 0)
     {
         switch (opt)
         {
@@ -126,6 +129,9 @@ void parse_args(int argc, char *argv[])
                 mdns_name = optarg;
                 export_mdns = true;
                 break;
+            case 'l':
+                printpackets = true;
+                break;
             default:
                 fprintf(stderr, "Unknown option %c\n", opt);
                 usage(argv[0]);
@@ -141,7 +147,12 @@ void parse_args(int argc, char *argv[])
 int appl_main(int argc, char *argv[])
 {
     parse_args(argc, argv);
-    GcPacketPrinter packet_printer(&can_hub0, timestamped);
+    //GcPacketPrinter packet_printer(&can_hub0, timestamped);
+    GcPacketPrinter *packet_printer = NULL;
+    if (printpackets) {
+        packet_printer = new GcPacketPrinter(&can_hub0, timestamped);
+    }
+    fprintf(stderr,"packet_printer points to %p\n",packet_printer);
     GcTcpHub hub(&can_hub0, port);
     vector<std::unique_ptr<ConnectionClient>> connections;
 

--- a/applications/hub/targets/linux.x86/AvaHiMDNS.cxx
+++ b/applications/hub/targets/linux.x86/AvaHiMDNS.cxx
@@ -124,12 +124,10 @@ void mdns_publish(const char *name, uint16_t port)
         HASSERT(group);
     }
 
-    char r[128];
-
     int result = avahi_entry_group_add_service(group, AVAHI_IF_UNSPEC,
         AVAHI_PROTO_UNSPEC, (AvahiPublishFlags)0, name,
         openlcb::TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN, NULL, NULL, port,
-        "platform=linux-x86-openmrn", r, NULL);
+        "platform=linux-x86-openmrn", NULL);
 
     if (result != 0)
     {

--- a/src/os/LinuxGpio.hxx
+++ b/src/os/LinuxGpio.hxx
@@ -8,7 +8,7 @@
 //  Author        : $Author$
 //  Created By    : Robert Heller
 //  Created       : Tue Oct 9 21:19:14 2018
-//  Last Modified : <181014.1601>
+//  Last Modified : <181014.2046>
 //
 //  Description	
 //
@@ -106,8 +106,8 @@ public:
         FILE *fp = fopen("/sys/class/gpio/export","w");
         fprintf(fp,"%d\n",PIN);
         fclose(fp);
-        // 50ms delay might be needed while kernel changes ownership of created GPIO directory
-        //usleep(50000); 
+        // 50ms delay IS needed while kernel changes ownership of created GPIO directory
+        usleep(50000); 
     }
     
     /// Sets pin to output.

--- a/src/os/LinuxGpio.hxx
+++ b/src/os/LinuxGpio.hxx
@@ -1,0 +1,133 @@
+// -!- c++ -!- //////////////////////////////////////////////////////////////
+//
+//  System        : 
+//  Module        : 
+//  Object Name   : $RCSfile$
+//  Revision      : $Revision$
+//  Date          : $Date$
+//  Author        : $Author$
+//  Created By    : Robert Heller
+//  Created       : Tue Oct 9 21:19:14 2018
+//  Last Modified : <181010.0947>
+//
+//  Description	
+//
+//  Notes
+//
+//  History
+//
+
+/** \copyright
+ *
+ *    Copyright (C) 2018  Robert Heller D/B/A Deepwoods Software
+ *			51 Locke Hill Road
+ *			Wendell, MA 01379-9728
+ *
+ *    This program is free software; you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation; either version 2 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program; if not, write to the Free Software
+ *    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * 
+ *
+ *
+ * \file LinuxGpio.hxx
+ * 
+ * @author Robert Heller
+ * @date 10 October 2018
+ */
+
+#ifndef __LINUXGPIO_HXX
+#define __LINUXGPIO_HXX
+
+#include "os/Gpio.hxx"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+
+/**
+ * Gpio wrapper for a Linux GPIO bit using the sysfs interface.
+ * 
+ * 
+ */
+
+class LinuxGpio : public Gpio
+{
+public:
+    
+    constexpr LinuxGpio(const unsigned pin, const bool is_output)
+          : pin_(pin)
+          , isOutput_(is_output ? 1 : 0)
+    {
+        char buffer[128];
+        FILE *fp = fopen("/sys/class/gpio/export","w");
+        fprintf(fp,"%d\n",pin_);
+        fclose(fp);
+        snprintf(buffer,sizeof(buffer),"/sys/class/gpio/gpio%d/direction",pin_);
+        fp = fopen(buffer,"w");
+        fprintf(fp,(isOutput_ == 1) ? "out\n" : "in\n");
+        fclose(fp);
+        snprintf(buffer,sizeof(buffer),"/sys/class/gpio/gpio%d/value",pin_);
+        fd = open(buffer, O_RDWR);
+    }
+    void write(Value new_state) const OVERRIDE
+    {
+        if (new_state == Value::SET) {
+            ::write(fd,"1\n",2);
+        } else {
+            ::write(fd,"0\n",2);
+        }
+    }
+    void set() const OVERRIDE
+    {
+        write(Value::SET);
+    }
+
+    void clr() const OVERRIDE
+    {
+        write(Value::CLR);
+    }
+
+    Value read() const OVERRIDE
+    {
+        char c;
+        lseek(fd, 0L, SEEK_SET) ;
+        ::read(fd,&c,1);
+        return (c == '0')? Value::CLR : Value::SET;
+    }
+
+    void set_direction(Direction dir) OVERRIDE
+    {
+        char buffer[128];
+        isOutput_ = (dir == Direction::OUTPUT) ? 1 : 0;
+        snprintf(buffer,sizeof(buffer),"/sys/class/gpio/gpio%d/direction",pin_);
+        FILE *fp = fopen(buffer,"w");
+        fprintf(fp,(isOutput_ == 1) ? "out\n" : "in\n");
+        fclose(fp);
+    }
+
+    Direction direction() const OVERRIDE
+    {
+        return isOutput_ ? Direction::OUTPUT : Direction::INPUT;
+    }
+
+private:
+    /// Which pin
+    const unsigned pin_;
+    /// 1 if this GPIO is an output, 0 if it's an input.
+    unsigned isOutput_ : 1;
+    /// /sysfs file destriptor.
+    int fd;
+};
+#endif // __LINUXGPIO_HXX
+

--- a/src/os/LinuxGpio.hxx
+++ b/src/os/LinuxGpio.hxx
@@ -8,7 +8,7 @@
 //  Author        : $Author$
 //  Created By    : Robert Heller
 //  Created       : Tue Oct 9 21:19:14 2018
-//  Last Modified : <181013.2257>
+//  Last Modified : <181013.2314>
 //
 //  Description	
 //
@@ -106,8 +106,8 @@ public:
         FILE *fp = fopen("/sys/class/gpio/export","w");
         fprintf(fp,"%d\n",PIN);
         fclose(fp);
-        // 50ms delay needed while kernel changes ownership of created GPIO directory
-        usleep(50000); 
+        // 250ms delay needed while kernel changes ownership of created GPIO directory
+        usleep(250000); 
     }
     
     /// Sets pin to output.

--- a/src/os/LinuxGpio.hxx
+++ b/src/os/LinuxGpio.hxx
@@ -8,7 +8,7 @@
 //  Author        : $Author$
 //  Created By    : Robert Heller
 //  Created       : Tue Oct 9 21:19:14 2018
-//  Last Modified : <181014.2046>
+//  Last Modified : <181031.2137>
 //
 //  Description	
 //
@@ -23,21 +23,29 @@
  *			51 Locke Hill Road
  *			Wendell, MA 01379-9728
  *
- *    This program is free software; you can redistribute it and/or modify
- *    it under the terms of the GNU General Public License as published by
- *    the Free Software Foundation; either version 2 of the License, or
- *    (at your option) any later version.
+ * All rights reserved.
  *
- *    This program is distributed in the hope that it will be useful,
- *    but WITHOUT ANY WARRANTY; without even the implied warranty of
- *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *    GNU General Public License for more details.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
  *
- *    You should have received a copy of the GNU General Public License
- *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
  *
- * 
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  *
  *
  * \file LinuxGpio.hxx

--- a/src/os/LinuxGpio.hxx
+++ b/src/os/LinuxGpio.hxx
@@ -1,22 +1,3 @@
-// -!- c++ -!- //////////////////////////////////////////////////////////////
-//
-//  System        : 
-//  Module        : 
-//  Object Name   : $RCSfile$
-//  Revision      : $Revision$
-//  Date          : $Date$
-//  Author        : $Author$
-//  Created By    : Robert Heller
-//  Created       : Tue Oct 9 21:19:14 2018
-//  Last Modified : <181031.2137>
-//
-//  Description	
-//
-//  Notes
-//
-//  History
-//
-
 /** \copyright
  *
  *    Copyright (C) 2018  Robert Heller D/B/A Deepwoods Software

--- a/src/os/LinuxGpio.hxx
+++ b/src/os/LinuxGpio.hxx
@@ -8,7 +8,7 @@
 //  Author        : $Author$
 //  Created By    : Robert Heller
 //  Created       : Tue Oct 9 21:19:14 2018
-//  Last Modified : <181013.2314>
+//  Last Modified : <181014.1601>
 //
 //  Description	
 //
@@ -106,8 +106,8 @@ public:
         FILE *fp = fopen("/sys/class/gpio/export","w");
         fprintf(fp,"%d\n",PIN);
         fclose(fp);
-        // 250ms delay needed while kernel changes ownership of created GPIO directory
-        usleep(250000); 
+        // 50ms delay might be needed while kernel changes ownership of created GPIO directory
+        //usleep(50000); 
     }
     
     /// Sets pin to output.
@@ -279,7 +279,7 @@ public:
     {
         return GpioWrapper<GpioInputPin<Base>>::instance();
     }
-    static void get()
+    static bool get()
     {
         if (ACTIVE_HIGH)
         {


### PR DESCRIPTION
This is something of a clone of the other base level Gpio code, but using the SYSFS API under Linux, rather than doing the direct register hackery typical of MCUs like the Tiva or Microsys boards under FreeRTOS.  It appears to work just fine under Raspbian on Raspberry Pis, both with the on-board GPIO and with MCP230xx I2C port expanders.