### PR TITLE
Refactors statically allocated objects for the event handlers

### DIFF
--- a/boards/st-stm32f091rc-nucleo-dev-board/HwInit.cxx
+++ b/boards/st-stm32f091rc-nucleo-dev-board/HwInit.cxx
@@ -158,9 +158,6 @@ void timer14_interrupt_handler(void)
 
 void diewith(uint32_t pattern)
 {
-    asm("cpsid i\n");
-    NVIC_SystemReset();
-    
     // vPortClearInterruptMask(0x20);
     asm("cpsie i\n");
 

--- a/src/openlcb/ConfiguredConsumer.hxx
+++ b/src/openlcb/ConfiguredConsumer.hxx
@@ -222,29 +222,28 @@ private:
         {
             return done->notify();
         }
-        SendConsumerIdentified(done);
+        SendConsumerIdentified(event, done);
     }
 
-    void SendConsumerIdentified(BarrierNotifiable *done)
+    void SendConsumerIdentified(EventReport *event, BarrierNotifiable *done)
     {
         Defs::MTI mti = Defs::MTI_CONSUMER_IDENTIFIED_VALID;
         if (!pulseRemaining_)
         {
             mti++; // INVALID
         }
-        event_write_helper3.WriteAsync(node_, mti, WriteHelper::global(),
-                                       eventid_to_buffer(event_), done);
+        event->event_write_helper<3>()->WriteAsync(
+            node_, mti, WriteHelper::global(), eventid_to_buffer(event_), done);
     }
 
     void handle_identify_consumer(const EventRegistryEntry &registry_entry,
-                                EventReport *event, BarrierNotifiable *done)
-        OVERRIDE
+        EventReport *event, BarrierNotifiable *done) OVERRIDE
     {
         if (event->event != event_)
         {
             return done->notify();
         }
-        SendConsumerIdentified(done);
+        SendConsumerIdentified(event, done);
     }
 
     void handle_event_report(const EventRegistryEntry &registry_entry,

--- a/src/openlcb/EventHandler.hxx
+++ b/src/openlcb/EventHandler.hxx
@@ -56,7 +56,7 @@ class EventHandler;
 
 /// Shared notification structure that is assembled for each incoming
 /// event-related message, and passed around to all event handlers.
-typedef struct
+struct EventReport
 {
     /// The event ID from the incoming message.
     EventId event;
@@ -87,9 +87,16 @@ typedef struct
     }
 
 private:
+    /// Constrained access to the constructors. We do this because the
+    /// EventReport structure is pretty expensive due to the statically
+    /// allocated memory of the write helpers. Only the EventIteratorFlow
+    /// should have objects of this type.
+    EventReport() {}
+    friend class EventIteratorFlow;
+    
     /// Static objects usable by all event handler implementations.
-    WriteHelper *write_helpers;
-} EventReport;
+    WriteHelper write_helpers[4];
+};
 
 /// Structure used in registering event handlers.
 class EventRegistryEntry

--- a/src/openlcb/EventHandler.hxx
+++ b/src/openlcb/EventHandler.hxx
@@ -76,6 +76,19 @@ typedef struct
     /// producer/consumer as the sender of the message
     /// (valid/invalid/unknown/reserved).
     EventState state;
+
+    /// These allow event handlers to produce up to four messages per
+    /// invocation. They are always available at the entry to an event handler
+    /// function.
+    template <int N> WriteHelper *event_write_helper()
+    {
+        static_assert(1 <= N && N <= 4, "WriteHelper out of range.");
+        return write_helpers + (N - 1);
+    }
+
+private:
+    /// Static objects usable by all event handler implementations.
+    WriteHelper* write_helpers;
 } EventReport;
 
 /// Structure used in registering event handlers.
@@ -104,16 +117,6 @@ public:
     {
     }
 };
-
-// Static objects usable by all event handler implementations
-
-// These allow event handlers to produce up to four messages per
-// invocation. They are locked by the event-handler_mutex and always available
-// at the entry to an event handler function.
-extern WriteHelper event_write_helper1;
-extern WriteHelper event_write_helper2;
-extern WriteHelper event_write_helper3;
-extern WriteHelper event_write_helper4;
 
 /// Abstract base class for all event handlers. Instances of this class can
 /// get registered with the event service to receive notifications of incoming

--- a/src/openlcb/EventHandler.hxx
+++ b/src/openlcb/EventHandler.hxx
@@ -88,7 +88,7 @@ typedef struct
 
 private:
     /// Static objects usable by all event handler implementations.
-    WriteHelper* write_helpers;
+    WriteHelper *write_helpers;
 } EventReport;
 
 /// Structure used in registering event handlers.

--- a/src/openlcb/EventHandlerTemplates.cxx
+++ b/src/openlcb/EventHandlerTemplates.cxx
@@ -232,8 +232,8 @@ void BitRangeEventPC::HandleIdentifyBase(Defs::MTI mti_valid,
         mti++; // mti INVALID
     }
 
-    event->event_write_helper<1>()->WriteAsync(node_, mti, WriteHelper::global(),
-                                   eventid_to_buffer(event->event), done);
+    event->event_write_helper<1>()->WriteAsync(node_, mti,
+        WriteHelper::global(), eventid_to_buffer(event->event), done);
 }
 
 uint64_t EncodeRange(uint64_t begin, unsigned size)
@@ -267,12 +267,12 @@ void BitRangeEventPC::handle_identify_global(const EventRegistryEntry& entry, Ev
         return done->notify();
     }
     uint64_t range = EncodeRange(event_base_, size_ * 2);
-    event->event_write_helper<1>()->WriteAsync(node_, Defs::MTI_PRODUCER_IDENTIFIED_RANGE,
-                                   WriteHelper::global(),
-                                   eventid_to_buffer(range), done->new_child());
-    event->event_write_helper<2>()->WriteAsync(node_, Defs::MTI_CONSUMER_IDENTIFIED_RANGE,
-                                   WriteHelper::global(),
-                                   eventid_to_buffer(range), done->new_child());
+    event->event_write_helper<1>()->WriteAsync(node_,
+        Defs::MTI_PRODUCER_IDENTIFIED_RANGE, WriteHelper::global(),
+        eventid_to_buffer(range), done->new_child());
+    event->event_write_helper<2>()->WriteAsync(node_,
+        Defs::MTI_CONSUMER_IDENTIFIED_RANGE, WriteHelper::global(),
+        eventid_to_buffer(range), done->new_child());
     done->maybe_done();
 }
 
@@ -352,8 +352,8 @@ void ByteRangeEventC::handle_identify_consumer(const EventRegistryEntry& entry, 
     {
         mti++; // mti INVALID
     }
-    event->event_write_helper<1>()->WriteAsync(node_, mti, WriteHelper::global(),
-                                   eventid_to_buffer(event->event), done);
+    event->event_write_helper<1>()->WriteAsync(node_, mti,
+        WriteHelper::global(), eventid_to_buffer(event->event), done);
 }
 
 void ByteRangeEventC::handle_identify_global(const EventRegistryEntry& entry, EventReport *event,
@@ -364,9 +364,9 @@ void ByteRangeEventC::handle_identify_global(const EventRegistryEntry& entry, Ev
         return done->notify();
     }
     uint64_t range = EncodeRange(event_base_, size_ * 256);
-    event->event_write_helper<1>()->WriteAsync(node_, Defs::MTI_CONSUMER_IDENTIFIED_RANGE,
-                                   WriteHelper::global(),
-                                   eventid_to_buffer(range), done->new_child());
+    event->event_write_helper<1>()->WriteAsync(node_,
+        Defs::MTI_CONSUMER_IDENTIFIED_RANGE, WriteHelper::global(),
+        eventid_to_buffer(range), done->new_child());
     done->maybe_done();
 }
 
@@ -419,9 +419,9 @@ void ByteRangeEventP::handle_identify_producer(const EventRegistryEntry& entry, 
         Update(
             storage - data_, event->event_write_helper<2>(), done->new_child());
     }
-    event->event_write_helper<1>()->WriteAsync(node_, mti, WriteHelper::global(),
-                                   eventid_to_buffer(event->event),
-                                   done->new_child());
+    event->event_write_helper<1>()->WriteAsync(node_, mti,
+        WriteHelper::global(), eventid_to_buffer(event->event),
+        done->new_child());
     done->maybe_done();
 }
 void ByteRangeEventP::handle_identify_global(const EventRegistryEntry& entry, EventReport *event,
@@ -432,9 +432,9 @@ void ByteRangeEventP::handle_identify_global(const EventRegistryEntry& entry, Ev
         return done->notify();
     }
     uint64_t range = EncodeRange(event_base_, size_ * 256);
-    event->event_write_helper<1>()->WriteAsync(node_, Defs::MTI_PRODUCER_IDENTIFIED_RANGE,
-                                   WriteHelper::global(),
-                                   eventid_to_buffer(range), done);
+    event->event_write_helper<1>()->WriteAsync(node_,
+        Defs::MTI_PRODUCER_IDENTIFIED_RANGE, WriteHelper::global(),
+        eventid_to_buffer(range), done);
 }
 
 void ByteRangeEventP::SendIdentified(WriteHelper *writer,
@@ -556,30 +556,32 @@ void BitEventHandler::unregister_handler()
     EventRegistry::instance()->unregister_handler(this);
 }
 
-void BitEventHandler::SendProducerIdentified(EventReport* event, BarrierNotifiable *done)
+void BitEventHandler::SendProducerIdentified(
+    EventReport *event, BarrierNotifiable *done)
 {
     EventState state = bit_->get_current_state();
     Defs::MTI mti = Defs::MTI_PRODUCER_IDENTIFIED_VALID + state;
-    event->event_write_helper<1>()->WriteAsync(bit_->node(), mti, WriteHelper::global(),
-                                   eventid_to_buffer(bit_->event_on()),
-                                   done->new_child());
+    event->event_write_helper<1>()->WriteAsync(bit_->node(), mti,
+        WriteHelper::global(), eventid_to_buffer(bit_->event_on()),
+        done->new_child());
     mti = Defs::MTI_PRODUCER_IDENTIFIED_VALID + invert_event_state(state);
-    event->event_write_helper<2>()->WriteAsync(bit_->node(), mti, WriteHelper::global(),
-                                   eventid_to_buffer(bit_->event_off()),
-                                   done->new_child());
+    event->event_write_helper<2>()->WriteAsync(bit_->node(), mti,
+        WriteHelper::global(), eventid_to_buffer(bit_->event_off()),
+        done->new_child());
 }
 
-void BitEventHandler::SendConsumerIdentified(EventReport* event, BarrierNotifiable *done)
+void BitEventHandler::SendConsumerIdentified(
+    EventReport *event, BarrierNotifiable *done)
 {
     EventState state = bit_->get_current_state();
     Defs::MTI mti = Defs::MTI_CONSUMER_IDENTIFIED_VALID + state;
-    event->event_write_helper<3>()->WriteAsync(bit_->node(), mti, WriteHelper::global(),
-                                   eventid_to_buffer(bit_->event_on()),
-                                   done->new_child());
+    event->event_write_helper<3>()->WriteAsync(bit_->node(), mti,
+        WriteHelper::global(), eventid_to_buffer(bit_->event_on()),
+        done->new_child());
     mti = Defs::MTI_CONSUMER_IDENTIFIED_VALID + invert_event_state(state);
-    event->event_write_helper<4>()->WriteAsync(bit_->node(), mti, WriteHelper::global(),
-                                   eventid_to_buffer(bit_->event_off()),
-                                   done->new_child());
+    event->event_write_helper<4>()->WriteAsync(bit_->node(), mti,
+        WriteHelper::global(), eventid_to_buffer(bit_->event_off()),
+        done->new_child());
 }
 
 void BitEventHandler::SendEventReport(WriteHelper *writer, Notifiable *done)
@@ -624,8 +626,8 @@ void BitEventHandler::HandlePCIdentify(Defs::MTI mti, EventReport *event,
         return;
     }
     mti = mti + active;
-    event->event_write_helper<1>()->WriteAsync(bit_->node(), mti, WriteHelper::global(),
-                                   eventid_to_buffer(event->event), done);
+    event->event_write_helper<1>()->WriteAsync(bit_->node(), mti,
+        WriteHelper::global(), eventid_to_buffer(event->event), done);
 }
 
 void BitEventConsumer::handle_producer_identified(const EventRegistryEntry& entry, EventReport *event,

--- a/src/openlcb/EventHandlerTemplates.hxx
+++ b/src/openlcb/EventHandlerTemplates.hxx
@@ -151,7 +151,7 @@ public:
         {
             return done->notify();
         }
-        event_write_helper1.WriteAsync(
+        event->event_write_helper<1>()->WriteAsync(
             node_, openlcb::Defs::MTI_PRODUCER_IDENTIFIED_UNKNOWN,
             WriteHelper::global(), openlcb::eventid_to_buffer(EVENT_ID), done);
     }
@@ -503,7 +503,7 @@ protected:
     ///
     /// @TODO: for consistency of API this function should be changed to notify
     /// the barrier. The caller should always use new_child.
-    void SendProducerIdentified(BarrierNotifiable *done);
+    void SendProducerIdentified(EventReport *event, BarrierNotifiable *done);
 
     /// Sends off two packets using event_write_helper{3,4} of
     /// ConsumerIdentified
@@ -512,7 +512,7 @@ protected:
     ///
     /// @TODO: for consistency of API this function should be changed to notify
     /// the barrier. The caller should always use new_child.
-    void SendConsumerIdentified(BarrierNotifiable *done);
+    void SendConsumerIdentified(EventReport *event, BarrierNotifiable *done);
 
     /// Checks if the event in the report is something we are interested in, and
     /// if so, sends off a {Producer|Consumer}Identified{Valid|Invalid} message

--- a/src/openlcb/EventHandlerTemplates.hxx
+++ b/src/openlcb/EventHandlerTemplates.hxx
@@ -151,8 +151,8 @@ public:
         {
             return done->notify();
         }
-        event->event_write_helper<1>()->WriteAsync(
-            node_, openlcb::Defs::MTI_PRODUCER_IDENTIFIED_UNKNOWN,
+        event->event_write_helper<1>()->WriteAsync(node_,
+            openlcb::Defs::MTI_PRODUCER_IDENTIFIED_UNKNOWN,
             WriteHelper::global(), openlcb::eventid_to_buffer(EVENT_ID), done);
     }
 

--- a/src/openlcb/EventServiceImpl.hxx
+++ b/src/openlcb/EventServiceImpl.hxx
@@ -82,7 +82,6 @@ public:
 
 private:
     virtual Action entry() OVERRIDE;
-    Action perform_call();
     Action call_done();
 
     BarrierNotifiable n_;
@@ -138,9 +137,6 @@ protected:
 
 private:
     virtual Action dispatch_event(const EventRegistryEntry *entry);
-    /// Called when there will be no more dispatch_event calls for this
-    /// iteration.
-    virtual void no_more_matches() {};
 
 protected:
     EventService *eventService_;
@@ -189,12 +185,7 @@ public:
 
 private:
     Action dispatch_event(const EventRegistryEntry *entry) OVERRIDE;
-    void no_more_matches() OVERRIDE;
 
-    Action perform_call();
-
-    /// True if we are already holding the event handler mutex.
-    bool holdingEventMutex_{false};
     /// The handler we need to call.
     const EventRegistryEntry *currentEntry_{nullptr};
 };

--- a/src/openlcb/MultiConfiguredConsumer.hxx
+++ b/src/openlcb/MultiConfiguredConsumer.hxx
@@ -185,8 +185,7 @@ private:
     /// Sends out a ConsumerIdentified message for the given registration
     /// entry.
     void SendConsumerIdentified(const EventRegistryEntry &registry_entry,
-                                EventReport *event,
-                                BarrierNotifiable *done)
+        EventReport *event, BarrierNotifiable *done)
     {
         Defs::MTI mti = Defs::MTI_CONSUMER_IDENTIFIED_VALID;
         unsigned b1 = pins_[registry_entry.user_arg >> 1]->is_set() ? 1 : 0;

--- a/src/openlcb/MultiConfiguredConsumer.hxx
+++ b/src/openlcb/MultiConfiguredConsumer.hxx
@@ -154,7 +154,7 @@ public:
         {
             return done->notify();
         }
-        SendConsumerIdentified(registry_entry, done);
+        SendConsumerIdentified(registry_entry, event, done);
     }
 
     void handle_identify_consumer(const EventRegistryEntry &registry_entry,
@@ -165,7 +165,7 @@ public:
         {
             return done->notify();
         }
-        SendConsumerIdentified(registry_entry, done);
+        SendConsumerIdentified(registry_entry, event, done);
     }
 
     void handle_event_report(const EventRegistryEntry &registry_entry,
@@ -185,6 +185,7 @@ private:
     /// Sends out a ConsumerIdentified message for the given registration
     /// entry.
     void SendConsumerIdentified(const EventRegistryEntry &registry_entry,
+                                EventReport *event,
                                 BarrierNotifiable *done)
     {
         Defs::MTI mti = Defs::MTI_CONSUMER_IDENTIFIED_VALID;
@@ -194,9 +195,9 @@ private:
         {
             mti++; // INVALID
         }
-        event_write_helper3.WriteAsync(node_, mti, WriteHelper::global(),
-                                       eventid_to_buffer(registry_entry.event),
-                                       done);
+        event->event_write_helper<3>()->WriteAsync(node_, mti,
+            WriteHelper::global(), eventid_to_buffer(registry_entry.event),
+            done);
     }
 
     /// Removed registration of this event handler from the global event

--- a/src/openlcb/NonAuthoritativeEventProducer.cxx
+++ b/src/openlcb/NonAuthoritativeEventProducer.cxx
@@ -192,11 +192,9 @@ void BitRangeNonAuthoritativeEventP::handle_identify_global(
                 range = EncodeRange(eventBaseOff_, size_);
                 break;
         }
-        event_write_helper1.WriteAsync(node_,
-                                       Defs::MTI_PRODUCER_IDENTIFIED_RANGE,
-                                       WriteHelper::global(),
-                                       eventid_to_buffer(range),
-                                       done);
+        event->event_write_helper<1>()->WriteAsync(node_,
+            Defs::MTI_PRODUCER_IDENTIFIED_RANGE, WriteHelper::global(),
+            eventid_to_buffer(range), done);
     }
 }
 
@@ -239,11 +237,9 @@ void BitRangeNonAuthoritativeEventP::handle_identify_producer(
 
     if (valid)
     {
-        event_write_helper1.WriteAsync(node_,
-                                       Defs::MTI_PRODUCER_IDENTIFIED_UNKNOWN,
-                                       WriteHelper::global(),
-                                       eventid_to_buffer(event->event),
-                                       done);
+        event->event_write_helper<1>()->WriteAsync(node_,
+            Defs::MTI_PRODUCER_IDENTIFIED_UNKNOWN, WriteHelper::global(),
+            eventid_to_buffer(event->event), done);
     }
     else
     {


### PR DESCRIPTION
- Removes global static event_write_helper1234 objects.
- Replaces them with objects that are accessible via the EventReport* structure that is passed in to each handler callback to the event handler. This fixes the unnecessarily wide scoping of these buffers.
- Makes the actual write helpers be owned by the EventIteratorFlow objects. This makes it unnecessary to coordinate the different priorities of event handling iterations.
- Removes the event_handler_mutex that was responsible for that coordination.
- Simplifies the state flows that now do not need this mutex.

The end result is that the event handlers on different priority can proceed independently of each other. This fixes a deadlock when the low priority global event handlers' outputs get stuck in the CAN device's outbound queue due to the bus being busy with other event traffic that the high priority event handler needs to make progress upon.