### PR TITLE
Linker init for servo channels.

### DIFF
--- a/boards/st-stm32f091rc-nucleo-dev-board/HwInit.cxx
+++ b/boards/st-stm32f091rc-nucleo-dev-board/HwInit.cxx
@@ -77,10 +77,10 @@ const size_t EEPROMEmulation::SECTOR_SIZE = 4096;
 Stm32PWMGroup servo_timer(TIM3, (configCPU_CLOCK_HZ * 6 / 1000 + 65535) / 65536,
                           configCPU_CLOCK_HZ * 6 / 1000);
 
-extern PWM* servo_channels[];
+extern PWM* const servo_channels[];
 /// The order of these channels follows the schematic arrangement of MCU pins
 /// to logical servo ports.
-PWM *servo_channels[4] = { //
+PWM * const servo_channels[4] = { //
     Stm32PWMGroup::get_channel(&servo_timer, 4),
     Stm32PWMGroup::get_channel(&servo_timer, 2),
     Stm32PWMGroup::get_channel(&servo_timer, 3),

--- a/boards/st-stm32f091rc-nucleo-dev-board/HwInit.cxx
+++ b/boards/st-stm32f091rc-nucleo-dev-board/HwInit.cxx
@@ -81,8 +81,10 @@ extern PWM* servo_channels[];
 /// The order of these channels follows the schematic arrangement of MCU pins
 /// to logical servo ports.
 PWM *servo_channels[4] = { //
-    servo_timer.get_channel(4), servo_timer.get_channel(2),
-    servo_timer.get_channel(3), servo_timer.get_channel(1)};
+    Stm32PWMGroup::get_channel(&servo_timer, 4),
+    Stm32PWMGroup::get_channel(&servo_timer, 2),
+    Stm32PWMGroup::get_channel(&servo_timer, 3),
+    Stm32PWMGroup::get_channel(&servo_timer, 1)};
 
 /// Recursive mutex for SPI1 peripheral.
 OSMutex spi1_lock(true);

--- a/boards/st-stm32f091rc-nucleo-dev-board/hardware.hxx
+++ b/boards/st-stm32f091rc-nucleo-dev-board/hardware.hxx
@@ -48,4 +48,4 @@ typedef GpioInitializer<LED_GREEN_RAW_Pin, SW_USER_Pin, //
 typedef LED_GREEN_RAW_Pin BLINKER_RAW_Pin;
 typedef BLINKER_Pin LED_GREEN_Pin;
 
-extern PWM* servo_channels[];
+extern PWM* const servo_channels[];

--- a/boards/st-stm32f303re-nucleo-dev-board/HwInit.cxx
+++ b/boards/st-stm32f303re-nucleo-dev-board/HwInit.cxx
@@ -76,12 +76,14 @@ const size_t EEPROMEmulation::SECTOR_SIZE = 8192;
 Stm32PWMGroup servo_timer(TIM3, (configCPU_CLOCK_HZ * 6 / 1000 + 65535) / 65536,
                           configCPU_CLOCK_HZ * 6 / 1000);
 
-extern PWM* servo_channels[];
+extern PWM* const servo_channels[];
 /// The order of these channels follows the schematic arrangement of MCU pins
 /// to logical servo ports.
-PWM *servo_channels[4] = { //
-    servo_timer.get_channel(4), servo_timer.get_channel(2),
-    servo_timer.get_channel(3), servo_timer.get_channel(1)};
+PWM * const servo_channels[4] = { //
+    Stm32PWMGroup::get_channel(&servo_timer, 4),
+    Stm32PWMGroup::get_channel(&servo_timer, 2),
+    Stm32PWMGroup::get_channel(&servo_timer, 3),
+    Stm32PWMGroup::get_channel(&servo_timer, 1)};
 
 /// Recursive mutex for SPI1 peripheral.
 OSMutex spi1_lock(true);

--- a/src/freertos_drivers/st/Stm32PWM.hxx
+++ b/src/freertos_drivers/st/Stm32PWM.hxx
@@ -83,6 +83,14 @@ public:
         return &*channels_[id - 1];
     }
 
+    /// @return one PWM channel.
+    /// @param parent the PWMGroup object. Does not need to be initialized yet.
+    /// @param id is the channel number, 1..4
+    static constexpr PWM *get_channel(Stm32PWMGroup *parent, unsigned id)
+    {
+        return uninitialized<Channel>::cast_data(&parent->channels_[id - 1]);
+    }
+
 private:
     class Channel : public PWM
     {

--- a/src/utils/Uninitialized.hxx
+++ b/src/utils/Uninitialized.hxx
@@ -93,6 +93,12 @@ public:
         tptr()->~T();
     }
 
+    /// Public API to convert the pointer in a linker-initialized way.
+    static constexpr T *cast_data(uninitialized<T> *parent)
+    {
+        return reinterpret_cast<T *>(&parent->data);
+    }
+
 private:
     typename std::aligned_storage<sizeof(T), alignof(T)>::type data;
 


### PR DESCRIPTION
Moves the servo PWM initialization to a constexpr function to allow the servo_channels[] array be initialized by the linker instead of at static initialization time.

This fixes bug when the static initialization order is not appropriate.