### PR TITLE
Test for HW pin substitution

### DIFF
--- a/src/openlcb/ConfiguredConsumer.hxx
+++ b/src/openlcb/ConfiguredConsumer.hxx
@@ -98,7 +98,7 @@ public:
     }
 
     template <class HW>
-    ConfiguredConsumer(Node *node, const ConsumerConfig &cfg, const HW &, const Gpio* g = HW::instance())
+    ConfiguredConsumer(Node *node, const ConsumerConfig &cfg, const HW &, const Gpio* g = HW::instance(), decltype(HW::instance)* = 0)
         : impl_(node, 0, 0, g)
         , consumer_(&impl_)
         , cfg_(cfg)

--- a/src/openlcb/ConfiguredProducer.hxx
+++ b/src/openlcb/ConfiguredProducer.hxx
@@ -107,7 +107,7 @@ public:
 
     template <class HW>
     ConfiguredProducer(Node *node, const ProducerConfig &cfg, const HW &,
-                       const Gpio *g = HW::instance())
+        const Gpio *g = HW::instance(), decltype(HW::instance) * = 0)
         : producer_(QuiesceDebouncer::Options(3), node, 0, 0, g)
         , cfg_(cfg)
     {

--- a/src/openlcb/EventHandlerTemplates.hxx
+++ b/src/openlcb/EventHandlerTemplates.hxx
@@ -448,7 +448,7 @@ public:
     }
 
     template <class HW>
-    GPIOBit(Node *node, EventId event_on, EventId event_off, const HW &, const Gpio* g = HW::instance())
+    GPIOBit(Node *node, EventId event_on, EventId event_off, const HW &, const Gpio* g = HW::instance(), decltype(HW::instance)* = 0)
         : GPIOBit(node, event_on, event_off, g)
     {
     }


### PR DESCRIPTION
Adds a SFINAE test to ensure HW class substitution only happens when a Pin structure is passed as an argument.