### PR TITLE
Externalizes the wifi name and password parameters

### DIFF
--- a/arduino/OpenMRN.cpp
+++ b/arduino/OpenMRN.cpp
@@ -35,6 +35,10 @@
 #include <OpenMRN.h>
 
 
+extern const char DEFAULT_WIFI_NAME[] __attribute__((weak)) = "defaultap";
+extern const char DEFAULT_PASSWORD[] __attribute__((weak)) = "defaultpw";
+
+
 OpenMRN::OpenMRN(openlcb::NodeID node_id)
 {
     init(node_id);

--- a/arduino/OpenMRN.h
+++ b/arduino/OpenMRN.h
@@ -42,6 +42,11 @@
 #include "utils/Uninitialized.hxx"
 #include "freertos_drivers/arduino/ArduinoGpio.hxx"
 
+extern "C" {
+extern const char DEFAULT_WIFI_NAME[];
+extern const char DEFAULT_PASSWORD[];
+}
+
 /// Bridge class that connects an Arduino API style serial port (sending CAN
 /// frames via gridconnect format) to the OpenMRN core stack. This can be
 /// generally used for USB ports or TCP sockets.

--- a/arduino/examples/ESP32IOBoard/.gitignore
+++ b/arduino/examples/ESP32IOBoard/.gitignore
@@ -1,0 +1,1 @@
+wifi_params.cpp

--- a/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
+++ b/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
@@ -45,8 +45,8 @@ constexpr uint16_t OPENMRN_TCP_PORT = 12021L;
 
 WiFiServer openMRNServer(OPENMRN_TCP_PORT);
 
-const char* ssid     = "apname";
-const char* password = "password";
+const char* ssid     = DEFAULT_WIFI_NAME;
+const char* password = DEFAULT_PASSWORD;
 const char* hostname = "esp32mrn";
 
 static constexpr uint64_t NODE_ID = UINT64_C(0x050101011423);


### PR DESCRIPTION
Externalizes the wifi name and password parameters and adds .gitignore file to avoid them accidentally being checked in.