### PR TITLE
Split mDNS names to allow more flexibility in mDNS implementations.

### DIFF
--- a/applications/hub/targets/linux.x86/AvaHiMDNS.cxx
+++ b/applications/hub/targets/linux.x86/AvaHiMDNS.cxx
@@ -126,7 +126,7 @@ void mdns_publish(const char *name, uint16_t port)
 
     int result = avahi_entry_group_add_service(group, AVAHI_IF_UNSPEC,
         AVAHI_PROTO_UNSPEC, (AvahiPublishFlags)0, name,
-        openlcb::TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN, NULL, NULL, port,
+        openlcb::TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN_TCP, NULL, NULL, port,
         "platform=linux-x86-openmrn", NULL);
 
     if (result != 0)

--- a/applications/modbus_controller/targets/custom-cc3220sf/main.cxx
+++ b/applications/modbus_controller/targets/custom-cc3220sf/main.cxx
@@ -550,7 +550,7 @@ int appl_main(int argc, char *argv[])
 
     resetblink(WIFI_BLINK_CONNECTING);
     g_socket_client = new SocketClient(stack.service(),
-        openlcb::TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN, WIFI_HUB_HOSTNAME,
+        openlcb::TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN_TCP, WIFI_HUB_HOSTNAME,
         WIFI_HUB_PORT, client_connect_callback);
 
     // This command donates the main thread to the operation of the

--- a/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
+++ b/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
@@ -137,7 +137,8 @@ void setup() {
     openMRNServer.setNoDelay(true);
     openMRNServer.begin();
     MDNS.begin(hostname);
-    MDNS.addService(openlcb::TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN, "tcp", OPENMRN_TCP_PORT);
+    MDNS.addService(openlcb::TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN,
+        openlcb::TcpDefs::MDNS_PROTOCOL_TCP, OPENMRN_TCP_PORT);
 }
 
 void loop() {

--- a/arduino/examples/ESP32WiFiClientBridge/ESP32WiFiClientBridge.ino
+++ b/arduino/examples/ESP32WiFiClientBridge/ESP32WiFiClientBridge.ino
@@ -105,7 +105,8 @@ void setup() {
     openMRNServer.setNoDelay(true);
     openMRNServer.begin();
     MDNS.begin(hostname);
-    MDNS.addService(openlcb::TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN, "tcp", OPENMRN_TCP_PORT);
+    MDNS.addService(openlcb::TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN,
+        openlcb::TcpDefs::MDNS_PROTOCOL_TCP, OPENMRN_TCP_PORT);
 }
 
 void loop() {

--- a/src/openlcb/TcpDefs.cxx
+++ b/src/openlcb/TcpDefs.cxx
@@ -37,7 +37,10 @@
 
 namespace openlcb {
 
-const char TcpDefs::MDNS_SERVICE_NAME_TCP[] = "_openlcb-hub._tcp";
-const char TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN[] = "_openlcb-can._tcp";
+const char TcpDefs::MDNS_PROTOCOL_TCP[] = "_tcp";
+const char TcpDefs::MDNS_SERVICE_NAME_HUB[] = "_openlcb-hub";
+const char TcpDefs::MDNS_SERVICE_NAME_HUB_TCP[] = "_openlcb-hub._tcp";
+const char TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN[] = "_openlcb-can";
+const char TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN_TCP[] = "_openlcb-can._tcp";
 
 }  // namespace openlcb

--- a/src/openlcb/TcpDefs.hxx
+++ b/src/openlcb/TcpDefs.hxx
@@ -42,15 +42,15 @@ namespace openlcb {
 
 class TcpDefs {
 public:
-    // Protocol to be used for mDNS broadcast
+    /// Protocol to be used for mDNS broadcast
     static const char MDNS_PROTOCOL_TCP[];
-    // base name of the mDNS Service Name for mDNS broadcast as a hub
+    /// base name of the mDNS Service Name for mDNS broadcast as a hub
     static const char MDNS_SERVICE_NAME_HUB[];
-    // complete mDNS broadcast name for a TCP hub
+    /// complete mDNS broadcast name for a TCP hub
     static const char MDNS_SERVICE_NAME_HUB_TCP[];
-    // base name of the mDNS Service Name for mDNS broadcast as a client
+    /// base name of the mDNS Service Name for mDNS broadcast as a client
     static const char MDNS_SERVICE_NAME_GRIDCONNECT_CAN[];
-    // complete mDNS broadcast name for a TCP GridConnect protocol client
+    /// complete mDNS broadcast name for a TCP GridConnect protocol client
     static const char MDNS_SERVICE_NAME_GRIDCONNECT_CAN_TCP[];
 
 private:

--- a/src/openlcb/TcpDefs.hxx
+++ b/src/openlcb/TcpDefs.hxx
@@ -43,15 +43,15 @@ namespace openlcb {
 class TcpDefs {
 public:
     // Protocol to be used for mDNS broadcast
-    static const char TcpDefs::MDNS_PROTOCOL_TCP[];
+    static const char MDNS_PROTOCOL_TCP[];
     // base name of the mDNS Service Name for mDNS broadcast as a hub
-    static const char TcpDefs::MDNS_SERVICE_NAME_HUB[];
+    static const char MDNS_SERVICE_NAME_HUB[];
     // complete mDNS broadcast name for a TCP hub
-    static const char TcpDefs::MDNS_SERVICE_NAME_HUB_TCP[];
+    static const char MDNS_SERVICE_NAME_HUB_TCP[];
     // base name of the mDNS Service Name for mDNS broadcast as a client
-    static const char TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN[];
+    static const char MDNS_SERVICE_NAME_GRIDCONNECT_CAN[];
     // complete mDNS broadcast name for a TCP GridConnect protocol client
-    static const char TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN_TCP[];
+    static const char MDNS_SERVICE_NAME_GRIDCONNECT_CAN_TCP[];
 
 private:
     /// Nobody can construct this class.

--- a/src/openlcb/TcpDefs.hxx
+++ b/src/openlcb/TcpDefs.hxx
@@ -42,8 +42,16 @@ namespace openlcb {
 
 class TcpDefs {
 public:
-    static const char MDNS_SERVICE_NAME_TCP[];
-    static const char MDNS_SERVICE_NAME_GRIDCONNECT_CAN[];
+    // Protocol to be used for mDNS broadcast
+    static const char TcpDefs::MDNS_PROTOCOL_TCP[];
+    // base name of the mDNS Service Name for mDNS broadcast as a hub
+    static const char TcpDefs::MDNS_SERVICE_NAME_HUB[];
+    // complete mDNS broadcast name for a TCP hub
+    static const char TcpDefs::MDNS_SERVICE_NAME_HUB_TCP[];
+    // base name of the mDNS Service Name for mDNS broadcast as a client
+    static const char TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN[];
+    // complete mDNS broadcast name for a TCP GridConnect protocol client
+    static const char TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN_TCP[];
 
 private:
     /// Nobody can construct this class.


### PR DESCRIPTION
This PR splits the mDNS definitions to allow more flexibility in mDNS implementations.