### PR TITLE
Makes mDNS publishing on the cc32xx use the temporary bit.

### DIFF
--- a/src/freertos_drivers/net_cc32xx/CC32xxWiFi.cxx
+++ b/src/freertos_drivers/net_cc32xx/CC32xxWiFi.cxx
@@ -1138,7 +1138,7 @@ void mdns_publish(const char *name, const char *service, uint16_t port)
         sl_NetAppMDNSRegisterService((const signed char*)full_name.c_str(),
                                      full_name.size(),
                                      (const signed char*)"OLCB", strlen("OLCB"), 
-                                     port, 200, 0);
+                                     port, 200, SL_NETAPP_MDNS_OPTIONS_IS_NOT_PERSISTENT);
 }
 
 extern "C"


### PR DESCRIPTION
This avoids services from persisting between firmware upgrades.