### PR TITLE
Arduino: dynamically create XML file

### DIFF
--- a/arduino/OpenMRN.cpp
+++ b/arduino/OpenMRN.cpp
@@ -34,6 +34,9 @@
 
 #include <OpenMRN.h>
 
+#ifdef HAVE_FILESYSTEM
+#include "utils/FileUtils.hxx"
+#endif
 
 extern const char DEFAULT_WIFI_NAME[] __attribute__((weak)) = "defaultap";
 extern const char DEFAULT_PASSWORD[] __attribute__((weak)) = "defaultpw";

--- a/arduino/OpenMRN.h
+++ b/arduino/OpenMRN.h
@@ -419,7 +419,6 @@ public:
         }
         if (need_write)
         {
-
             printf(
                 "Updating CDI file %s (len %u)", filename, cdi_string.size());
             write_string_to_file(filename, cdi_string);

--- a/arduino/OpenMRN.h
+++ b/arduino/OpenMRN.h
@@ -36,11 +36,21 @@
 #ifndef _ARDUINO_OPENMRN_H_
 #define _ARDUINO_OPENMRN_H_
 
+#ifdef ESP32
+#define HAVE_FILESYSTEM
+#endif
+
 #include "freertos_drivers/arduino/Can.hxx"
 #include "openlcb/SimpleStack.hxx"
 #include "utils/GridConnectHub.hxx"
 #include "utils/Uninitialized.hxx"
 #include "freertos_drivers/arduino/ArduinoGpio.hxx"
+
+
+#ifdef HAVE_FILESYSTEM
+string read_file_to_string(const string &filename);
+void write_string_to_file(const string &filename, const string &data);
+#endif
 
 extern "C" {
 extern const char DEFAULT_WIFI_NAME[];
@@ -367,6 +377,72 @@ public:
     {
         loopMembers_.push_back(new CanBridge(port, stack()->can_hub()));
     }
+
+#ifdef HAVE_FILESYSTEM
+    /// Creates the XML representation of the configuration structure and saves
+    /// it to a file on the filesystem. Must be called after SPIFFS.begin() but
+    /// before calling the {\link create_config_file_if_needed} method. The
+    /// config file will be re-written whenever there was a change in the
+    /// contents. It is also necessary to declare the static compiled-in CDI to
+    /// be empty:
+    /// ```
+    ///    namespace openlcb {
+    ///    // This will stop openlcb from exporting the CDI memory space
+    ///    // upon start.
+    ///    extern const char CDI_DATA[] = "";
+    ///    }  // namespace openlcb
+    /// ```
+    /// @param cfg is the global configuration instance (usually called cfg).
+    /// @param filename is where the xml file can be stored on the
+    /// filesystem. For example "/spiffs/cdi.xml".
+    template <class ConfigDef>
+    void create_config_descriptor_xml(
+        const ConfigDef &config, const char *filename)
+    {
+        string cdi_string;
+        ConfigDef cfg(config.offset());
+        cfg.config_renderer().render_cdi(&cdi_string);
+
+        bool need_write = false;
+        FILE *ff = fopen(filename, "rb");
+        if (!ff)
+        {
+            need_write = true;
+        }
+        else
+        {
+            fclose(ff);
+            string current_str = read_file_to_string(filename);
+            if (current_str != cdi_string)
+            {
+                need_write = true;
+            }
+        }
+        if (need_write)
+        {
+
+            printf("Updating CDI file %s (len %u)", filename,
+                cdi_string.size());
+            write_string_to_file(filename, cdi_string);
+        }
+
+        // Creates list of event IDs for factory reset.
+        auto* v = new vector<uint16_t>();
+        cfg.handle_events([v](unsigned o)
+        {
+            v->push_back(o);
+        });
+        v->push_back(0);
+        stack()->set_event_offsets(v);
+        // We leak v because it has to stay alive for the entire lifetime of
+        // the stack.
+
+        // Exports the file memory space.
+        openlcb::MemorySpace *space = new openlcb::ROFileMemorySpace(filename);
+        stack()->memory_config_handler()->registry()->insert(
+            stack()->node(), openlcb::MemoryConfigDefs::SPACE_CDI, space);
+    }
+#endif
 
 private:
     /// Callback from the loop() method. Internally called.

--- a/arduino/OpenMRN.h
+++ b/arduino/OpenMRN.h
@@ -46,7 +46,6 @@
 #include "utils/Uninitialized.hxx"
 #include "freertos_drivers/arduino/ArduinoGpio.hxx"
 
-
 #ifdef HAVE_FILESYSTEM
 string read_file_to_string(const string &filename);
 void write_string_to_file(const string &filename, const string &data);
@@ -421,17 +420,14 @@ public:
         if (need_write)
         {
 
-            printf("Updating CDI file %s (len %u)", filename,
-                cdi_string.size());
+            printf(
+                "Updating CDI file %s (len %u)", filename, cdi_string.size());
             write_string_to_file(filename, cdi_string);
         }
 
         // Creates list of event IDs for factory reset.
-        auto* v = new vector<uint16_t>();
-        cfg.handle_events([v](unsigned o)
-        {
-            v->push_back(o);
-        });
+        auto *v = new vector<uint16_t>();
+        cfg.handle_events([v](unsigned o) { v->push_back(o); });
         v->push_back(0);
         stack()->set_event_offsets(v);
         // We leak v because it has to stay alive for the entire lifetime of

--- a/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
+++ b/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
@@ -40,7 +40,6 @@
 
 #include <OpenMRN.h>
 #include <openlcb/TcpDefs.hxx>
-#include <utils/FileUtils.hxx>
 #include "config.h"
 
 constexpr uint16_t OPENMRN_TCP_PORT = 12021L;
@@ -126,40 +125,8 @@ extern const char CDI_DATA[] = "";
 
 void setup() {
     SPIFFS.begin(true);
-    string cdi_string;
-    cfg.config_renderer().render_cdi(&cdi_string);
-
-    bool need_write = false;
-    FILE* ff = fopen(CDI_FILENAME, "rb");
-    if (!ff) {
-      need_write = true;
-    } else {
-      fclose(ff);
-      string current_str = read_file_to_string(CDI_FILENAME);
-      if (current_str != cdi_string) {
-        need_write = true;      
-      }
-    }
-    if (need_write) {
-
-       int fd = ::open(CDI_FILENAME, O_CREAT|O_TRUNC|O_RDWR, S_IRUSR | S_IWUSR);
-        if (fd < 0)
-        {
-            printf("Failed to create config file: fd %d errno %d: %s\n",
-                   fd, errno, strerror(errno));
-            DIE();
-        }
-        close(fd);
-      
-      printf("Updating CDI file %s (len %u)", CDI_FILENAME, cdi_string.size());
-      write_string_to_file(CDI_FILENAME, cdi_string);      
-    }
-
-    openlcb::MemorySpace* space = new openlcb::ROFileMemorySpace(CDI_FILENAME);
-    openmrn.stack()->memory_config_handler()->registry()->insert(
-            openmrn.stack()->node(), openlcb::MemoryConfigDefs::SPACE_CDI, space);
-
     Serial.begin(115200L);
+    openmrn.create_config_descriptor_xml(cfg, CDI_FILENAME);
 
     printf("\nConnecting to: %s\n", ssid);
     WiFi.begin(ssid, password);

--- a/src/openlcb/SimpleStack.cxx
+++ b/src/openlcb/SimpleStack.cxx
@@ -293,7 +293,7 @@ int SimpleCanStackBase::check_version_and_factory_reset(
 /// exported by the cdi compilation mechanism (in CompileCdiMain.cxx) and
 /// defined by cdi.o for the linker.
 extern const uint16_t CDI_EVENT_OFFSETS[];
-const uint16_t* cdi_event_offsets_ptr = CDI_EVENT_OFFSETS;
+const uint16_t *cdi_event_offsets_ptr = CDI_EVENT_OFFSETS;
 
 void SimpleCanStackBase::set_event_offsets(const vector<uint16_t> *offsets)
 {

--- a/src/openlcb/SimpleStack.cxx
+++ b/src/openlcb/SimpleStack.cxx
@@ -293,6 +293,12 @@ int SimpleCanStackBase::check_version_and_factory_reset(
 /// exported by the cdi compilation mechanism (in CompileCdiMain.cxx) and
 /// defined by cdi.o for the linker.
 extern const uint16_t CDI_EVENT_OFFSETS[];
+const uint16_t* cdi_event_offsets_ptr = CDI_EVENT_OFFSETS;
+
+void SimpleCanStackBase::set_event_offsets(const vector<uint16_t> *offsets)
+{
+    cdi_event_offsets_ptr = &(*offsets)[0];
+}
 
 void SimpleCanStackBase::factory_reset_all_events(
     const InternalConfigData &cfg, int fd)
@@ -300,19 +306,19 @@ void SimpleCanStackBase::factory_reset_all_events(
     // First we find the event count.
     uint16_t new_next_event = cfg.next_event().read(fd);
     uint16_t next_event = new_next_event;
-    for (unsigned i = 0; CDI_EVENT_OFFSETS[i]; ++i)
+    for (unsigned i = 0; cdi_event_offsets_ptr[i]; ++i)
     {
         ++new_next_event;
     }
     // We block off the event IDs first.
     cfg.next_event().write(fd, new_next_event);
     // Then we write them to eeprom.
-    for (unsigned i = 0; CDI_EVENT_OFFSETS[i]; ++i)
+    for (unsigned i = 0; cdi_event_offsets_ptr[i]; ++i)
     {
         EventId id = node()->node_id();
         id <<= 16;
         id |= next_event++;
-        EventConfigEntry(CDI_EVENT_OFFSETS[i]).write(fd, id);
+        EventConfigEntry(cdi_event_offsets_ptr[i]).write(fd, id);
     }
 }
 

--- a/src/openlcb/SimpleStack.hxx
+++ b/src/openlcb/SimpleStack.hxx
@@ -315,8 +315,8 @@ public:
     /// dyamically created instead of statically linked.
     /// @param offsets is a vector with the data. The last entry must be
     /// zero. This vector must outlive the SimpleStack object.
-    void set_event_offsets(const vector<uint16_t>* offsets);
-    
+    void set_event_offsets(const vector<uint16_t> *offsets);
+
     /// Helper function to send an event report to the bus. Performs
     /// synchronous (dynamic) memory allocation so use it sparingly and when
     /// there is sufficient amount of RAM available.

--- a/src/openlcb/SimpleStack.hxx
+++ b/src/openlcb/SimpleStack.hxx
@@ -309,6 +309,14 @@ public:
     /// Overwrites all events in the eeprom with a brand new event ID.
     void factory_reset_all_events(const InternalConfigData &ofs, int fd);
 
+    /// Call this function at the beginning of appl_main, just before {\link
+    /// check_version_and_factory_reset} or {\link
+    /// create_config_file_if_needed} if the list of event offsets are
+    /// dyamically created instead of statically linked.
+    /// @param offsets is a vector with the data. The last entry must be
+    /// zero. This vector must outlive the SimpleStack object.
+    void set_event_offsets(const vector<uint16_t>* offsets);
+    
     /// Helper function to send an event report to the bus. Performs
     /// synchronous (dynamic) memory allocation so use it sparingly and when
     /// there is sufficient amount of RAM available.


### PR DESCRIPTION
Adds code to the arduino helper library to generate the XML representation of the CDI in the target, and save it to a local filesystem such as SPIFFS.
Extends the base library to allow dynamicaly created CDI event offsets.