### PR TITLE
arduino esp32 updates

### DIFF
--- a/arduino/OpenMRN.h
+++ b/arduino/OpenMRN.h
@@ -36,24 +36,24 @@
 #ifndef _ARDUINO_OPENMRN_H_
 #define _ARDUINO_OPENMRN_H_
 
-#ifdef ESP32
+#if defined(ESP32)
 #define HAVE_FILESYSTEM
 #endif
 
+#include "freertos_drivers/arduino/ArduinoGpio.hxx"
 #include "freertos_drivers/arduino/Can.hxx"
 #include "openlcb/SimpleStack.hxx"
 #include "utils/GridConnectHub.hxx"
 #include "utils/Uninitialized.hxx"
-#include "freertos_drivers/arduino/ArduinoGpio.hxx"
 
-#ifdef HAVE_FILESYSTEM
+#if defined(HAVE_FILESYSTEM)
 string read_file_to_string(const string &filename);
 void write_string_to_file(const string &filename, const string &data);
 #endif
 
 extern "C" {
-extern const char DEFAULT_WIFI_NAME[];
-extern const char DEFAULT_PASSWORD[];
+    extern const char DEFAULT_WIFI_NAME[];
+    extern const char DEFAULT_PASSWORD[];
 }
 
 /// Bridge class that connects an Arduino API style serial port (sending CAN
@@ -285,12 +285,12 @@ private:
 
 #if defined(ESP32)
 /// Default stack size to use for the OpenMRN background task on the ESP32 platform.
-constexpr uint32_t OPENMRN_STACK_SIZE = 5120L;
+constexpr uint32_t OPENMRN_STACK_SIZE = 4096L;
 
 /// Default thread priority for the OpenMRN background task on the ESP32 platform.
 constexpr UBaseType_t OPENMRN_TASK_PRIORITY = tskIDLE_PRIORITY + 1;
 
-constexpr TickType_t OPENMRN_TASK_TICK_DELAY = pdMS_TO_TICKS(50);
+constexpr TickType_t OPENMRN_TASK_TICK_DELAY = pdMS_TO_TICKS(1);
 #endif
 
 /// Main class to declare the OpenMRN stack. Create one instance of this in the
@@ -377,7 +377,7 @@ public:
         loopMembers_.push_back(new CanBridge(port, stack()->can_hub()));
     }
 
-#ifdef HAVE_FILESYSTEM
+#if defined(HAVE_FILESYSTEM)
     /// Creates the XML representation of the configuration structure and saves
     /// it to a file on the filesystem. Must be called after SPIFFS.begin() but
     /// before calling the {\link create_config_file_if_needed} method. The
@@ -437,7 +437,7 @@ public:
         stack()->memory_config_handler()->registry()->insert(
             stack()->node(), openlcb::MemoryConfigDefs::SPACE_CDI, space);
     }
-#endif
+#endif // HAVE_FILESYSTEM
 
 private:
     /// Callback from the loop() method. Internally called.

--- a/arduino/OpenMRN.h
+++ b/arduino/OpenMRN.h
@@ -340,7 +340,7 @@ public:
         for (auto *e : loopMembers_)
         {
 #if defined(ESP32)
-            /// Feed the watchdog so it doesn't reset the ESP32
+            // Feed the watchdog so it doesn't reset the ESP32
             esp_task_wdt_reset();
 #endif // ESP32
             e->run();
@@ -442,15 +442,15 @@ public:
             write_string_to_file(filename, cdi_string);
         }
 
-        /// Creates list of event IDs for factory reset.
+        // Creates list of event IDs for factory reset.
         auto *v = new vector<uint16_t>();
         cfg.handle_events([v](unsigned o) { v->push_back(o); });
         v->push_back(0);
         stack()->set_event_offsets(v);
-        /// We leak v because it has to stay alive for the entire lifetime of
-        /// the stack.
+        // We leak v because it has to stay alive for the entire lifetime of
+        // the stack.
 
-        /// Exports the file memory space.
+        // Exports the file memory space.
         openlcb::MemorySpace *space = new openlcb::ROFileMemorySpace(filename);
         stack()->memory_config_handler()->registry()->insert(
             stack()->node(), openlcb::MemoryConfigDefs::SPACE_CDI, space);
@@ -470,10 +470,10 @@ private:
         OpenMRN *openmrn = reinterpret_cast<OpenMRN *>(param);
         while(true)
         {
-            /// Feed the watchdog so it doesn't reset the ESP32
+            // Feed the watchdog so it doesn't reset the ESP32
             esp_task_wdt_reset();
 
-            /// yield to other tasks that are running on the ESP32
+            // yield to other tasks that are running on the ESP32
             openmrn->loop();
             vTaskDelay(OPENMRN_TASK_TICK_DELAY);
         }

--- a/arduino/OpenMRN.h
+++ b/arduino/OpenMRN.h
@@ -42,6 +42,9 @@
 
 #include "freertos_drivers/arduino/ArduinoGpio.hxx"
 #include "freertos_drivers/arduino/Can.hxx"
+#if defined(ESP32)
+#include "freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx"
+#endif
 #include "openlcb/SimpleStack.hxx"
 #include "utils/GridConnectHub.hxx"
 #include "utils/Uninitialized.hxx"

--- a/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
+++ b/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
@@ -58,9 +58,9 @@ WiFiServer openMRNServer(OPENMRN_TCP_PORT);
 //     const char DEFAULT_WIFI_NAME[] = "linksys";
 //     const char DEFAULT_PASSWORD[] = "theTRUEsupers3cr3t";
 
-// This is the name of the WiFi network (access point) to connect to.
+/// This is the name of the WiFi network (access point) to connect to.
 const char* ssid     = DEFAULT_WIFI_NAME;
-// Password of the wifi network.
+/// Password of the wifi network.
 const char* password = DEFAULT_PASSWORD;
 const char* hostname = "esp32mrn";
 

--- a/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
+++ b/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
@@ -74,48 +74,61 @@ string somewhere("abcdef");
 // layout. The argument of offset zero is ignored and will be removed later.
 static constexpr openlcb::ConfigDef cfg(0);
 
-#if !defined(LED_BUILTIN)
-//constexpr uint8_t LED_BUILTIN = 13;
-#endif
+// Declare output pins
+GPIO_PIN(IO0, GpioOutputSafeLow, 2);
+GPIO_PIN(IO1, GpioOutputSafeLow, 4);
+GPIO_PIN(IO2, GpioOutputSafeLow, 5);
+GPIO_PIN(IO3, GpioOutputSafeLow, 16);
+GPIO_PIN(IO4, GpioOutputSafeLow, 17);
+GPIO_PIN(IO5, GpioOutputSafeLow, 18);
+GPIO_PIN(IO6, GpioOutputSafeLow, 19);
+GPIO_PIN(IO7, GpioOutputSafeLow, 23);
 
-GPIO_PIN(LED, GpioOutputSafeLow, LED_BUILTIN);
+// Declare input pins, these are using analog pins as digital inputs
+// NOTE: pins 25 and 26 can not safely be used as analog pins while
+// WiFi is active.
+GPIO_PIN(IO8, GpioInputPU, 32);
+GPIO_PIN(IO9, GpioInputPU, 33);
+GPIO_PIN(IO10, GpioInputPU, 34);
+GPIO_PIN(IO11, GpioInputPU, 35);
+GPIO_PIN(IO12, GpioInputPU, 36);
+GPIO_PIN(IO13, GpioInputPU, 39);
+GPIO_PIN(IO14, GpioInputPU, 25);
+GPIO_PIN(IO15, GpioInputPU, 26);
 
-//openlcb::ConfiguredConsumer onboard_led(
-//    openmrn.stack()->node(), cfg.seg().consumers().entry<0>(), LED_Pin());
+openlcb::ConfiguredConsumer IO0_consumer(
+    openmrn.stack()->node(), cfg.seg().consumers().entry<0>(), IO0_Pin());
+openlcb::ConfiguredConsumer IO1_consumer(
+    openmrn.stack()->node(), cfg.seg().consumers().entry<1>(), IO1_Pin());
+openlcb::ConfiguredConsumer IO2_consumer(
+    openmrn.stack()->node(), cfg.seg().consumers().entry<2>(), IO2_Pin());
+openlcb::ConfiguredConsumer IO3_consumer(
+    openmrn.stack()->node(), cfg.seg().consumers().entry<3>(), IO3_Pin());
+openlcb::ConfiguredConsumer IO4_consumer(
+    openmrn.stack()->node(), cfg.seg().consumers().entry<4>(), IO4_Pin());
+openlcb::ConfiguredConsumer IO5_consumer(
+    openmrn.stack()->node(), cfg.seg().consumers().entry<5>(), IO5_Pin());
+openlcb::ConfiguredConsumer IO6_consumer(
+    openmrn.stack()->node(), cfg.seg().consumers().entry<6>(), IO6_Pin());
+openlcb::ConfiguredConsumer IO7_consumer(
+    openmrn.stack()->node(), cfg.seg().consumers().entry<7>(), IO7_Pin());
 
-class WiFiClientAdapter {
-public:
-    WiFiClientAdapter(WiFiClient client) : client_(client){
-        client_.setNoDelay(true);
-        printf("[%s] OpenMRN GridConnect client connected.\n",
-            client_.remoteIP().toString().c_str());
-    }
-    // on the ESP32 there is no TX limit method
-    size_t availableForWrite() {
-        return client_.connected();
-    }
-    size_t write(const char *buffer, size_t len) {
-        if(client_.connected()) {
-            return client_.write(buffer, len);  
-        }
-        return 0;
-    }
-    size_t available() {
-        if(client_.connected()) {
-            return client_.available();
-        }
-        return 0;
-    }
-    size_t read(const char *buffer, size_t len) {
-        size_t bytesRead = 0;
-        if(client_.connected()) {
-            bytesRead = client_.read((uint8_t *)buffer, len);
-        }
-        return bytesRead;
-    }
-private:
-    WiFiClient client_;
-};
+openlcb::ConfiguredProducer IO8_producer(
+    openmrn.stack()->node(), cfg.seg().producers().entry<0>(), IO8_Pin());
+openlcb::ConfiguredProducer IO9_producer(
+    openmrn.stack()->node(), cfg.seg().producers().entry<1>(), IO9_Pin());
+openlcb::ConfiguredProducer IO10_producer(
+    openmrn.stack()->node(), cfg.seg().producers().entry<2>(), IO10_Pin());
+openlcb::ConfiguredProducer IO11_producer(
+    openmrn.stack()->node(), cfg.seg().producers().entry<3>(), IO11_Pin());
+openlcb::ConfiguredProducer IO12_producer(
+    openmrn.stack()->node(), cfg.seg().producers().entry<4>(), IO12_Pin());
+openlcb::ConfiguredProducer IO13_producer(
+    openmrn.stack()->node(), cfg.seg().producers().entry<5>(), IO13_Pin());
+openlcb::ConfiguredProducer IO14_producer(
+    openmrn.stack()->node(), cfg.seg().producers().entry<6>(), IO14_Pin());
+openlcb::ConfiguredProducer IO15_producer(
+    openmrn.stack()->node(), cfg.seg().producers().entry<7>(), IO15_Pin());
 
 const char CDI_FILENAME[] = "/spiffs/cdi.xml";
 namespace openlcb {
@@ -154,9 +167,8 @@ void loop() {
     if(openMRNServer.hasClient()) {
         WiFiClient client = openMRNServer.available();
         if(client) {
-            openmrn.add_gridconnect_port(new WiFiClientAdapter(client));
+            openmrn.add_gridconnect_port(new Esp32WiFiClientAdapter(client));
         }
     }
     openmrn.loop();
-    //vTaskDelay(pdMS_TO_TICKS(50));
 }

--- a/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
+++ b/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
@@ -58,16 +58,18 @@ WiFiServer openMRNServer(OPENMRN_TCP_PORT);
 //     const char DEFAULT_WIFI_NAME[] = "linksys";
 //     const char DEFAULT_PASSWORD[] = "theTRUEsupers3cr3t";
 
-/// This is the name of the WiFi network (access point) to connect to.
+// This is the name of the WiFi network (access point) to connect to.
 const char* ssid     = DEFAULT_WIFI_NAME;
-/// Password of the wifi network.
+// Password of the wifi network.
 const char* password = DEFAULT_PASSWORD;
 const char* hostname = "esp32mrn";
 
 static constexpr uint64_t NODE_ID = UINT64_C(0x050101011423);
 OpenMRN openmrn(NODE_ID);
 
-string somewhere("abcdef");
+// note the dummy string below is required due to a bug in the GCC compiler
+// for the ESP32
+string dummystring("abcdef");
 // ConfigDef comes from config.hxx and is specific to the particular device and
 // target. It defines the layout of the configuration memory space and is also
 // used to generate the cdi.xml file. Here we instantiate the configuration
@@ -130,45 +132,110 @@ openlcb::ConfiguredProducer IO14_producer(
 openlcb::ConfiguredProducer IO15_producer(
     openmrn.stack()->node(), cfg.seg().producers().entry<7>(), IO15_Pin());
 
-const char CDI_FILENAME[] = "/spiffs/cdi.xml";
 namespace openlcb {
-// This will stop openlcb from exporting the CDI memory space upon start.
-extern const char CDI_DATA[] = "";
+    // Name of CDI.xml to generate dynamically.
+    const char CDI_FILENAME[] = "/spiffs/cdi.xml";
+
+    // This will stop openlcb from exporting the CDI memory space upon start.
+    extern const char CDI_DATA[] = "";
+
+    // Path to where OpenMRN should persist general configuration data.
+    extern const char *const CONFIG_FILENAME = "/spiffs/openlcb_config";
+
+    // The size of the memory space to export over the above device.
+    extern const size_t CONFIG_FILE_SIZE = cfg.seg().size() + cfg.seg().offset();
+
+    // Default to store the dynamic SNIP data is stored in the same persistant
+    // data file as general configuration data.
+    extern const char *const SNIP_DYNAMIC_FILENAME = CONFIG_FILENAME;
 }
 
 void setup() {
-    SPIFFS.begin(true);
     Serial.begin(115200L);
-    openmrn.create_config_descriptor_xml(cfg, CDI_FILENAME);
 
     printf("\nConnecting to: %s\n", ssid);
     WiFi.begin(ssid, password);
-
-    while (WiFi.status() != WL_CONNECTED) {
+    uint8_t attempts = 60;
+    while (WiFi.status() != WL_CONNECTED && attempts--)
+    {
         delay(500);
         Serial.print(".");
     }
-    // This makes the wifi much more responsive. Since we are plugged in we don't care about the increased power usage. Disable when on battery.
+    if(WiFi.status() != WL_CONNECTED)
+    {
+        printf("\nFailed to connect to WiFi, restarting\n");
+        ESP.restart();
+
+        // in case the above call doesn't trigger restart, force WDT to restart the ESP32
+        while(1)
+        {
+            // The ESP32 has built in watchdog timers that as of arduino-esp32 1.0.1 are
+            // enabled on both core 0 (OS core) and core 1 (Arduino core). It usually
+            // takes a couple seconds of an endless loop such as this one to trigger the
+            // WDT to force a restart.
+        }
+    }
+
+    // This makes the wifi much more responsive. Since we are plugged in we don't care
+    // about the increased power usage. Disable when on battery.
     WiFi.setSleep(false);
 
     printf("\nWiFi connected, IP address: %s\n", WiFi.localIP().toString().c_str());
 
-    openmrn.stack()->print_all_packets();
-    //openmrn.start_background_task();
+    // Initialize the SPIFFS filesystem as our persistence layer
+    if(!SPIFFS.begin())
+    {
+        printf("SPIFFS failed to mount, attempting to format and remount\n");
+        if(!SPIFFS.begin(true))
+        {
+            printf("SPIFFS mount failed even with format, giving up!\n");
+            while(1)
+            {
+                // Unable to start SPIFFS successfully, give up and wait
+                // for WDT to kick in
+            }
+        }
+    }
 
+    // Create the CDI.xml dynamically
+    openmrn.create_config_descriptor_xml(cfg, openlcb::CDI_FILENAME);
+
+    // Create the default internal configuration file
+    openmrn.stack()->create_config_file_if_needed(cfg.seg().internal_config(),
+        openlcb::CANONICAL_VERSION, openlcb::CONFIG_FILE_SIZE);
+
+    // Start the OpenMRN stack
+    openmrn.begin();
+
+    // Dump all packets as they are sent/received.
+    // Note: This should not be enabled in deployed nodes as it will
+    // have performance impact.
+    openmrn.stack()->print_all_packets();
+
+    // Start the TCP/IP listener
     openMRNServer.setNoDelay(true);
     openMRNServer.begin();
+
+    // Start the mDNS subsystem
     MDNS.begin(hostname);
+
+    // Broadcast this node's hostname with the mDNS service name
+    // for a TCP GridConnect endpoint.
     MDNS.addService(openlcb::TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN,
         openlcb::TcpDefs::MDNS_PROTOCOL_TCP, OPENMRN_TCP_PORT);
 }
 
 void loop() {
+    // if the TCP/IP listener has a new client accept it and add it
+    // as a new GridConnect port.
     if(openMRNServer.hasClient()) {
         WiFiClient client = openMRNServer.available();
         if(client) {
             openmrn.add_gridconnect_port(new Esp32WiFiClientAdapter(client));
         }
     }
+
+    // Call the OpenMRN executor, this needs to be done as often
+    // as possible from the loop() method. 
     openmrn.loop();
 }

--- a/arduino/examples/ESP32IOBoard/config.h
+++ b/arduino/examples/ESP32IOBoard/config.h
@@ -23,11 +23,11 @@ namespace openlcb
 /// - the Simple Node Ident Info Protocol will return this data
 /// - the ACDI memory space will contain this data.
 extern const SimpleNodeStaticValues SNIP_STATIC_DATA = {
-    4,               "OpenMRN", "ESP32 IO Board",
-    "Arduino", "1.00"};
+    4,               "OpenMRN", "Arduino IO Board",
+    ARDUINO_VARIANT, "1.00"};
 
-#define NUM_OUTPUTS 4
-#define NUM_INPUTS 1
+constexpr uint8_t NUM_OUTPUTS = 8;
+constexpr uint8_t NUM_INPUTS = 8;
 
 /// Declares a repeated group of a given base group and number of repeats. The
 /// ProducerConfig and ConsumerConfig groups represent the configuration layout

--- a/arduino/examples/ESP32SerialBridge/config.h
+++ b/arduino/examples/ESP32SerialBridge/config.h
@@ -1,5 +1,5 @@
-#ifndef _ARDUINO_EXAMPLE_ESP32IOBOARD_CONFIG_H_
-#define _ARDUINO_EXAMPLE_ESP32IOBOARD_CONFIG_H_
+#ifndef _ARDUINO_EXAMPLE_ESP32SERIALBRIDGE_CONFIG_H_
+#define _ARDUINO_EXAMPLE_ESP32SERIALBRIDGE_CONFIG_H_
 
 #include "openlcb/ConfiguredConsumer.hxx"
 #include "openlcb/ConfiguredProducer.hxx"
@@ -23,18 +23,8 @@ namespace openlcb
 /// - the Simple Node Ident Info Protocol will return this data
 /// - the ACDI memory space will contain this data.
 extern const SimpleNodeStaticValues SNIP_STATIC_DATA = {
-    4,               "OpenMRN", "Arduino IO Board",
+    4,               "OpenMRN", "Arduino Serial Bridge",
     ARDUINO_VARIANT, "1.00"};
-
-constexpr uint8_t NUM_OUTPUTS = 8;
-constexpr uint8_t NUM_INPUTS = 8;
-
-/// Declares a repeated group of a given base group and number of repeats. The
-/// ProducerConfig and ConsumerConfig groups represent the configuration layout
-/// needed by the ConfiguredProducer and ConfiguredConsumer classes, and come
-/// from their respective hxx file.
-using AllConsumers = RepeatedGroup<ConsumerConfig, NUM_OUTPUTS>;
-using AllProducers = RepeatedGroup<ProducerConfig, NUM_INPUTS>;
 
 /// Modify this value every time the EEPROM needs to be cleared on the node
 /// after an update.
@@ -46,8 +36,6 @@ CDI_GROUP(IoBoardSegment, Segment(MemoryConfigDefs::SPACE_CONFIG), Offset(128));
 /// Each entry declares the name of the current entry, then the type and then
 /// optional arguments list.
 CDI_GROUP_ENTRY(internal_config, InternalConfigData);
-CDI_GROUP_ENTRY(consumers, AllConsumers, Name("Outputs"));
-CDI_GROUP_ENTRY(producers, AllProducers, Name("Inputs"));
 CDI_GROUP_END();
 
 /// This segment is only needed temporarily until there is program code to set
@@ -76,4 +64,4 @@ CDI_GROUP_END();
 
 } // namespace openlcb
 
-#endif // _ARDUINO_EXAMPLE_ESP32IOBOARD_CONFIG_H_
+#endif // _ARDUINO_EXAMPLE_ESP32SERIALBRIDGE_CONFIG_H_

--- a/arduino/libify.sh
+++ b/arduino/libify.sh
@@ -5,10 +5,12 @@ OPENMRNPATH=$2
 
 if [ "${TARGET_LIB_DIR}x" == "x" ]; then
     echo "TARGET_LIB_DIR NOT DEFINED"
+    exit 1
 fi
 
 if [ "${OPENMRNPATH}x" == "x" ]; then
     echo "OPENMRNPATH NOT DEFINED"
+    exit 1
 fi
 
 cp ${OPENMRNPATH}/arduino/library.json \

--- a/src/freertos_drivers/arduino/Can.hxx
+++ b/src/freertos_drivers/arduino/Can.hxx
@@ -34,8 +34,8 @@
  */
 
 // This include is exclusive against freertos_drivers/common/Can.hxx
-#ifndef _FREERTOS_DRIVERS_COMMON_CAN_HXX_
-#define _FREERTOS_DRIVERS_COMMON_CAN_HXX_
+#ifndef _FREERTOS_DRIVERS_ARDUINO_CAN_HXX_
+#define _FREERTOS_DRIVERS_ARDUINO_CAN_HXX_
 
 #include "DeviceBuffer.hxx"
 #include "can_frame.h"
@@ -125,4 +125,4 @@ private:
     DISALLOW_COPY_AND_ASSIGN(Can);
 };
 
-#endif /* _FREERTOS_DRIVERS_COMMON_CAN_HXX_ */
+#endif /* _FREERTOS_DRIVERS_ARDUINO_CAN_HXX_ */

--- a/src/freertos_drivers/arduino/Esp32HardwareSerialAdapter.hxx
+++ b/src/freertos_drivers/arduino/Esp32HardwareSerialAdapter.hxx
@@ -24,7 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * \file Esp32WiFiClientAdapter.hxx
+ * \file Esp32HardwareSerialAdapter.hxx
  *
  * On the ESP32 the HardwareSerial code does not have a read(const char *, size_t)
  * method so it is necessary to wrap it here.
@@ -33,7 +33,6 @@
  * @date 20 January 2019
  */
 
-// This include is exclusive against freertos_drivers/arduino/Esp32HardwareSerialAdapter.hxx
 #ifndef _FREERTOS_DRIVERS_ARDUINO_ESP32SERIAL_HXX_
 #define _FREERTOS_DRIVERS_ARDUINO_ESP32SERIAL_HXX_
 

--- a/src/freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
+++ b/src/freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
@@ -42,7 +42,7 @@
 
 class Esp32WiFiClientAdapter {
 public:
-    WiFiClientAdapter(WiFiClient client) : client_(client){
+    Esp32WiFiClientAdapter(WiFiClient client) : client_(client){
         client_.setNoDelay(true);
     }
     // on the ESP32 there is no TX limit method

--- a/src/freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
+++ b/src/freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
@@ -33,7 +33,6 @@
  * @date 13 January 2019
  */
 
-// This include is exclusive against freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
 #ifndef _FREERTOS_DRIVERS_ARDUINO_ESP32WIFI_HXX_
 #define _FREERTOS_DRIVERS_ARDUINO_ESP32WIFI_HXX_
 

--- a/src/freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
+++ b/src/freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
@@ -24,7 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * \file Can.hxx
+ * \file Esp32WiFiClientAdapter.hxx
  *
  * ESP32 adapter code using the WiFiClient provided by the WiFiServer code
  * for interfacing with the OpenMRN stack.

--- a/src/freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
+++ b/src/freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
@@ -33,7 +33,7 @@
  * @date 13 January 2019
  */
 
-// This include is exclusive against freertos_drivers/common/Can.hxx
+// This include is exclusive against freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
 #ifndef _FREERTOS_DRIVERS_ARDUINO_ESP32WIFI_HXX_
 #define _FREERTOS_DRIVERS_ARDUINO_ESP32WIFI_HXX_
 

--- a/src/openlcb/SimpleStack.cxx
+++ b/src/openlcb/SimpleStack.cxx
@@ -72,12 +72,12 @@ SimpleCanStack::SimpleCanStack(const openlcb::NodeID node_id)
 
 void SimpleCanStackBase::start_stack(bool delay_start)
 {
-#ifndef ARDUINO
+#if !defined(ARDUINO) || defined(ESP32)
     // Opens the eeprom file and sends configuration update commands to all
     // listeners.
     configUpdateFlow_.open_file(CONFIG_FILENAME);
     configUpdateFlow_.init_flow();
-#endif
+#endif // NOT ARDUINO, YES ESP32
 
     if (!delay_start) {
         // Bootstraps the alias allocation process.
@@ -107,7 +107,7 @@ void SimpleCanStackBase::default_start_node()
             node(), MemoryConfigDefs::SPACE_ACDI_SYS, space);
         additionalComponents_.emplace_back(space);
     }
-#ifndef ARDUINO
+#if !defined(ARDUINO) || defined(ESP32)
     {
         auto *space = new FileMemorySpace(
             SNIP_DYNAMIC_FILENAME, sizeof(SimpleNodeDynamicValues));
@@ -115,7 +115,7 @@ void SimpleCanStackBase::default_start_node()
             node(), MemoryConfigDefs::SPACE_ACDI_USR, space);
         additionalComponents_.emplace_back(space);
     }
-#endif
+#endif // NOT ARDUINO, YES ESP32
     size_t cdi_size = strlen(CDI_DATA);
     if (cdi_size > 0)
     {
@@ -125,10 +125,7 @@ void SimpleCanStackBase::default_start_node()
             node(), MemoryConfigDefs::SPACE_CDI, space);
         additionalComponents_.emplace_back(space);
     }
-#if defined(ARDUINO)
-// @todo (balazs.racz): find a solution for storing configuration on an
-// arduino binary.
-#else
+#if !defined(ARDUINO) || defined(ESP32)
     if (CONFIG_FILENAME != nullptr)
     {
         auto *space = new FileMemorySpace(CONFIG_FILENAME, CONFIG_FILE_SIZE);
@@ -136,7 +133,7 @@ void SimpleCanStackBase::default_start_node()
             node(), openlcb::MemoryConfigDefs::SPACE_CONFIG, space);
         additionalComponents_.emplace_back(space);
     }
-#endif
+#endif // NOT ARDUINO, YES ESP32
 }
 
 SimpleTrainCanStack::SimpleTrainCanStack(

--- a/src/openlcb/SimpleStack.cxx
+++ b/src/openlcb/SimpleStack.cxx
@@ -72,7 +72,7 @@ SimpleCanStack::SimpleCanStack(const openlcb::NodeID node_id)
 
 void SimpleCanStackBase::start_stack(bool delay_start)
 {
-#if (!defined(ARDUINO) || defined(ESP32))
+#if (!defined(ARDUINO)) || defined(ESP32)
     // Opens the eeprom file and sends configuration update commands to all
     // listeners.
     configUpdateFlow_.open_file(CONFIG_FILENAME);
@@ -107,7 +107,7 @@ void SimpleCanStackBase::default_start_node()
             node(), MemoryConfigDefs::SPACE_ACDI_SYS, space);
         additionalComponents_.emplace_back(space);
     }
-#if (!defined(ARDUINO) || defined(ESP32))
+#if (!defined(ARDUINO)) || defined(ESP32)
     {
         auto *space = new FileMemorySpace(
             SNIP_DYNAMIC_FILENAME, sizeof(SimpleNodeDynamicValues));
@@ -125,7 +125,7 @@ void SimpleCanStackBase::default_start_node()
             node(), MemoryConfigDefs::SPACE_CDI, space);
         additionalComponents_.emplace_back(space);
     }
-#if (!defined(ARDUINO) || defined(ESP32))
+#if (!defined(ARDUINO)) || defined(ESP32)
     if (CONFIG_FILENAME != nullptr)
     {
         auto *space = new FileMemorySpace(CONFIG_FILENAME, CONFIG_FILE_SIZE);

--- a/src/openlcb/SimpleStack.cxx
+++ b/src/openlcb/SimpleStack.cxx
@@ -72,7 +72,7 @@ SimpleCanStack::SimpleCanStack(const openlcb::NodeID node_id)
 
 void SimpleCanStackBase::start_stack(bool delay_start)
 {
-#if !defined(ARDUINO) || defined(ESP32)
+#if (!defined(ARDUINO) || defined(ESP32))
     // Opens the eeprom file and sends configuration update commands to all
     // listeners.
     configUpdateFlow_.open_file(CONFIG_FILENAME);
@@ -107,7 +107,7 @@ void SimpleCanStackBase::default_start_node()
             node(), MemoryConfigDefs::SPACE_ACDI_SYS, space);
         additionalComponents_.emplace_back(space);
     }
-#if !defined(ARDUINO) || defined(ESP32)
+#if (!defined(ARDUINO) || defined(ESP32))
     {
         auto *space = new FileMemorySpace(
             SNIP_DYNAMIC_FILENAME, sizeof(SimpleNodeDynamicValues));
@@ -125,7 +125,7 @@ void SimpleCanStackBase::default_start_node()
             node(), MemoryConfigDefs::SPACE_CDI, space);
         additionalComponents_.emplace_back(space);
     }
-#if !defined(ARDUINO) || defined(ESP32)
+#if (!defined(ARDUINO) || defined(ESP32))
     if (CONFIG_FILENAME != nullptr)
     {
         auto *space = new FileMemorySpace(CONFIG_FILENAME, CONFIG_FILE_SIZE);

--- a/src/utils/logging.cxx
+++ b/src/utils/logging.cxx
@@ -54,7 +54,7 @@ void log_output(char* buf, int size) {
     send_stdio_serial_message(buf);
 }
 
-#elif defined(__linux__) || defined(__MACH__) || defined(__EMSCRIPTEN__)
+#elif defined(__linux__) || defined(__MACH__) || defined(__EMSCRIPTEN__) || defined(ESP32)
 
 #include "utils/stdio_logging.h"
 


### PR DESCRIPTION
Arduino ESP32 updates:
- Separates stack startup in two pieces to avoid using filesystem calls during static initialization.
- Adds config file on SPIFFS. Enables filesystem dependent parts of SimpleStack when using ESP32 arduino.
- Adds watchdog timer clears to the openmrn tasks to allow using the WDT.
- Instantiates 8 inputs and 8 outputs for the IO board example
- Refactors wifi client into a separate file.

this replaces https://github.com/bakerstu/openmrn/pull/195 as there is a critical issue in the HW CAN adapter code which I'll need to rework.

