### PR TITLE
esp32 write performance

### DIFF
--- a/arduino/OpenMRN.h
+++ b/arduino/OpenMRN.h
@@ -461,7 +461,7 @@ private:
     /// Callback from the loop() method. Internally called.
     void run() override
     {
-        stack_->executor()->loop_once();
+        stack_->executor()->loop_some();
     }
 
 #if defined(ESP32)

--- a/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
+++ b/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
@@ -76,6 +76,9 @@ string dummystring("abcdef");
 // layout. The argument of offset zero is ignored and will be removed later.
 static constexpr openlcb::ConfigDef cfg(0);
 
+OVERRIDE_CONST(gridconnect_buffer_size, 512);
+OVERRIDE_CONST(gridconnect_buffer_delay_usec, 2000);
+
 // Declare output pins
 GPIO_PIN(IO0, GpioOutputSafeLow, 2);
 GPIO_PIN(IO1, GpioOutputSafeLow, 4);
@@ -210,7 +213,7 @@ void setup() {
     // Dump all packets as they are sent/received.
     // Note: This should not be enabled in deployed nodes as it will
     // have performance impact.
-    openmrn.stack()->print_all_packets();
+    // openmrn.stack()->print_all_packets();
 
     // Start the TCP/IP listener
     openMRNServer.setNoDelay(true);

--- a/src/freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
+++ b/src/freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
@@ -82,9 +82,7 @@ public:
     size_t write(const char *buffer, size_t len)
     {
         if(client_.connected()) {
-            size_t r = client_.write(buffer, len);
-            LOG(INFO, "w%u", len, r);
-            return r;
+            return client_.write(buffer, len);
         }
         return 0;
     }

--- a/src/freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
+++ b/src/freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
@@ -71,7 +71,7 @@ public:
 
         if (FD_ISSET(fd, &set))
         {
-            return 500;
+            return WRITE_PACKET_SIZE;
         }
         else
         {

--- a/src/freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
+++ b/src/freertos_drivers/arduino/Esp32WiFiClientAdapter.hxx
@@ -39,9 +39,12 @@
 #include <Arduino.h>
 #include <WiFi.h>
 
-class Esp32WiFiClientAdapter {
+class Esp32WiFiClientAdapter
+{
 public:
-    Esp32WiFiClientAdapter(WiFiClient client) : client_(client){
+    Esp32WiFiClientAdapter(WiFiClient client)
+        : client_(client)
+    {
         client_.setNoDelay(true);
     }
 
@@ -81,24 +84,30 @@ public:
 
     size_t write(const char *buffer, size_t len)
     {
-        if(client_.connected()) {
+        if (client_.connected())
+        {
             return client_.write(buffer, len);
         }
         return 0;
     }
-    size_t available() {
-        if(client_.connected()) {
+    size_t available()
+    {
+        if (client_.connected())
+        {
             return client_.available();
         }
         return 0;
     }
-    size_t read(const char *buffer, size_t len) {
+    size_t read(const char *buffer, size_t len)
+    {
         size_t bytesRead = 0;
-        if(client_.connected()) {
+        if (client_.connected())
+        {
             bytesRead = client_.read((uint8_t *)buffer, len);
         }
         return bytesRead;
     }
+
 private:
     WiFiClient client_;
 };


### PR DESCRIPTION
Optimizes write performance for the esp32 sockets:
- Adds a more efficient implementation for availableForWrite() that uses select() to identify whether the socket is writeable or not.
- Adds configuration overrides for gridconnect params to buffer entire datagram sends in one packet.
- Increases the number of Executor loops per arduino loops.