### PR TITLE
macOS and os_get_time_monotonic changes 

### DIFF
--- a/arduino/libify.sh
+++ b/arduino/libify.sh
@@ -3,6 +3,8 @@
 # 
 #
 
+#set -x
+
 function usage() {
     echo
     echo 'usage: libify.sh path/to/arduino/library/output path/to/openmrn [-f] [-l]'
@@ -14,8 +16,27 @@ function usage() {
     exit 1
 }
 
-TARGET_LIB_DIR=$(realpath $1 2>/dev/null)
-OPENMRNPATH=$(realpath $2 2>/dev/null)
+function realpath_macOS() {
+  OURPWD=$PWD
+  cd "$(dirname "$1")"
+  LINK=$(readlink "$(basename "$1")")
+  while [ "$LINK" ]; do
+    cd "$(dirname "$LINK")"
+    LINK=$(readlink "$(basename "$1")")
+  done
+  REALPATH="$PWD/$(basename "$1")"
+  cd "$OURPWD"
+  echo "$REALPATH"
+}
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+REALPATH=realpath_macOS
+else
+REALPATH=realpath
+fi
+
+TARGET_LIB_DIR=$($REALPATH $1 2>/dev/null)
+OPENMRNPATH=$($REALPATH $2 2>/dev/null)
 
 if [[ -z ${TARGET_LIB_DIR} ]]; then
   if [[ $1 ]]; then
@@ -72,7 +93,13 @@ function copy_file() {
         if [ "x$VERBOSE" != "x" ]; then
             echo "${OPENMRNPATH}/${1} ==> ${TARGET_LIB_DIR}/${REL_DIR}"
         fi
-        cp -fax ${USE_LINK} ${OPENMRNPATH}/${1} .
+
+	    if [[ "$OSTYPE" == "darwin"* ]]; then
+    	    cp -fa ${USE_LINK} ${OPENMRNPATH}/${1} .
+    	else
+    	    cp -fax ${USE_LINK} ${OPENMRNPATH}/${1} .
+    	fi
+    	
         shift
     done
     popd >/dev/null
@@ -92,7 +119,13 @@ function copy_dir() {
     if [ "x$VERBOSE" != "x" ]; then
         echo "${OPENMRNPATH}/${2} ==> ${TARGET_LIB_DIR}/$1"
     fi
-    cp -faxr ${USE_LINK} ${OPENMRNPATH}/$2 .
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+	    cp -fa ${USE_LINK} ${OPENMRNPATH}/$2 .
+	else
+	    cp -faxr ${USE_LINK} ${OPENMRNPATH}/$2 .
+	fi
+
     popd >/dev/null
 }
 

--- a/arduino/libify.sh
+++ b/arduino/libify.sh
@@ -94,12 +94,12 @@ function copy_file() {
             echo "${OPENMRNPATH}/${1} ==> ${TARGET_LIB_DIR}/${REL_DIR}"
         fi
 
-	    if [[ "$OSTYPE" == "darwin"* ]]; then
-    	    cp -fa ${USE_LINK} ${OPENMRNPATH}/${1} .
-    	else
-    	    cp -fax ${USE_LINK} ${OPENMRNPATH}/${1} .
-    	fi
-    	
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            cp -fa ${USE_LINK} ${OPENMRNPATH}/${1} .
+        else
+            cp -fax ${USE_LINK} ${OPENMRNPATH}/${1} .
+        fi
+
         shift
     done
     popd >/dev/null
@@ -121,10 +121,10 @@ function copy_dir() {
     fi
 
     if [[ "$OSTYPE" == "darwin"* ]]; then
-	    cp -fa ${USE_LINK} ${OPENMRNPATH}/$2 .
-	else
-	    cp -faxr ${USE_LINK} ${OPENMRNPATH}/$2 .
-	fi
+        cp -fa ${USE_LINK} ${OPENMRNPATH}/$2 .
+    else
+        cp -faxr ${USE_LINK} ${OPENMRNPATH}/$2 .
+    fi
 
     popd >/dev/null
 }

--- a/arduino/readme.md
+++ b/arduino/readme.md
@@ -24,11 +24,6 @@ the Git bash commandline will work. On Linux/MacOS the native bash shell will
 work.
     sh libify.sh {path to OpenMRN-lite creation directory} {path to OpenMRN}
 
-Note, on MacOS the script may require some edits for "realpath" and the "cp"
-command. Additionally the "link" feature should not be used on the MacOS at
-this time. An updated libify.sh script will be available soon that is more
-portable.
-
 #### Arduino IDE library generation
 On Windows the Arduino IDE stores the libraries under
 "Documents\Arduino\libraries", this can be accessed via the Git bash
@@ -38,8 +33,11 @@ commandline as:
 ```
 when executed from the OpenMRN repository root folder.
 
-On Linux or MacOS the location would normally be
+On Linux the location would normally be
 /home/{user}/Documents/Arduino/libraries.
+
+On macOS the location would normally be
+/Users/{user}/Documents/Arduino/libraries.
 
 #### PlatformIO IDE library generation
 For PlatformIO IDE it would be recommended to put this into the project lib

--- a/src/os/os.c
+++ b/src/os/os.c
@@ -618,10 +618,10 @@ long long os_get_time_monotonic(void)
     time = ((long long)tv.tv_sec * 1000LL * 1000LL * 1000LL) +
            ((long long)tv.tv_usec * 1000LL);
 #elif defined(ARDUINO)
-	// redeclare micros() prototype to keep the compiler happy
-	unsigned long micros();
-	
-	time = micros();
+    // redeclare micros() prototype to keep the compiler happy
+    unsigned long micros();
+
+    time = micros();
 #elif defined(ESP_NONOS)
     static uint32_t clockmul = 0;
     if (clockmul == 0) {

--- a/src/os/os.c
+++ b/src/os/os.c
@@ -618,10 +618,23 @@ long long os_get_time_monotonic(void)
     time = ((long long)tv.tv_sec * 1000LL * 1000LL * 1000LL) +
            ((long long)tv.tv_usec * 1000LL);
 #elif defined(ARDUINO)
-    // redeclare micros() prototype to keep the compiler happy
+    // redeclare micros() prototype to remove compiler warning
     unsigned long micros();
-
-    time = micros();
+    
+    static uint32_t last_micros = 0;
+    static uint32_t overflow_micros = 0;
+    
+    uint32_t new_micros = (uint32_t) micros();
+    if (new_micros < last_micros)
+    {
+        ++overflow_micros;
+    }
+    last_micros = new_micros;
+    
+    time = overflow_micros;
+    time <<= 32;
+    time += new_micros;
+    time *= 1000;    // Convert micros to nanos
 #elif defined(ESP_NONOS)
     static uint32_t clockmul = 0;
     if (clockmul == 0) {

--- a/src/os/os.c
+++ b/src/os/os.c
@@ -618,17 +618,10 @@ long long os_get_time_monotonic(void)
     time = ((long long)tv.tv_sec * 1000LL * 1000LL * 1000LL) +
            ((long long)tv.tv_usec * 1000LL);
 #elif defined(ARDUINO)
-    static uint32_t last_millis = 0;
-    auto new_millis = millis();
-    static uint32_t overflow_millis = 0;
-    if (new_millis < last_millis)
-    {
-        ++overflow_millis;
-    }
-    time = overflow_millis;
-    time <<= 32;
-    time += new_millis;
-    time *= 1000000;
+	// redeclare micros() prototype to keep the compiler happy
+	unsigned long micros();
+	
+	time = micros();
 #elif defined(ESP_NONOS)
     static uint32_t clockmul = 0;
     if (clockmul == 0) {


### PR DESCRIPTION
added macOS specific support to the libify.sh shell script
changed os_get_time_monotonic() to just call the Arduino micros() function to improve precision and added a prototype to suppress the warning