### PR TITLE
Dynamic declaration of segments

### DIFF
--- a/src/openlcb/ConfigEntry.hxx
+++ b/src/openlcb/ConfigEntry.hxx
@@ -92,7 +92,8 @@ class ConfigEntryBase : public ConfigReference
 public:
     INHERIT_CONSTEXPR_CONSTRUCTOR(ConfigEntryBase, ConfigReference)
 
-    static constexpr GroupConfigOptions group_opts()
+    template<typename... Args>
+    static constexpr GroupConfigOptions group_opts(Args... args)
     {
         return GroupConfigOptions();
     }

--- a/src/openlcb/ConfigRenderer.cxxtest
+++ b/src/openlcb/ConfigRenderer.cxxtest
@@ -231,8 +231,13 @@ CDI_GROUP_ENTRY(e1, Uint8ConfigEntry, Name("e1"));
 CDI_GROUP_ENTRY(e2, Uint16ConfigEntry, Description("e2"));
 CDI_GROUP_END();
 
+CDI_GROUP(ThirdSegment);
+CDI_GROUP_ENTRY(first, Uint8ConfigEntry);
+CDI_GROUP_END();
+
 CDI_GROUP(TestCdi1, MainCdi());
 CDI_GROUP_ENTRY(testseg, TestSegment);
+CDI_GROUP_ENTRY(seg3, ThirdSegment, Segment(13), Offset(142), Name("Foo"));
 CDI_GROUP_END();
 
 TEST(CdiRender, Render)
@@ -250,6 +255,11 @@ TEST(CdiRender, Render)
 </int>
 <int size='2'>
 <description>e2</description>
+</int>
+</segment>
+<segment space='13' origin='142'>
+<name>Foo</name>
+<int size='1'>
 </int>
 </segment>
 </cdi>

--- a/src/openlcb/ConfigRepresentation.cxxtest
+++ b/src/openlcb/ConfigRepresentation.cxxtest
@@ -114,6 +114,10 @@ CDI_GROUP(SecondSegment, Segment(MemoryConfigDefs::SPACE_CONFIG));
 CDI_GROUP_ENTRY(first, Uint8ConfigEntry);
 CDI_GROUP_END();
 
+CDI_GROUP(ThirdSegment);
+CDI_GROUP_ENTRY(first, Uint8ConfigEntry);
+CDI_GROUP_END();
+
 
 CDI_GROUP(ConfigDef, MainCdi());
 CDI_GROUP_ENTRY(ident, Identification);
@@ -121,6 +125,7 @@ CDI_GROUP_ENTRY(acdi, Acdi);
 CDI_GROUP_ENTRY(userinfo, UserInfoSegment);
 CDI_GROUP_ENTRY(seg, IoBoardSegment);
 CDI_GROUP_ENTRY(seg2, SecondSegment);
+CDI_GROUP_ENTRY(seg3, ThirdSegment, Segment(13), Offset(142));
 CDI_GROUP_END();
 
 TEST(FullCdi, SegmentOffset)
@@ -144,6 +149,9 @@ TEST(FullCdi, SegmentOffset)
 
     EXPECT_EQ(128u, def.seg().first().offset());
     EXPECT_EQ(0u, def.seg2().first().offset());
+
+    EXPECT_EQ(142u, def.seg3().first().offset());
+    EXPECT_EQ(13, def.seg3_options().segment());
 }
 
 TempDir dir;

--- a/src/openlcb/ConfigRepresentation.hxx
+++ b/src/openlcb/ConfigRepresentation.hxx
@@ -136,9 +136,10 @@ public:
         {                                                                      \
             return openlcb::GroupBaseEntry(offset_);                           \
         }                                                                      \
-        static constexpr openlcb::GroupConfigOptions group_opts()              \
+        template <typename... Args>                                            \
+        static constexpr openlcb::GroupConfigOptions group_opts(Args... args)  \
         {                                                                      \
-            return openlcb::GroupConfigOptions(ARGS);                          \
+            return openlcb::GroupConfigOptions(args..., ##ARGS);               \
         }                                                                      \
         static constexpr unsigned size()                                       \
         {                                                                      \
@@ -190,11 +191,11 @@ public:
 #define CDI_GROUP_ENTRY_HELPER(LINE, NAME, TYPE, ...)                          \
     constexpr TYPE entry(const openlcb::EntryMarker<LINE> &) const             \
     {                                                                          \
-        static_assert(                                                         \
-            !group_opts().is_cdi() || TYPE(0).group_opts().is_segment(),       \
+        static_assert(!group_opts().is_cdi() ||                                \
+                TYPE(0).group_opts(__VA_ARGS__).is_segment(),                  \
             "May only have segments inside CDI.");                             \
         return TYPE(group_opts().is_cdi()                                      \
-                ? TYPE(0).group_opts().get_segment_offset()                    \
+                ? TYPE(0).group_opts(__VA_ARGS__).get_segment_offset()         \
                 : entry(openlcb::EntryMarker<LINE - 1>()).end_offset());       \
     }                                                                          \
     constexpr TYPE NAME() const                                                \
@@ -382,7 +383,8 @@ class ToplevelEntryBase : public ConfigEntryBase
 public:
     using base_type = ConfigEntryBase;
     INHERIT_CONSTEXPR_CONSTRUCTOR(ToplevelEntryBase, base_type)
-    static constexpr GroupConfigOptions group_opts()
+    template<typename... Args>
+    static constexpr GroupConfigOptions group_opts(Args... args)
     {
         return GroupConfigOptions(GroupConfigOptions::Segment(1000));
     }


### PR DESCRIPTION
Forwards the arguments of the CDI_GROUP_ENTRY(...) into the group_opts call.
This allows us to make a group be a segment on demand.