### PR TITLE
Switches SocketClientParams to return string arguments.

### DIFF
--- a/src/utils/SocketClient.cxxtest
+++ b/src/utils/SocketClient.cxxtest
@@ -165,7 +165,7 @@ public:
     {
     }
 
-    const char *manual_host_name() override
+    string manual_host_name() override
     {
         return "127.0.0.1";
     }
@@ -218,9 +218,9 @@ public:
     {
     }
 
-    const char *manual_host_name() override
+    string manual_host_name() override
     {
-        return manualHostName_.c_str();
+        return manualHostName_;
     }
 
     int manual_port() override
@@ -228,9 +228,9 @@ public:
         return manualPort_;
     }
 
-    const char *mdns_service_name() override
+    string mdns_service_name() override
     {
-        return mdnsServiceName_.c_str();
+        return mdnsServiceName_;
     }
 
     SearchMode search_mode() override
@@ -255,9 +255,9 @@ public:
         parent_->last_callback(hostname, port);
     }
 
-    const char *last_host_name() override
+    string last_host_name() override
     {
-        return lastHostName_.c_str();
+        return lastHostName_;
     }
 
     int last_port() override

--- a/src/utils/SocketClient.hxx
+++ b/src/utils/SocketClient.hxx
@@ -359,15 +359,14 @@ private:
                 return wait_retry();
             case Attempt::RECONNECT:
                 return try_schedule_connect(SocketClientParams::CONNECT_RE,
-                    to_string(params_->last_host_name()), params_->last_port());
+                    params_->last_host_name(), params_->last_port());
             case Attempt::INITIATE_MDNS:
                 return start_mdns();
             case Attempt::CONNECT_MDNS:
                 return wait_and_connect_mdns();
             case Attempt::CONNECT_STATIC:
                 return try_schedule_connect(SocketClientParams::CONNECT_MANUAL,
-                    to_string(params_->manual_host_name()),
-                    params_->manual_port());
+                    params_->manual_host_name(), params_->manual_port());
         }
     }
 
@@ -462,8 +461,8 @@ private:
     {
         HASSERT(mdnsExecutor_);
         mdnsAddr_.reset();
-        string srv = to_string(params_->mdns_service_name());
-        string host = to_string(params_->mdns_host_name());
+        string srv = params_->mdns_service_name();
+        string host = params_->mdns_host_name();
         if (!srv.empty())
         {
             {

--- a/src/utils/SocketClientParams.hxx
+++ b/src/utils/SocketClientParams.hxx
@@ -83,17 +83,17 @@ public:
 
     /// @return the service name to use for mDNS lookup; nullptr or empty
     /// string if mdns is not to be used.
-    virtual const char *mdns_service_name() = 0;
+    virtual string mdns_service_name() = 0;
 
     /// @return null or empty string if any mdns server is okay to connect
     /// to. If nonempty, then only an mdns server will be chosen that has the
     /// specific host name.
-    virtual const char *mdns_host_name() = 0;
+    virtual string mdns_host_name() = 0;
 
     /// @return null or empty string if no manual address is
     /// configured. Otherwise a dotted-decimal IP address or a DNS hostname
     /// (not mDNS) for manual address to connect to.
-    virtual const char *manual_host_name() = 0;
+    virtual string manual_host_name() = 0;
 
     /// @return port number to use for manual connection.
     virtual int manual_port() = 0;
@@ -105,7 +105,7 @@ public:
     /// @return the last successfully used IP address, as dotted
     /// decimal. Nullptr or empty if no successful connection has ever been
     /// made.
-    virtual const char *last_host_name() = 0;
+    virtual string last_host_name() = 0;
 
     /// @return the last successfully used port number.
     virtual int last_port() = 0;
@@ -182,25 +182,25 @@ public:
 
     /// @return the service name to use for mDNS lookup; nullptr or empty
     /// string if mdns is not to be used.
-    const char *mdns_service_name() override
+    string mdns_service_name() override
     {
-        return nullptr;
+        return string();
     }
 
     /// @return null or empty string if any mdns server is okay to connect
     /// to. If nonempty, then only an mdns server will be chosen that has the
     /// specific host name.
-    const char *mdns_host_name() override
+    string mdns_host_name() override
     {
-        return nullptr;
+        return string();
     }
 
     /// @return null or empty string if no manual address is
     /// configured. Otherwise a dotted-decimal IP address or a DNS hostname
     /// (not mDNS) for manual address to connect to.
-    const char *manual_host_name() override
+    string manual_host_name() override
     {
-        return nullptr;
+        return string();
     }
 
     /// @return port number to use for manual connection.
@@ -219,9 +219,9 @@ public:
     /// @return the last successfully used IP address, as dotted
     /// decimal. Nullptr or empty if no successful connection has ever been
     /// made.
-    const char *last_host_name() override
+    string last_host_name() override
     {
-        return nullptr;
+        return string();
     }
 
     /// @return the last successfully used port number.
@@ -238,17 +238,17 @@ class DefaultSocketClientParams : public EmptySocketClientParams
 public:
     /// @return the service name to use for mDNS lookup; nullptr or empty
     /// string if mdns is not to be used.
-    const char *mdns_service_name() override
+    string mdns_service_name() override
     {
-        return mdnsService_.c_str();
+        return mdnsService_;
     }
 
     /// @return null or empty string if no manual address is
     /// configured. Otherwise a dotted-decimal IP address or a DNS hostname
     /// (not mDNS) for manual address to connect to.
-    const char *manual_host_name() override
+    string manual_host_name() override
     {
-        return staticHost_.c_str();
+        return staticHost_;
     }
 
     /// @return port number to use for manual connection.


### PR DESCRIPTION
Using const char* made it difficult for using temporary copies of data read out from files.