### PR TITLE
[WIP] ESP32 WiFi manager code

### DIFF
--- a/arduino/OpenMRN.h
+++ b/arduino/OpenMRN.h
@@ -61,6 +61,7 @@ constexpr UBaseType_t OPENMRN_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO;
 #include "freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx"
 #include "freertos_drivers/esp32/Esp32HardwareSerialAdapter.hxx"
 #include "freertos_drivers/esp32/Esp32WiFiClientAdapter.hxx"
+#include "freertos_drivers/esp32/Esp32WiFiManager.hxx"
 
 // On the ESP32 we have persistent file system access so enable
 // dynamic CDI.xml generation support
@@ -397,11 +398,9 @@ public:
     void remove_port(Executable *exec)
     {
         auto e = std::find(loopMembers_.begin(), loopMembers_.end(), exec);
-        if(e != loopMembers_.end())
-        {
-            loopMembers_.erase(e);
-        }
-        delete *e;
+        HASSERT(e != loopMembers_.end());
+        loopMembers_.erase(e);
+        delete exec;
     }
 
 #if defined(HAVE_FILESYSTEM)

--- a/arduino/OpenMRN.h
+++ b/arduino/OpenMRN.h
@@ -368,19 +368,40 @@ public:
     /// }
     ///
     /// @param port is the serial port instance from Arduino.
-    template <class SerialType> void add_gridconnect_port(SerialType *port)
+    /// @return @ref Executable instance representing the newly added port.
+    template <class SerialType> Executable *add_gridconnect_port(SerialType *port)
     {
-        loopMembers_.push_back(
-            new SerialBridge<SerialType>(port, stack()->can_hub()));
+        Executable *e = new SerialBridge<SerialType>(port, stack()->can_hub());
+        loopMembers_.push_back(e);
+        return e;
     }
 
     /// Adds a hardware CAN port to the stack. If multiple ports are added,
     /// OpenMRN will be forwarding traffic frames between them: the simplest
     /// CAN-USB sketch just adds the serial port connecting to the computer and
     /// the hardware CAN port.
-    void add_can_port(Can *port)
+    ///
+    /// @param port is the hardware CAN driver to be added.
+    /// @return Executable instance representing the newly added port.
+    Executable *add_can_port(Can *port)
     {
-        loopMembers_.push_back(new CanBridge(port, stack()->can_hub()));
+        Executable *e = new CanBridge(port, stack()->can_hub());
+        loopMembers_.push_back(e);
+        return e;
+    }
+
+    /// Removes an Executor from OpenMRN stack that was created via
+    /// @ref add_gridconnect_port or @ref add_can_port.
+    ///
+    /// @param exec is the @ref Executable to remove.
+    void remove_port(Executable *exec)
+    {
+        auto e = std::find(loopMembers_.begin(), loopMembers_.end(), exec);
+        if(e != loopMembers_.end())
+        {
+            loopMembers_.erase(e);
+        }
+        delete *e;
     }
 
 #if defined(HAVE_FILESYSTEM)

--- a/arduino/OpenMRN.h
+++ b/arduino/OpenMRN.h
@@ -49,6 +49,27 @@
 #include <esp_task.h>
 #include <esp_task_wdt.h>
 
+// Check for and prevent namespace polution on the ESP32 by checking for
+// specific header defines from VFS libraries which will polute the global
+// namespace if not correctly handled.
+#ifdef _SD_H_
+#error "OpenMRN.h must be included prior to SD.h to prevent namespace polution."
+#elif defined(FS_H)
+#error "OpenMRN.h must be included prior to FS.h to prevent namespace polution."
+#elif defined(_SDMMC_H_)
+#error "OpenMRN.h must be included prior to SD_MMC.h to prevent namespace polution."
+#elif defined(_SPIFFS_H_)
+#error "OpenMRN.h must be included prior to SPIFFS.h to prevent namespace polution."
+#elif defined(_FFAT_H_)
+#error "OpenMRN.h must be included prior to FFat.h to prevent namespace polution."
+#endif
+
+// include the FS base library which is used by the various VFS libraries
+// above, by including it here we can prevent some of the namespace polution
+// by this library with the define below.
+#define FS_NO_GLOBALS
+#include <FS.h>
+
 /// Default stack size to use for all OpenMRN tasks on the ESP32 platform.
 constexpr uint32_t OPENMRN_STACK_SIZE = 4096L;
 

--- a/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
+++ b/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
@@ -78,10 +78,6 @@ const char *ssid = DEFAULT_WIFI_NAME;
 /// Password of the wifi network.
 const char *password = DEFAULT_PASSWORD;
 
-/// This is the hostname which the ESP32 will advertise via mDNS, it should be
-/// unique.
-const char *hostname = "esp32mrn";
-
 OVERRIDE_CONST(gridconnect_buffer_size, 512);
 OVERRIDE_CONST(gridconnect_buffer_delay_usec, 2000);
 
@@ -120,8 +116,7 @@ string dummystring("abcdef");
 static constexpr openlcb::ConfigDef cfg(0);
 
 #if defined(USE_WIFI)
-Esp32WiFiManager wifiManager(ssid, password, hostname, &openmrn, NODE_ID,
-    cfg.seg().wifi());
+Esp32WiFiManager wifiManager(ssid, password, &openmrn, cfg.seg().wifi());
 #endif // USE_WIFI
 
 // Declare output pins

--- a/arduino/examples/ESP32IOBoard/config.h
+++ b/arduino/examples/ESP32IOBoard/config.h
@@ -1,7 +1,7 @@
 #ifndef _ARDUINO_EXAMPLE_ESP32IOBOARD_CONFIG_H_
 #define _ARDUINO_EXAMPLE_ESP32IOBOARD_CONFIG_H_
 
-#include "freertos_drivers/esp32/Esp32WiFiManager.hxx"
+#include "freertos_drivers/esp32/Esp32WiFiConfiguration.hxx"
 #include "openlcb/ConfiguredConsumer.hxx"
 #include "openlcb/ConfiguredProducer.hxx"
 #include "openlcb/ConfigRepresentation.hxx"

--- a/arduino/examples/ESP32IOBoard/config.h
+++ b/arduino/examples/ESP32IOBoard/config.h
@@ -1,6 +1,7 @@
 #ifndef _ARDUINO_EXAMPLE_ESP32IOBOARD_CONFIG_H_
 #define _ARDUINO_EXAMPLE_ESP32IOBOARD_CONFIG_H_
 
+#include "freertos_drivers/esp32/Esp32WiFiManager.hxx"
 #include "openlcb/ConfiguredConsumer.hxx"
 #include "openlcb/ConfiguredProducer.hxx"
 #include "openlcb/ConfigRepresentation.hxx"
@@ -64,6 +65,9 @@ CDI_GROUP(IoBoardSegment, Segment(MemoryConfigDefs::SPACE_CONFIG), Offset(128));
 CDI_GROUP_ENTRY(internal_config, InternalConfigData);
 CDI_GROUP_ENTRY(consumers, AllConsumers, Name("Outputs"));
 CDI_GROUP_ENTRY(producers, AllProducers, Name("Inputs"));
+#if defined(USE_WIFI)
+CDI_GROUP_ENTRY(wifi, WiFiConfiguration, Name("WiFi Configuration"));
+#endif
 CDI_GROUP_END();
 
 /// This segment is only needed temporarily until there is program code to set

--- a/arduino/examples/ESP32WifiCanBridge/ESP32WifiCanBridge.ino
+++ b/arduino/examples/ESP32WifiCanBridge/ESP32WifiCanBridge.ino
@@ -83,10 +83,6 @@ const char *ssid = DEFAULT_WIFI_NAME;
 /// Password of the wifi network.
 const char *password = DEFAULT_PASSWORD;
 
-/// This is the hostname which the ESP32 will advertise via mDNS, it should be
-/// unique.
-const char *hostname = "esp32mrn";
-
 /// This is the primary entrypoint for the OpenMRN/LCC stack.
 OpenMRN openmrn(NODE_ID);
 
@@ -100,8 +96,7 @@ string dummystring("abcdef");
 // layout. The argument of offset zero is ignored and will be removed later.
 static constexpr openlcb::ConfigDef cfg(0);
 
-Esp32WiFiManager wifiManager(ssid, password, hostname, &openmrn, NODE_ID,
-    cfg.seg().wifi());
+Esp32WiFiManager wifiManager(ssid, password, &openmrn, cfg.seg().wifi());
 
 class FactoryResetHelper : public DefaultConfigUpdateListener {
 public:

--- a/arduino/examples/ESP32WifiCanBridge/ESP32WifiCanBridge.ino
+++ b/arduino/examples/ESP32WifiCanBridge/ESP32WifiCanBridge.ino
@@ -34,10 +34,9 @@
  */
 
 #include <Arduino.h>
-#include <ESPmDNS.h>
+#include <openlcb/TcpDefs.hxx>
 #include <OpenMRN.h>
 #include <SPIFFS.h>
-#include <openlcb/TcpDefs.hxx>
 
 #include "config.h"
 
@@ -60,10 +59,6 @@ constexpr gpio_num_t CAN_RX_PIN = GPIO_NUM_4;
 /// Note: Any pin can be used for this other than 6-11 which are connected to
 /// the onboard flash and 34-39 which are input only.
 constexpr gpio_num_t CAN_TX_PIN = GPIO_NUM_5;
-
-/// This is the TCP/IP port which the ESP32 will listen on for incoming
-/// GridConnect formatted CAN frames.
-constexpr uint16_t OPENMRN_TCP_PORT = 12021L;
 
 /// This is the node id to assign to this device, this must be unique
 /// on the CAN bus.
@@ -92,9 +87,6 @@ const char *password = DEFAULT_PASSWORD;
 /// unique.
 const char *hostname = "esp32mrn";
 
-/// This is the TCP/IP listener on the ESP32.
-WiFiServer openMRNServer(OPENMRN_TCP_PORT);
-
 /// This is the primary entrypoint for the OpenMRN/LCC stack.
 OpenMRN openmrn(NODE_ID);
 
@@ -107,6 +99,9 @@ string dummystring("abcdef");
 // used to generate the cdi.xml file. Here we instantiate the configuration
 // layout. The argument of offset zero is ignored and will be removed later.
 static constexpr openlcb::ConfigDef cfg(0);
+
+Esp32WiFiManager wifiManager(ssid, password, hostname, &openmrn, NODE_ID,
+    cfg.seg().wifi());
 
 class FactoryResetHelper : public DefaultConfigUpdateListener {
 public:
@@ -147,39 +142,6 @@ void setup()
 {
     Serial.begin(SERIAL_BAUD);
 
-    printf("\nConnecting to: %s\n", ssid);
-    WiFi.begin(ssid, password);
-    uint8_t attempts = 30;
-    while (WiFi.status() != WL_CONNECTED &&
-        WiFi.status() != WL_CONNECT_FAILED &&
-        WiFi.status() != WL_NO_SSID_AVAIL && attempts--)
-    {
-        delay(500);
-        Serial.print(".");
-    }
-    if (WiFi.status() != WL_CONNECTED)
-    {
-        printf("\nFailed to connect to WiFi, restarting\n");
-        ESP.restart();
-
-        // in case the above call doesn't trigger restart, force WDT to restart
-        // the ESP32
-        while (1)
-        {
-            // The ESP32 has built in watchdog timers that as of
-            // arduino-esp32 1.0.1 are enabled on both core 0 (OS core) and core
-            // 1 (Arduino core). It usually takes a couple seconds of an endless
-            // loop such as this one to trigger the WDT to force a restart.
-        }
-    }
-
-    // This makes the wifi much more responsive. Since we are plugged in we
-    // don't care about the increased power usage. Disable when on battery.
-    WiFi.setSleep(false);
-
-    printf("\nWiFi connected, IP address: %s\n",
-        WiFi.localIP().toString().c_str());
-
     // Initialize the SPIFFS filesystem as our persistence layer
     if (!SPIFFS.begin())
     {
@@ -194,18 +156,6 @@ void setup()
             }
         }
     }
-
-    // Start the TCP/IP listener
-    openMRNServer.setNoDelay(true);
-    openMRNServer.begin();
-
-    // Start the mDNS subsystem
-    MDNS.begin(hostname);
-
-    // Broadcast this node's hostname with the mDNS service name
-    // for a TCP GridConnect endpoint.
-    MDNS.addService(openlcb::TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN,
-        openlcb::TcpDefs::MDNS_PROTOCOL_TCP, OPENMRN_TCP_PORT);
 
     // Create the CDI.xml dynamically
     openmrn.create_config_descriptor_xml(cfg, openlcb::CDI_FILENAME);
@@ -231,17 +181,6 @@ void setup()
 
 void loop()
 {
-    // if the TCP/IP listener has a new client accept it and add it
-    // as a new GridConnect port.
-    if (openMRNServer.hasClient())
-    {
-        WiFiClient client = openMRNServer.available();
-        if (client)
-        {
-            openmrn.add_gridconnect_port(new Esp32WiFiClientAdapter(client));
-        }
-    }
-
     // Call the OpenMRN executor, this needs to be done as often
     // as possible from the loop() method.
     openmrn.loop();

--- a/arduino/examples/ESP32WifiCanBridge/config.h
+++ b/arduino/examples/ESP32WifiCanBridge/config.h
@@ -1,7 +1,7 @@
 #ifndef _ARDUINO_EXAMPLE_ESP32WIFICANBRIDGE_CONFIG_H_
 #define _ARDUINO_EXAMPLE_ESP32WIFICANBRIDGE_CONFIG_H_
 
-#include "freertos_drivers/esp32/Esp32WiFiManager.hxx"
+#include "freertos_drivers/esp32/Esp32WiFiConfiguration.hxx"
 #include "openlcb/ConfiguredConsumer.hxx"
 #include "openlcb/ConfiguredProducer.hxx"
 #include "openlcb/ConfigRepresentation.hxx"

--- a/arduino/examples/ESP32WifiCanBridge/config.h
+++ b/arduino/examples/ESP32WifiCanBridge/config.h
@@ -1,6 +1,7 @@
 #ifndef _ARDUINO_EXAMPLE_ESP32WIFICANBRIDGE_CONFIG_H_
 #define _ARDUINO_EXAMPLE_ESP32WIFICANBRIDGE_CONFIG_H_
 
+#include "freertos_drivers/esp32/Esp32WiFiManager.hxx"
 #include "openlcb/ConfiguredConsumer.hxx"
 #include "openlcb/ConfiguredProducer.hxx"
 #include "openlcb/ConfigRepresentation.hxx"
@@ -39,6 +40,7 @@ CDI_GROUP(IoBoardSegment, Segment(MemoryConfigDefs::SPACE_CONFIG), Offset(128));
 /// Each entry declares the name of the current entry, then the type and then
 /// optional arguments list.
 CDI_GROUP_ENTRY(internal_config, InternalConfigData);
+CDI_GROUP_ENTRY(wifi, WiFiConfiguration, Name("WiFi Configuration"));
 CDI_GROUP_END();
 
 /// This segment is only needed temporarily until there is program code to set

--- a/arduino/libify.sh
+++ b/arduino/libify.sh
@@ -144,21 +144,24 @@ rm -f ${TARGET_LIB_DIR}/src/openlcb/CompileCdiMain.cxx \
 
 copy_file src/freertos_drivers/arduino \
           src/freertos_drivers/common/DeviceBuffer.{hxx,cxx} \
+          src/freertos_drivers/common/DeviceFile.{hxx,cxx} \
+          src/freertos_drivers/common/Devtab.hxx \
+          src/freertos_drivers/common/Fileio.cxx \
           src/freertos_drivers/common/GpioWrapper.hxx \
-          src/freertos_drivers/arduino/*
+          src/freertos_drivers/common/Select.cxx \
+          src/freertos_drivers/arduino/* \
+          include/freertos/stropts.h
 
-copy_file src/freertos_drivers/esp32 \
-          src/freertos_drivers/esp32/*
+copy_dir src/freertos_drivers \
+          src/freertos_drivers/esp32
 
-copy_file src/os src/os/*.h src/os/*.c src/os/*.hxx
+copy_file src/os src/os/*.h src/os/*.c src/os/*.hxx src/os/OS.cxx
 
 copy_file src/sys include/sys/tree.hxx
 
 copy_file src/utils src/utils/*.{cxx,hxx,c,h}
 
-rm -f ${TARGET_LIB_DIR}/src/utils/ReflashBootloader.cxx \
-    ${TARGET_LIB_DIR}/src/utils/HubDeviceSelect.cxx \
-    ${TARGET_LIB_DIR}/src/utils/HubDeviceSelect.hxx
+rm -f ${TARGET_LIB_DIR}/src/utils/ReflashBootloader.cxx
 
 if [ "x$VERBOSE" != "x" ]; then
     echo "Renaming all cxx to cpp under ${TARGET_LIB_DIR}/src"

--- a/src/executor/Executor.cxx
+++ b/src/executor/Executor.cxx
@@ -225,7 +225,7 @@ void *ExecutorBase::entry()
     return nullptr;
 }
 
-#elif defined(ARDUINO)
+#elif defined(ARDUINO) && (!defined(ESP32))
 
 void *ExecutorBase::entry()
 {

--- a/src/executor/Executor.cxx
+++ b/src/executor/Executor.cxx
@@ -423,7 +423,7 @@ void ExecutorBase::shutdown()
     add(this);
     while (!done_)
     {
-#if defined(ARDUINO)
+#if defined(ARDUINO) && !defined(ESP32)
         delay(1);
 #else
         usleep(100);

--- a/src/freertos_drivers/common/Devtab.hxx
+++ b/src/freertos_drivers/common/Devtab.hxx
@@ -35,7 +35,11 @@
 #define _FREERTOS_DRIVERS_COMMON_DEVTAB_HXX_
 
 #include <dirent.h>
+#ifndef ARDUINO
 #include <stropts.h>
+#else
+#include "freertos_drivers/arduino/stropts.h"
+#endif
 #include <sys/types.h>
 #include <sys/select.h>
 #include "os/OS.hxx"

--- a/src/freertos_drivers/common/Fileio.cxx
+++ b/src/freertos_drivers/common/Fileio.cxx
@@ -320,6 +320,10 @@ int FileIO::fcntl(File *file, int cmd, unsigned long data)
     }
 }
 
+// The ESP32 VFS layer provides the functions below and will have conflicts
+// if these are used instead.
+#ifndef ESP32
+
 extern "C" {
 
 /** Open a file or device.
@@ -504,3 +508,5 @@ int fcntl(int fd, int cmd, ...)
 }
 
 }
+
+#endif // ESP32

--- a/src/freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx
+++ b/src/freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx
@@ -199,6 +199,7 @@ private:
                 // not possible when in this state.
                 LOG(WARNING, "ESP32-CAN: initiating recovery");
                 can_initiate_recovery();
+                parent->busOffCount++;
                 continue;
             }
             else if (status.state == CAN_STATE_RECOVERING)

--- a/src/freertos_drivers/esp32/Esp32WiFiClientAdapter.hxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiClientAdapter.hxx
@@ -49,6 +49,7 @@ public:
         : client_(client)
     {
         client_.setNoDelay(true);
+        // TODO: should we set the client RX/TX timeout?
     }
 
     /// This is how many bytes we return as writeable when select says the
@@ -120,6 +121,34 @@ public:
             bytesRead = client_.read((uint8_t *)buffer, len);
         }
         return bytesRead;
+    }
+
+    /// @return true if the underlying WiFiClient is still connected.
+    bool connected()
+    {
+        return client_.connected();
+    }
+
+    /// @return remote IP address from the underlying WiFiClient.
+    IPAddress remoteIP() const
+    {
+        return client_.remoteIP();
+    }
+
+    /// @return remote port from the underlying WiFiClient.
+    uint16_t remotePort() const
+    {
+        return client_.remotePort();
+    }
+
+    /// @return true if we successfully reconnected to the remote connection
+    bool reconnect()
+    {
+        if (connected())
+        {
+            return true;
+        }
+        return client_.connect(client_.remoteIP(), client_.remotePort());
     }
 
 private:

--- a/src/freertos_drivers/esp32/Esp32WiFiConfiguration.hxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiConfiguration.hxx
@@ -42,7 +42,7 @@ class Esp32WiFiConfigurationParams
 {
 public:
     /// <map> of possible keys and descriptive values to show to the user for
-    /// the search_mode field.
+    /// the wifi_sleep and hub_mode fields.
     static constexpr const char *BOOLEAN_MAP =
         "<relation><property>0</property><value>No</value></relation>"
         "<relation><property>1</property><value>Yes</value></relation>";

--- a/src/freertos_drivers/esp32/Esp32WiFiConfiguration.hxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiConfiguration.hxx
@@ -1,0 +1,123 @@
+/** \copyright
+ * Copyright (c) 2019, Mike Dunston
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file Esp32WiFiConfiguration.hxx
+ *
+ * ESP32 WiFiConfiguration CDI declarations
+ *
+ * @author Mike Dunston
+ * @date 11 February 2019
+ */
+
+#ifndef _FREERTOS_DRIVERS_ESP32_ESP32WIFICONFIG_HXX_
+#define _FREERTOS_DRIVERS_ESP32_ESP32WIFICONFIG_HXX_
+
+#include "openlcb/ConfigRepresentation.hxx"
+#include "openlcb/ConfiguredTcpConnection.hxx"
+
+class Esp32WiFiConfigurationParams
+{
+public:
+    /// <map> of possible keys and descriptive values to show to the user for
+    /// the search_mode field.
+    static constexpr const char *BOOLEAN_MAP =
+        "<relation><property>0</property><value>No</value></relation>"
+        "<relation><property>1</property><value>Yes</value></relation>";
+
+    /// Visible name for the WiFi Power Savings mode.
+    static constexpr const char *WIFI_POWER_SAVE_NAME =
+        "WiFi Power Savings Mode";
+
+    /// Visible description for the WiFi Power Savings mode.
+    static constexpr const char *WIFI_POWER_SAVE_DESC = 
+        "When enabled this allows the ESP32 WiFi radio to use power savings "
+        "mode which puts the radio to sleep except to receive beacon updates "
+        "from the connected SSID. This should generally not need to be "
+        "enabled unless you are powering the ESP32 from a battery.";
+
+    /// Visible name for the Hub Configuration group.
+    static constexpr const char *HUB_NAME = "Hub Configuration";
+
+    /// Visible description for the Hub Configuration group.
+    static constexpr const char *HUB_DESC = 
+        "Configuration settings for an OpenLCB Hub";
+
+    /// Visible name for the hub_mode field.
+    static constexpr const char *HUB_MODE_NAME = "Enable Hub Mode";
+
+    /// Visible description for the hub_mode field.
+    static constexpr const char *HUB_MODE_DESC = 
+        "Defines this node as a hub which can accept connections";
+
+    /// Visible name for the hub_listener_port field.
+    static constexpr const char *HUB_LISTENER_PORT_NAME =
+        "Hub Listener Port";
+
+    /// Visible name for the hub_listener_port field.
+    static constexpr const char *HUB_LISTENER_PORT_DESC = 
+        "Defines the TCP/IP listener port this node will use when operating "
+        "as a hub. Most of the time this does not need to be changed.";
+
+    /// Visible name for the link_config group.
+    static constexpr const char *LINK_NAME = "Node Connect Configuration";
+
+    /// Visible name for the link_config group.
+    static constexpr const char *LINK_DESC =
+        "Configures how this node will connect to other nodes.";
+};
+
+CDI_GROUP(HubConfiguration);
+CDI_GROUP_ENTRY(enabled, openlcb::Uint8ConfigEntry,
+    Name(Esp32WiFiConfigurationParams::HUB_MODE_NAME),
+    Description(Esp32WiFiConfigurationParams::HUB_MODE_DESC),
+    Min(0), Max(1), Default(0),
+    MapValues(Esp32WiFiConfigurationParams::BOOLEAN_MAP));
+CDI_GROUP_ENTRY(port, openlcb::Uint16ConfigEntry,
+    Name(Esp32WiFiConfigurationParams::HUB_LISTENER_PORT_NAME),
+    Description(Esp32WiFiConfigurationParams::HUB_LISTENER_PORT_DESC),
+    Min(1), Max(65535),
+    Default(openlcb::TcpClientDefaultParams::DEFAULT_PORT))
+CDI_GROUP_ENTRY(service_name, openlcb::StringConfigEntry<48>,
+    Name(openlcb::TcpClientDefaultParams::SERVICE_NAME),
+    Description(openlcb::TcpClientDefaultParams::SERVICE_DESCR));
+CDI_GROUP_END();
+
+CDI_GROUP(WiFiConfiguration);
+CDI_GROUP_ENTRY(wifi_sleep, openlcb::Uint8ConfigEntry,
+    Name(Esp32WiFiConfigurationParams::WIFI_POWER_SAVE_NAME),
+    Description(Esp32WiFiConfigurationParams::WIFI_POWER_SAVE_DESC),
+    Min(0), Max(1), Default(0),
+    MapValues(Esp32WiFiConfigurationParams::BOOLEAN_MAP));
+CDI_GROUP_ENTRY(hub_config, HubConfiguration,
+    Name(Esp32WiFiConfigurationParams::HUB_NAME),
+    Description(Esp32WiFiConfigurationParams::HUB_DESC));
+CDI_GROUP_ENTRY(link_config,
+    openlcb::TcpClientConfig<openlcb::TcpClientDefaultParams>,
+    Name(Esp32WiFiConfigurationParams::LINK_NAME),
+    Description(Esp32WiFiConfigurationParams::LINK_DESC));
+CDI_GROUP_END();
+
+#endif // _FREERTOS_DRIVERS_ESP32_ESP32WIFICONFIG_HXX_

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
@@ -1,0 +1,614 @@
+/** \copyright
+ * Copyright (c) 2019, Mike Dunston
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file Esp32WiFiManager.cxx
+ *
+ * ESP32 WiFi Manager
+ *
+ * @author Mike Dunston
+ * @date 4 February 2019
+ */
+
+#include "freertos_drivers/esp32/Esp32WiFiManager.hxx"
+#include "OpenMRN.h"
+#include "openlcb/ConfiguredTcpConnection.hxx"
+#include "openlcb/TcpDefs.hxx"
+
+using openlcb::TcpDefs;
+using openlcb::NodeID;
+
+/// String values for wifi_status_t values, WL_NO_SHIELD has been intentionally
+/// omitted as its value is 255 and is explicitly checked for.
+static constexpr char const *WIFI_STATUS[] =
+{
+    "WiFi Idle",            // WL_IDLE_STATUS
+    "SSID not found",       // WL_NO_SSID_AVAIL
+    "SSID scan completed",  // WL_SCAN_COMPLETED
+    "WiFi connected",       // WL_CONNECTED
+    "SSID connect failed",  // WL_CONNECT_FAILED
+    "WiFi connection lost", // WL_CONNECTION_LOST
+    "WiFi disconnected"     // WL_DISCONNECTED
+};
+
+Esp32WiFiManager::Esp32WiFiManager(const char *ssid, const char *password,
+    const char *hostname_prefix, OpenMRN *openmrn,
+    const openlcb::NodeID node_id, const WiFiConfiguration &cfg) : ssid_(ssid),
+    password_(password), cfg_(cfg), openmrn_(openmrn)
+{
+    // register the Esp32WiFiManager instance to receive config updates.
+    ConfigUpdateService::instance()->register_update_listener(this);
+
+    // if these are not passed in we will not manage the WiFi stack with this
+    // class, only the hub and outbound connection features.
+    if (ssid_ && password_ && hostname_prefix)
+    {
+        // calculate the hostname for the ESP32 based on the provided prefix and
+        // the last 32 bits of the node id.
+        // node_id : 0x050101011425
+        // hostname_ : hostname_prefix + '-' + 01011425
+        hostname_ = String(hostname_prefix) + "-";
+        // append the last 32 bits of the provided node id, ie:
+        hostname_ += String((uint32_t)(node_id & 0xFFFFFFFF), 16);
+
+        // the maximum length hostname for the ESP32 is 32 bytes so truncate if
+        // necessary
+        // ref https://github.com/espressif/esp-idf/blob/master/components/tcpip_adapter/include/tcpip_adapter.h#L611
+        if (hostname_.length() > TCPIP_HOSTNAME_MAX_SIZE)
+        {
+            LOG(WARNING, "ESP32 hostname is too long, original hostname: %s", hostname_.c_str());
+            hostname_ = hostname_.substring(0, TCPIP_HOSTNAME_MAX_SIZE);
+            LOG(WARNING, "truncated hostname: %s", hostname_.c_str());
+        }
+        manageWiFi_ = true;
+    }
+    else
+    {
+        // since we do not have an SSID, Password and hostname prefix we should
+        // not manage the WiFi stack within this class.
+        manageWiFi_ = false;
+    }
+}
+
+#define VERIFY_CACHED_VALUE(current_value, new_value) \
+    if (current_value != new_value) \
+    { \
+        current_value = new_value; \
+        configUpdated = true; \
+    }
+
+ConfigUpdateListener::UpdateAction Esp32WiFiManager::apply_configuration(
+    int fd, bool initial_load, BarrierNotifiable *done)
+{
+    AutoNotify n(done);
+    LOG(VERBOSE, "Esp32WiFiManager::apply_configuration(%d, %d)", fd, initial_load);
+    bool configUpdated = false;
+    bool wifiSleepMode = cfg_.wifi_sleep().read(fd);
+    bool hubEnabled = cfg_.hub_config().enabled().read(fd);
+    uint16_t hubPort = cfg_.hub_config().port().read(fd);
+    String hubServiceName = String(cfg_.hub_config().service_name().read(fd).c_str());
+    const TcpClientConfig<TcpClientDefaultParams> &link_config =
+        cfg_.link_config();
+    SocketClientParams::SearchMode tcpClientMode =
+        (SocketClientParams::SearchMode)link_config.search_mode().read(fd);
+    String tcpmDNSServiceName =
+        String(link_config.auto_address().service_name().read(fd).c_str());
+    String tcpAutoHostName =
+        String(link_config.auto_address().host_name().read(fd).c_str());
+    String tcpManualHostName =
+        String(link_config.manual_address().ip_address().read(fd).c_str());
+    uint16_t tcpManualPort = link_config.manual_address().port().read(fd);
+
+    // if this is the first time this node is loading its config we can simply
+    // accept all config as is and start the WiFi system.
+    if (initial_load)
+    {
+        configUpdated = true;
+        wifiSleepMode_ = wifiSleepMode;
+        hubEnabled_ = hubEnabled;
+        hubPort_ = hubPort;
+        hubServiceName_ = hubServiceName;
+        tcpClientMode_ = tcpClientMode;
+        tcpmDNSServiceName_ = tcpmDNSServiceName;
+        tcpAutoHostName_ = tcpAutoHostName;
+        tcpManualHostName_ = tcpManualHostName;
+        tcpManualPort_ = tcpManualPort;
+    }
+    else
+    {
+        // check each parameter and update the cache if it is different
+        VERIFY_CACHED_VALUE(wifiSleepMode_, wifiSleepMode)
+        VERIFY_CACHED_VALUE(hubEnabled_, hubEnabled)
+        VERIFY_CACHED_VALUE(hubPort_, hubPort)
+        VERIFY_CACHED_VALUE(hubServiceName_, hubServiceName)
+        VERIFY_CACHED_VALUE(tcpClientMode_, tcpClientMode)
+        VERIFY_CACHED_VALUE(tcpmDNSServiceName_, tcpmDNSServiceName)
+        VERIFY_CACHED_VALUE(tcpAutoHostName_, tcpAutoHostName)
+        VERIFY_CACHED_VALUE(tcpManualHostName_, tcpManualHostName)
+        VERIFY_CACHED_VALUE(tcpManualPort_, tcpManualPort)
+    }
+
+    // verify settings provided to make sure they are valid
+    if (tcpClientMode_ != SocketClientParams::SearchMode::AUTO_ONLY)
+    {
+        // if the manual hostname is not provided (or is blank) or we do not
+        // have a valid manual port force settings to AUTO_ONLY.
+        if (!tcpManualHostName_.length() || tcpManualPort_ == 0)
+        {
+            LOG(WARNING, "Missing manual hub hostname or port, "
+                "switching to AUTO_ONLY mode");
+            tcpClientMode_ = SocketClientParams::SearchMode::AUTO_ONLY;
+            // record the updated settings.
+            link_config.search_mode().write(fd, tcpClientMode_);
+        }
+    }
+
+    // if this is the first time we are loaded start the WiFi system.
+    if (initial_load)
+    {
+        startWiFiSystem();
+    }
+
+    // if the configuration settings have changed, restart the WiFi manager
+    // task to pick up the updated settings.
+    if (configUpdated)
+    {
+        stopWiFiTask();
+        startWiFiTask();
+    }
+
+    return ConfigUpdateListener::UpdateAction::UPDATED;
+}
+
+void Esp32WiFiManager::factory_reset(int fd)
+{
+    LOG(VERBOSE, "Esp32WiFiManager::factory_reset(%d)", fd);
+    // General WiFi configuration settings
+    CDI_FACTORY_RESET(cfg_.wifi_sleep);
+
+    // Hub specific configuration settings
+    CDI_FACTORY_RESET(cfg_.hub_config().enabled);
+    CDI_FACTORY_RESET(cfg_.hub_config().port);
+    cfg_.hub_config().service_name().write(fd,
+        TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN_TCP);
+
+    // node link configuration settings
+    CDI_FACTORY_RESET(cfg_.link_config().search_mode);
+    CDI_FACTORY_RESET(cfg_.link_config().reconnect);
+
+    // node link manual configuration settings
+    cfg_.link_config().manual_address().ip_address().write(fd, "");
+    CDI_FACTORY_RESET(cfg_.link_config().manual_address().port);
+
+    // node link automatic configuration settings
+    cfg_.link_config().auto_address().service_name().write(fd,
+        TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN_TCP);
+    cfg_.link_config().auto_address().host_name().write(fd, "");
+
+    // node link automatic last connected node address
+    cfg_.link_config().last_address().ip_address().write(fd, "");
+    CDI_FACTORY_RESET(cfg_.link_config().last_address().port);
+
+    // reconnect to last connected node
+    CDI_FACTORY_RESET(cfg_.link_config().reconnect);
+}
+
+void Esp32WiFiManager::startWiFiSystem()
+{
+    // if we are to manage the entire WiFi stack start and configure it here
+    if (manageWiFi_)
+    {
+        // set the WiFI mode to STATION since we will connect to an AP
+        WiFi.mode(WIFI_STA);
+
+        // this next line tells the WiFi system to shutdown, this is needed to
+        // ensure we have a higher success rate of connecting to the AP.
+        WiFi.disconnect(true);
+
+        // configure the WiFi system to automatically reconnect to the AP if we
+        // get disconnected for any reason.
+        WiFi.setAutoReconnect(true);
+
+        LOG(INFO, "ESP32 hostname: %s", hostname_.c_str());
+        WiFi.setHostname(hostname_.c_str());
+        LOG(INFO, "Connecting to SSID: %s", ssid_);
+        if (WiFi.begin(ssid_, password_) != WL_CONNECT_FAILED) {
+            // allow up to 10 checks to see if we have connected to the SSID.
+            static constexpr uint8_t attempts = 10;
+            uint8_t attempt = 0;
+
+            // this call waits up to 10sec for a result before timing out so it
+            // needs to be called a few times until we get a final result.
+            uint8_t wifiStatus = WiFi.waitForConnectResult();
+            while (wifiStatus != WL_CONNECTED &&      // successfully connected
+                   wifiStatus != WL_NO_SSID_AVAIL &&  // SSID not found
+                   wifiStatus != WL_CONNECT_FAILED && // generic failure
+                   ++attempt <= attempts)
+            {
+                esp_task_wdt_reset();
+                LOG(WARNING, "[%d/%d] WiFi not connected yet, status: %d (%s)",
+                    attempt, attempts, wifiStatus, WIFI_STATUS[wifiStatus]);
+                wifiStatus = WiFi.waitForConnectResult();
+            }
+        }
+        if (WiFi.status() != WL_CONNECTED)
+        {
+            LOG(FATAL, "SSID connection failed: %s",
+                WIFI_STATUS[WiFi.status()]);
+        }
+        else
+        {
+            LOG(INFO, "Connected to SSID: %s, IP: %s", ssid_,
+                WiFi.localIP().toString().c_str());
+        }
+    }
+
+    // This can make the wifi much more responsive. Since we are plugged in we
+    // don't care about the increased power usage. Disable when on battery.
+    // this is managed by this class regardless of manageWiFi_ setting since it
+    // is exposed in the CDI.
+    WiFi.setSleep(wifiSleepMode_);
+}
+
+void Esp32WiFiManager::startWiFiTask()
+{
+    // if we have a manual hostname defined, resolve the hostname to an IP
+    if (!tcpManualHostName_.equals(""))
+    {
+        // note this call can block for up to 2sec.
+        tcpManualIP_ = MDNS.queryHost(tcpManualHostName_);
+    }
+
+    if (!hubServiceName_.equals("") && hubEnabled_)
+    {
+        // split the mDNS service name since the ESPmDNS library wants it to
+        // be passed as two parameters.
+        hubServiceNameNoProtocol_ = hubServiceName_.substring(
+            0, hubServiceName_.indexOf("."));
+        hubServiceProtocol_ = hubServiceName_.substring(
+            hubServiceName_.indexOf(".") + 1);
+    }
+
+    if (!tcpmDNSServiceName_.equals(""))
+    {
+        // split the mDNS service name since the ESPmDNS library wants it to
+        // be passed as two parameters.
+        tcpmDNSServiceNameNoProtocol_ = tcpmDNSServiceName_.substring(
+            0, tcpmDNSServiceName_.indexOf("."));
+        tcpmDNSServiceProtocol_ = tcpmDNSServiceName_.substring(
+            tcpmDNSServiceName_.indexOf(".") + 1);
+    }
+
+    os_thread_create(&wifiTaskHandle_, "OpenMRN-WiFi-Mgr", WIFI_TASK_PRIORITY,
+        WIFI_TASK_STACK_SIZE, wifi_manager_task, this);
+}
+
+void Esp32WiFiManager::stopWiFiTask()
+{
+    // request the wifi_manager_task to shutdown
+    wifiTaskShutdownReq_ = true;
+
+    // wait for wifi_manager_task to stop
+    while (wifiTaskRunning_)
+    {
+        esp_task_wdt_reset();
+        vTaskDelay(pdMS_TO_TICKS(250));
+    }
+    wifiTaskHandle_ = nullptr;
+}
+
+bool Esp32WiFiManager::connectedTo(const String hostname, const IPAddress ip)
+{
+    // check if the passed hostname is this node
+    if (hostname_ == hostname)
+    {
+        // it is us, we don't need to connect to it
+        return true;
+    }
+
+    // passed hostname is not this node, check if we have an active connection
+    // already being tracked.
+    for (auto const &pair : hubConnections_)
+    {
+        if (pair.first->remoteIP() == ip)
+        {
+            return true;
+        }
+    }
+
+    // it is not this node and we don't already have a connection so it is safe
+    // to connect to it.
+    return false;
+}
+
+bool Esp32WiFiManager::isPreferredHub(const String hostname)
+{
+    // if we have a preferred hub check if the passed hostname is it
+    if (tcpAutoHostName_ != hostname)
+    {
+        // we have a preferred hub and this is not it
+        return false;
+    }
+    // either we don't have a preferred hub or this was it
+    return true;
+}
+
+bool Esp32WiFiManager::connectToHub(String hostname, IPAddress ip,
+    uint16_t remotePort)
+{
+    if (connectedTo(hostname, ip))
+    {
+        LOG(WARNING, "[CLIENT] Already connected to %s:%d, skipping",
+            hostname.c_str(), remotePort);
+        return true;
+    }
+
+    // check if we have been called with an invalid configuration and silently
+    // reject it
+    if (hostname.equals(""))
+    {
+        return false;
+    }
+
+    // we found a remote hub to try and connect to
+    WiFiClient remoteNode;
+    LOG(INFO, "[CLIENT] Connecting to %s:%d...", hostname.c_str(), remotePort);
+    if (!remoteNode.connect(ip, remotePort))
+    {
+        LOG(WARNING, "[CLIENT] Failed to connect to %s:%d!",
+            hostname.c_str(), remotePort);
+        return false;
+    }
+    LOG(INFO, "[CLIENT] Successfully connected to %s:%d!",
+        hostname.c_str(), remotePort);
+    Esp32WiFiClientAdapter *adapter = new Esp32WiFiClientAdapter(remoteNode);
+    // add the new connction to the stack and record the returned excutor so
+    // we can clean it up later if needed.
+    hubConnections_.insert(std::make_pair(adapter,
+        openmrn_->add_gridconnect_port(adapter)));
+    return true;
+}
+
+bool Esp32WiFiManager::connectToManualHubIfNeeded()
+{
+    // if we are in manual-auto or manual-only mode try and connect to the
+    // configured hub. NOTE: we are not checking for auto-manual here as
+    // this node may successfully connect to an mDNS remote hub instead.
+    if(tcpClientMode_ == SocketClientParams::SearchMode::MANUAL_AUTO ||
+       tcpClientMode_ == SocketClientParams::SearchMode::MANUAL_ONLY)
+    {
+        return connectToHub(tcpManualHostName_, tcpManualIP_, tcpManualPort_);
+    }
+    return false;
+}
+
+bool Esp32WiFiManager::connectToMDNSHubs()
+{
+    bool connected = false;
+    LOG(INFO, "[CLIENT] Scanning for mDNS service %s.%s",
+        tcpmDNSServiceNameNoProtocol_.c_str(), tcpmDNSServiceProtocol_.c_str());
+    // NOTE: this blocks for up to 3sec to collect results
+    int entries = MDNS.queryService(hubServiceNameNoProtocol_,
+        tcpmDNSServiceProtocol_);
+    for (int index = 0; index < entries; index++)
+    {
+        // check if this is a preferred hub, this will internally check if we
+        // have a preferred hub or not.
+        if (!isPreferredHub(MDNS.hostname(index)))
+        {
+            LOG(VERBOSE, "[CLIENT] Found %s but it is not our preferred host.",
+                MDNS.hostname(index).c_str());
+            continue;
+        }
+        // attempt to connect to the remote hub, this will internally check if
+        // we are already connected or not.
+        if (connectToHub(MDNS.hostname(index), MDNS.IP(index),
+            MDNS.port(index)))
+        {
+            connected = true;
+        }
+    }
+    return connected;
+}
+
+void *Esp32WiFiManager::wifi_manager_task(void *param)
+{
+    Esp32WiFiManager *wifi = static_cast<Esp32WiFiManager *>(param);
+
+    // set this flag to indicate we are running.
+    wifi->wifiTaskRunning_ = true;
+
+    // set this flag to ensure we loop at least once before shutdown.
+    wifi->wifiTaskShutdownReq_ = false;
+
+    // reset this to default
+    wifi->hubSocket_ = nullptr;
+
+    // Add this task to the WDT
+    esp_task_wdt_add(wifi->wifiTaskHandle_);
+
+    // check if we need to manage the MDNS services
+    if (wifi->manageWiFi_)
+    {
+        // start the MDNS system now that we have an IP address
+        MDNS.begin(wifi->hostname_.c_str());
+    }
+
+    // if we are a hub we need to setup the mDNS entry to advertise that we can
+    // accept connections from other client nodes
+    if (wifi->hubEnabled_)
+    {
+        LOG(INFO, "[HUB] Starting TCP/IP listener on port %d", wifi->hubPort_);
+        wifi->hubSocket_ = new SocketListener(wifi->hubPort_,
+            [wifi](int socket)
+            {
+                Esp32WiFiClientAdapter *newClient =
+                    new Esp32WiFiClientAdapter(WiFiClient(socket));
+                LOG(VERBOSE, "[HUB] New WiFi connection: %s",
+                    newClient->remoteIP().toString().c_str());
+                wifi->clientConnections_.insert(std::make_pair(newClient,
+                    wifi->openmrn_->add_gridconnect_port(newClient)));
+            }
+        );
+        LOG(INFO, "[HUB] Configuring mDNS broadcast %s.%s:%d",
+            wifi->hubServiceNameNoProtocol_.c_str(),
+            wifi->hubServiceProtocol_.c_str(),
+            wifi->hubPort_);
+        // Broadcast this node's hostname with the mDNS service name
+        // for a TCP GridConnect endpoint.
+        MDNS.addService(wifi->hubServiceNameNoProtocol_,
+            wifi->hubServiceProtocol_, wifi->hubPort_);
+    }
+
+    // cache parameters we are using often
+    SocketClientParams::SearchMode client_mode = wifi->tcpClientMode_;
+
+    TickType_t next_mdns_scan_tick = 0;
+    while (!wifi->wifiTaskShutdownReq_)
+    {
+        // tracking list for dead connections, this is common to both the hub
+        // mode and client mode.
+        std::vector<Esp32WiFiClientAdapter *> deadConnections;
+
+        // Feed the watchdog so it doesn't reset the ESP32
+        esp_task_wdt_reset();
+
+        // if this node is a hub verify that all connected clients are still
+        // connected, any that have disconnected we need to remove from the
+        // stack.
+        if (wifi->hubEnabled_)
+        {
+            for (const auto &pair : wifi->clientConnections_)
+            {
+                // Feed the watchdog so it doesn't reset the ESP32
+                esp_task_wdt_reset();
+                if (!pair.first->connected())
+                {
+                    // connection has died, clean it up
+                    wifi->openmrn_->remove_port(pair.second);
+                    deadConnections.push_back(pair.first);
+                }
+            }
+        }
+
+        // if sufficient ticks have passed since our last mDNS scan and we
+        // do not have any connections to hubs, perform an mDNS scan and
+        // connect to any "new" endpoints.
+        auto current_tick_count = xTaskGetTickCount();
+        if (current_tick_count >= next_mdns_scan_tick)
+        {
+            next_mdns_scan_tick = current_tick_count + MDNS_SCAN_INTERVAL;
+            if (wifi->hubConnections_.empty())
+            {
+                // TODO: currently this code does not process the reconnect
+                // flag declared in the CDI. However, if a connection is
+                // established to a hub and that connection goes down it will
+                // attempt to reconnect.
+
+                bool connected = wifi->connectToManualHubIfNeeded();
+                // if we haven't connected to a hub and we are in an auto mode
+                // try and connect to an mDNS discovered hub.
+                if (!connected &&
+                    client_mode != SocketClientParams::SearchMode::MANUAL_ONLY)
+                {
+                    connected = wifi->connectToMDNSHubs();
+                }
+
+                // if we have not connected to a hub and we are in AUTO_MANUAL
+                // mode and have a manual hostname try and connect to it.
+                if (!connected &&
+                    client_mode == SocketClientParams::SearchMode::AUTO_MANUAL)
+                {
+                    // if we didn't connect to any hubs via mDNS, try and
+                    // connect to a manually configured hub.
+                    // NOTE: there is no check that we connected successfully
+                    // here as we will loop through and check again for
+                    // automatic entries and re-enter this block if we don't
+                    // connect to one.
+                    wifi->connectToHub(wifi->tcpManualHostName_,
+                        wifi->tcpManualIP_, wifi->tcpManualPort_);
+                }
+            }
+        }
+
+        // validate any hub connections to ensure they are all still active
+        // any that are dead we remove from the stack
+        for (const auto &pair : wifi->hubConnections_)
+        {
+            // Feed the watchdog so it doesn't reset the ESP32
+            esp_task_wdt_reset();
+
+            if (!pair.first->connected())
+            {
+                // connection has died, try to reconnect
+                if (!pair.first->reconnect())
+                {
+                    // remote hub is gone, remove it from the stack
+                    wifi->openmrn_->remove_port(pair.second);
+                    deadConnections.push_back(pair.first);
+                }
+            }
+        }
+
+        // if we identified any dead connections above, clean them up.
+        for (auto client : deadConnections)
+        {
+            // Feed the watchdog so it doesn't reset the ESP32
+            esp_task_wdt_reset();
+
+            auto it = wifi->clientConnections_.find(client);
+            if (it != wifi->clientConnections_.end())
+            {
+                wifi->clientConnections_.erase(it);
+            }
+            else
+            {
+                it = wifi->hubConnections_.find(client);
+                if (it != wifi->hubConnections_.end())
+                {
+                    wifi->hubConnections_.erase(it);
+                }
+            }
+            delete client;
+        }
+        deadConnections.clear();
+    }
+
+    if (wifi->hubSocket_ != nullptr)
+    {
+        LOG(INFO, "[HUB] Shutting down TCP/IP listener");
+        wifi->hubSocket_->shutdown();
+        delete wifi->hubSocket_;
+        LOG(INFO, "[HUB] Removing mDNS broadcast %s.%s",
+            wifi->hubServiceNameNoProtocol_.c_str(),
+            wifi->hubServiceProtocol_.c_str());
+        // not using MDNS wrapper as it doesn't expose this method
+        mdns_service_remove(wifi->hubServiceNameNoProtocol_.c_str(),
+            wifi->hubServiceProtocol_.c_str());
+    }
+
+    wifi->wifiTaskRunning_ = false;
+    return nullptr;
+}

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
@@ -37,8 +37,17 @@
 #include "openlcb/ConfiguredTcpConnection.hxx"
 #include "openlcb/TcpDefs.hxx"
 
-using openlcb::TcpDefs;
+#include <ESPmDNS.h>
+#include <MD5Builder.h>
+#include <WiFi.h>
+
 using openlcb::NodeID;
+using openlcb::TcpAutoAddress;
+using openlcb::TcpClientConfig;
+using openlcb::TcpClientDefaultParams;
+using openlcb::TcpDefs;
+using openlcb::TcpManualAddress;
+using std::string;
 
 /// String values for wifi_status_t values, WL_NO_SHIELD has been intentionally
 /// omitted as its value is 255 and is explicitly checked for.
@@ -53,513 +62,588 @@ static constexpr char const *WIFI_STATUS[] =
     "WiFi disconnected"     // WL_DISCONNECTED
 };
 
-Esp32WiFiManager::Esp32WiFiManager(const char *ssid, const char *password,
-    const char *hostname_prefix, OpenMRN *openmrn,
-    const openlcb::NodeID node_id, const WiFiConfiguration &cfg) : ssid_(ssid),
-    password_(password), cfg_(cfg), openmrn_(openmrn)
+static constexpr const char *CLIENT_SEARCH_MODE_STRINGS[] =
 {
-    // register the Esp32WiFiManager instance to receive config updates.
-    ConfigUpdateService::instance()->register_update_listener(this);
+    "auto, manual",
+    "manual, auto",
+    "auto only",
+    "manual only"
+};
 
-    // if these are not passed in we will not manage the WiFi stack with this
-    // class, only the hub and outbound connection features.
-    if (ssid_ && password_ && hostname_prefix)
-    {
-        // calculate the hostname for the ESP32 based on the provided prefix and
-        // the last 32 bits of the node id.
-        // node_id : 0x050101011425
-        // hostname_ : hostname_prefix + '-' + 01011425
-        hostname_ = String(hostname_prefix) + "-";
-        // append the last 32 bits of the provided node id, ie:
-        hostname_ += String((uint32_t)(node_id & 0xFFFFFFFF), 16);
+static constexpr const char *BOOLEAN_DISPLAY_STRINGS[] =
+{
+    "No",
+    "Yes"
+};
 
-        // the maximum length hostname for the ESP32 is 32 bytes so truncate if
-        // necessary
-        // ref https://github.com/espressif/esp-idf/blob/master/components/tcpip_adapter/include/tcpip_adapter.h#L611
-        if (hostname_.length() > TCPIP_HOSTNAME_MAX_SIZE)
-        {
-            LOG(WARNING, "ESP32 hostname is too long, original hostname: %s", hostname_.c_str());
-            hostname_ = hostname_.substring(0, TCPIP_HOSTNAME_MAX_SIZE);
-            LOG(WARNING, "truncated hostname: %s", hostname_.c_str());
-        }
-        manageWiFi_ = true;
-    }
-    else
+Esp32WiFiManager::Esp32WiFiManager(const char *ssid, const char *password,
+    OpenMRN *openmrn, const WiFiConfiguration &cfg) :
+    DefaultConfigUpdateListener(), ssid_(ssid), password_(password),
+    cfg_(cfg), manageWiFi_(true), openmrn_(openmrn)
+{
+    // Extend the capacity of the hostname to make space for the node-id and
+    // underscore.
+    hostname_.reserve(TCPIP_HOSTNAME_MAX_SIZE);
+
+    // Generate the hostname for the ESP32 based on the provided node id.
+    // node_id : 0x050101011425
+    // hostname_ : esp32_050101011425
+    NodeID node_id = openmrn_->stack()->node()->node_id();
+    hostname_.append(uint64_to_string_hex(node_id, 0));
+
+    // Release any extra capacity allocated for the hostname.
+    hostname_.shrink_to_fit();
+
+    // The maximum length hostname for the ESP32 is 32 characters so truncate
+    // when necessary.
+    // ref https://github.com/espressif/esp-idf/blob/master/components/tcpip_adapter/include/tcpip_adapter.h#L611
+    if (hostname_.length() > TCPIP_HOSTNAME_MAX_SIZE)
     {
-        // since we do not have an SSID, Password and hostname prefix we should
-        // not manage the WiFi stack within this class.
-        manageWiFi_ = false;
+        LOG(WARNING, "ESP32 hostname is too long, original hostname: %s",
+            hostname_.c_str());
+        hostname_.resize(TCPIP_HOSTNAME_MAX_SIZE);
+        LOG(WARNING, "truncated hostname: %s", hostname_.c_str());
     }
 }
 
-#define VERIFY_CACHED_VALUE(current_value, new_value) \
-    if (current_value != new_value) \
-    { \
-        current_value = new_value; \
-        configUpdated = true; \
-    }
+Esp32WiFiManager::Esp32WiFiManager(OpenMRN *openmrn,
+    const WiFiConfiguration &cfg) : DefaultConfigUpdateListener(), cfg_(cfg),
+    manageWiFi_(false), openmrn_(openmrn)
+{
+    // Nothing to do here.
+}
 
 ConfigUpdateListener::UpdateAction Esp32WiFiManager::apply_configuration(
     int fd, bool initial_load, BarrierNotifiable *done)
 {
     AutoNotify n(done);
-    LOG(VERBOSE, "Esp32WiFiManager::apply_configuration(%d, %d)", fd, initial_load);
-    bool configUpdated = false;
-    bool wifiSleepMode = cfg_.wifi_sleep().read(fd);
-    bool hubEnabled = cfg_.hub_config().enabled().read(fd);
-    uint16_t hubPort = cfg_.hub_config().port().read(fd);
-    String hubServiceName = String(cfg_.hub_config().service_name().read(fd).c_str());
-    const TcpClientConfig<TcpClientDefaultParams> &link_config =
-        cfg_.link_config();
-    SocketClientParams::SearchMode tcpClientMode =
-        (SocketClientParams::SearchMode)link_config.search_mode().read(fd);
-    String tcpmDNSServiceName =
-        String(link_config.auto_address().service_name().read(fd).c_str());
-    String tcpAutoHostName =
-        String(link_config.auto_address().host_name().read(fd).c_str());
-    String tcpManualHostName =
-        String(link_config.manual_address().ip_address().read(fd).c_str());
-    uint16_t tcpManualPort = link_config.manual_address().port().read(fd);
+    LOG(VERBOSE, "Esp32WiFiManager::apply_configuration(%d, %d)", fd,
+        initial_load);
+    // Cache the fd for later use by the wifi background task.
+    configFd_ = fd;
+    configReloadRequested_ = initial_load;
 
-    // if this is the first time this node is loading its config we can simply
-    // accept all config as is and start the WiFi system.
-    if (initial_load)
+    // Load our full config set into memory to do an MD5 check against our last
+    // loaded configuration so we can avoid reloading configuration when there
+    // are no interesting changes.
+    MD5Builder md5;
+    std::unique_ptr<uint8_t[]> md5buf(new uint8_t[cfg_.size()]);
+    // If we are unable to seek to the right position in the persistent storage
+    // give up and request a reboot.
+    if(lseek(fd, cfg_.offset(), SEEK_SET) != cfg_.offset())
     {
-        configUpdated = true;
-        wifiSleepMode_ = wifiSleepMode;
-        hubEnabled_ = hubEnabled;
-        hubPort_ = hubPort;
-        hubServiceName_ = hubServiceName;
-        tcpClientMode_ = tcpClientMode;
-        tcpmDNSServiceName_ = tcpmDNSServiceName;
-        tcpAutoHostName_ = tcpAutoHostName;
-        tcpManualHostName_ = tcpManualHostName;
-        tcpManualPort_ = tcpManualPort;
+        LOG(WARNING, "lseek failed to reset fd offset, REBOOT_NEEDED");
+        return ConfigUpdateListener::UpdateAction::REBOOT_NEEDED;
+    }
+
+    // If we are unable to read the full configuration from persistent storage
+    // give up and request a reboot.
+    if(read(fd, md5buf.get(), cfg_.size()) != cfg_.size())
+    {
+        LOG(WARNING, "read failed to fully read the config, REBOOT_NEEDED");
+        return ConfigUpdateListener::UpdateAction::REBOOT_NEEDED;
+    }
+
+    // Calculate MD5 from the loaded buffer.
+    md5.begin();
+    md5.add(md5buf.get(), cfg_.size());
+    md5.calculate();
+    string configMD5 = md5.toString().c_str();
+    LOG(VERBOSE, "existing config MD5: \"%s\", new MD5: \"%s\"",
+        configMD5_.c_str(), configMD5.c_str());
+
+    if(!initial_load)
+    {
+        // Check the MD5 against our last known MD5, it doesn't matter which is
+        // different, but that they are different as part of setting
+        // configReloadRequested_.
+        configReloadRequested_ = configMD5_.compare(configMD5);
+        LOG(VERBOSE, "Config Change detected: %s",
+            BOOLEAN_DISPLAY_STRINGS[configReloadRequested_]);
     }
     else
     {
-        // check each parameter and update the cache if it is different
-        VERIFY_CACHED_VALUE(wifiSleepMode_, wifiSleepMode)
-        VERIFY_CACHED_VALUE(hubEnabled_, hubEnabled)
-        VERIFY_CACHED_VALUE(hubPort_, hubPort)
-        VERIFY_CACHED_VALUE(hubServiceName_, hubServiceName)
-        VERIFY_CACHED_VALUE(tcpClientMode_, tcpClientMode)
-        VERIFY_CACHED_VALUE(tcpmDNSServiceName_, tcpmDNSServiceName)
-        VERIFY_CACHED_VALUE(tcpAutoHostName_, tcpAutoHostName)
-        VERIFY_CACHED_VALUE(tcpManualHostName_, tcpManualHostName)
-        VERIFY_CACHED_VALUE(tcpManualPort_, tcpManualPort)
+        start_wifi_task();
     }
 
-    // verify settings provided to make sure they are valid
-    if (tcpClientMode_ != SocketClientParams::SearchMode::AUTO_ONLY)
-    {
-        // if the manual hostname is not provided (or is blank) or we do not
-        // have a valid manual port force settings to AUTO_ONLY.
-        if (!tcpManualHostName_.length() || tcpManualPort_ == 0)
-        {
-            LOG(WARNING, "Missing manual hub hostname or port, "
-                "switching to AUTO_ONLY mode");
-            tcpClientMode_ = SocketClientParams::SearchMode::AUTO_ONLY;
-            // record the updated settings.
-            link_config.search_mode().write(fd, tcpClientMode_);
-        }
-    }
+    // Store the calculated MD5 for future use when the apply_configuration
+    // method is called to detect any configuration changes.
+    configMD5_ = std::move(configMD5);
 
-    // if this is the first time we are loaded start the WiFi system.
-    if (initial_load)
-    {
-        startWiFiSystem();
-    }
-
-    // if the configuration settings have changed, restart the WiFi manager
-    // task to pick up the updated settings.
-    if (configUpdated)
-    {
-        stopWiFiTask();
-        startWiFiTask();
-    }
-
+    // Inform the caller that the configuration has been updated as the wifi
+    // task will reload the configuration as part of it's next wake up cycle.
     return ConfigUpdateListener::UpdateAction::UPDATED;
 }
 
 void Esp32WiFiManager::factory_reset(int fd)
 {
     LOG(VERBOSE, "Esp32WiFiManager::factory_reset(%d)", fd);
-    // General WiFi configuration settings
+    // General WiFi configuration settings.
     CDI_FACTORY_RESET(cfg_.wifi_sleep);
 
-    // Hub specific configuration settings
+    // Hub specific configuration settings.
     CDI_FACTORY_RESET(cfg_.hub_config().enabled);
     CDI_FACTORY_RESET(cfg_.hub_config().port);
     cfg_.hub_config().service_name().write(fd,
         TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN_TCP);
 
-    // node link configuration settings
+    // Node link configuration settings.
     CDI_FACTORY_RESET(cfg_.link_config().search_mode);
     CDI_FACTORY_RESET(cfg_.link_config().reconnect);
 
-    // node link manual configuration settings
+    // Node link manual configuration settings.
     cfg_.link_config().manual_address().ip_address().write(fd, "");
     CDI_FACTORY_RESET(cfg_.link_config().manual_address().port);
 
-    // node link automatic configuration settings
+    // Node link automatic configuration settings.
     cfg_.link_config().auto_address().service_name().write(fd,
         TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN_TCP);
     cfg_.link_config().auto_address().host_name().write(fd, "");
 
-    // node link automatic last connected node address
+    // Node link automatic last connected node address.
     cfg_.link_config().last_address().ip_address().write(fd, "");
     CDI_FACTORY_RESET(cfg_.link_config().last_address().port);
 
-    // reconnect to last connected node
+    // Reconnect to last connected node.
     CDI_FACTORY_RESET(cfg_.link_config().reconnect);
 }
 
-void Esp32WiFiManager::startWiFiSystem()
+void Esp32WiFiManager::start_wifi_system()
 {
-    // if we are to manage the entire WiFi stack start and configure it here
-    if (manageWiFi_)
+    // If we do not need to manage the WiFi / MDNS systems exit early.
+    if(!manageWiFi_)
     {
-        // set the WiFI mode to STATION since we will connect to an AP
-        WiFi.mode(WIFI_STA);
+        return;
+    }
 
-        // this next line tells the WiFi system to shutdown, this is needed to
-        // ensure we have a higher success rate of connecting to the AP.
-        WiFi.disconnect(true);
+    // Set the WiFI mode to STATION since we will connect to the SSID. This
+    // is also required to allow configuration of the ESP32 prior to calling
+    // WiFi.begin().
+    WiFi.mode(WIFI_STA);
 
-        // configure the WiFi system to automatically reconnect to the AP if we
-        // get disconnected for any reason.
-        WiFi.setAutoReconnect(true);
+    // This next line tells the WiFi system to shutdown, this is needed to
+    // ensure we have a higher success rate of connecting to the SSID.
+    WiFi.disconnect(true);
 
-        LOG(INFO, "ESP32 hostname: %s", hostname_.c_str());
-        WiFi.setHostname(hostname_.c_str());
-        LOG(INFO, "Connecting to SSID: %s", ssid_);
-        if (WiFi.begin(ssid_, password_) != WL_CONNECT_FAILED) {
-            // allow up to 10 checks to see if we have connected to the SSID.
-            static constexpr uint8_t attempts = 10;
-            uint8_t attempt = 0;
+    // Configure the WiFi system to automatically reconnect to the SSID if we
+    // get disconnected for any reason.
+    WiFi.setAutoReconnect(true);
 
-            // this call waits up to 10sec for a result before timing out so it
-            // needs to be called a few times until we get a final result.
-            uint8_t wifiStatus = WiFi.waitForConnectResult();
-            while (wifiStatus != WL_CONNECTED &&      // successfully connected
-                   wifiStatus != WL_NO_SSID_AVAIL &&  // SSID not found
-                   wifiStatus != WL_CONNECT_FAILED && // generic failure
-                   ++attempt <= attempts)
-            {
-                esp_task_wdt_reset();
-                LOG(WARNING, "[%d/%d] WiFi not connected yet, status: %d (%s)",
-                    attempt, attempts, wifiStatus, WIFI_STATUS[wifiStatus]);
-                wifiStatus = WiFi.waitForConnectResult();
-            }
-        }
-        if (WiFi.status() != WL_CONNECTED)
+    // Set the generated hostname prior to connecting to the SSID so that it
+    // shows up with the generated hostname instead of the default "Espressif".
+    LOG(INFO, "Setting ESP32 hostname: \"%s\"", hostname_.c_str());
+    WiFi.setHostname(hostname_.c_str());
+
+    // Attempt to connect to the SSID, this will block until the ESP32 starts
+    // the connection process, note it may not have an IP address immediately
+    // thus the need to check the connection result a few times before giving
+    // up with a FATAL error.
+    LOG(INFO, "Connecting to SSID: \"%s\"", ssid_);
+    if (WiFi.begin(ssid_, password_) != WL_CONNECT_FAILED)
+    {
+        // Allow up to 10 checks to see if we have connected to the SSID.
+        static constexpr uint8_t attempts = 10;
+        uint8_t attempt = 0;
+
+        // This call waits up to 10sec for a result before timing out so it
+        // needs to be called a few times until we get a final result.
+        uint8_t wifiStatus = WiFi.waitForConnectResult();
+        while (wifiStatus != WL_CONNECTED &&       // successfully connected
+                wifiStatus != WL_NO_SSID_AVAIL &&  // SSID not found
+                wifiStatus != WL_CONNECT_FAILED && // generic failure
+                ++attempt <= attempts)
         {
-            LOG(FATAL, "SSID connection failed: %s",
-                WIFI_STATUS[WiFi.status()]);
-        }
-        else
-        {
-            LOG(INFO, "Connected to SSID: %s, IP: %s", ssid_,
-                WiFi.localIP().toString().c_str());
+            esp_task_wdt_reset();
+            LOG(WARNING, "[%d/%d] WiFi not connected yet, status: %d (%s)",
+                attempt, attempts, wifiStatus, WIFI_STATUS[wifiStatus]);
+            wifiStatus = WiFi.waitForConnectResult();
         }
     }
 
-    // This can make the wifi much more responsive. Since we are plugged in we
-    // don't care about the increased power usage. Disable when on battery.
-    // this is managed by this class regardless of manageWiFi_ setting since it
-    // is exposed in the CDI.
-    WiFi.setSleep(wifiSleepMode_);
+    // Verify if we were successful in connecting to the SSID and obtaining
+    // a valid IP address via DHCP. Note the usage of FATAL will trigger the
+    // ESP32 to enter a failure state and reboot.
+    if (WiFi.status() != WL_CONNECTED)
+    {
+        LOG(FATAL, "SSID connection failed: %s", WIFI_STATUS[WiFi.status()]);
+    }
+
+    // The ESP32 successfully connected to the SSID and has received an IP
+    // address via DHCP.
+    LOG(INFO, "Connected to SSID: %s, Node IP: %s", ssid_,
+        WiFi.localIP().toString().c_str());
+
+    // Start the mDNS system with our generated hostname so it can be resolved
+    // by other nodes.
+    MDNS.begin(hostname_.c_str());
 }
 
-void Esp32WiFiManager::startWiFiTask()
+void Esp32WiFiManager::start_wifi_task()
 {
-    // if we have a manual hostname defined, resolve the hostname to an IP
-    if (!tcpManualHostName_.equals(""))
-    {
-        // note this call can block for up to 2sec.
-        tcpManualIP_ = MDNS.queryHost(tcpManualHostName_);
-    }
-
-    if (!hubServiceName_.equals("") && hubEnabled_)
-    {
-        // split the mDNS service name since the ESPmDNS library wants it to
-        // be passed as two parameters.
-        hubServiceNameNoProtocol_ = hubServiceName_.substring(
-            0, hubServiceName_.indexOf("."));
-        hubServiceProtocol_ = hubServiceName_.substring(
-            hubServiceName_.indexOf(".") + 1);
-    }
-
-    if (!tcpmDNSServiceName_.equals(""))
-    {
-        // split the mDNS service name since the ESPmDNS library wants it to
-        // be passed as two parameters.
-        tcpmDNSServiceNameNoProtocol_ = tcpmDNSServiceName_.substring(
-            0, tcpmDNSServiceName_.indexOf("."));
-        tcpmDNSServiceProtocol_ = tcpmDNSServiceName_.substring(
-            tcpmDNSServiceName_.indexOf(".") + 1);
-    }
-
-    os_thread_create(&wifiTaskHandle_, "OpenMRN-WiFi-Mgr", WIFI_TASK_PRIORITY,
+    os_thread_create(&wifiTaskHandle_, "OpenMRN-WiFiMgr", WIFI_TASK_PRIORITY,
         WIFI_TASK_STACK_SIZE, wifi_manager_task, this);
 }
 
-void Esp32WiFiManager::stopWiFiTask()
+bool Esp32WiFiManager::is_connected_to(const IPAddress ip, const uint16_t port)
 {
-    // request the wifi_manager_task to shutdown
-    wifiTaskShutdownReq_ = true;
-
-    // wait for wifi_manager_task to stop
-    while (wifiTaskRunning_)
+    // Check if the passed ip is this node, port doesn't matter.
+    if (WiFi.localIP() == ip)
     {
-        esp_task_wdt_reset();
-        vTaskDelay(pdMS_TO_TICKS(250));
-    }
-    wifiTaskHandle_ = nullptr;
-}
-
-bool Esp32WiFiManager::connectedTo(const String hostname, const IPAddress ip)
-{
-    // check if the passed hostname is this node
-    if (hostname_ == hostname)
-    {
-        // it is us, we don't need to connect to it
+        // The ip is for this node, we don't need to connect to it.
         return true;
     }
 
-    // passed hostname is not this node, check if we have an active connection
-    // already being tracked.
+    // Provided ip is not for this node, check if we have an active connection
+    // already being tracked using the provided port.
     for (auto const &pair : hubConnections_)
     {
-        if (pair.first->remoteIP() == ip)
+        if (pair.first->remoteIP() == ip && pair.first->remotePort() == port)
         {
             return true;
         }
     }
 
-    // it is not this node and we don't already have a connection so it is safe
-    // to connect to it.
+    // We don't already have a connection so it is safe to connect to it.
     return false;
 }
 
-bool Esp32WiFiManager::isPreferredHub(const String hostname)
+bool Esp32WiFiManager::connect_to_hub(const IPAddress ip, const uint16_t port)
 {
-    // if we have a preferred hub check if the passed hostname is it
-    if (tcpAutoHostName_ != hostname)
+    if (is_connected_to(ip, port))
     {
-        // we have a preferred hub and this is not it
-        return false;
-    }
-    // either we don't have a preferred hub or this was it
-    return true;
-}
-
-bool Esp32WiFiManager::connectToHub(String hostname, IPAddress ip,
-    uint16_t remotePort)
-{
-    if (connectedTo(hostname, ip))
-    {
-        LOG(WARNING, "[CLIENT] Already connected to %s:%d, skipping",
-            hostname.c_str(), remotePort);
+        LOG(WARNING, "[CLIENT] Already connected to %s:%d, skipping.",
+            ip.toString().c_str(), port);
         return true;
     }
 
-    // check if we have been called with an invalid configuration and silently
-    // reject it
-    if (hostname.equals(""))
-    {
-        return false;
-    }
 
-    // we found a remote hub to try and connect to
+    // Try and connect the provided ip and port as we are not currently
+    // connected to it.
     WiFiClient remoteNode;
-    LOG(INFO, "[CLIENT] Connecting to %s:%d...", hostname.c_str(), remotePort);
-    if (!remoteNode.connect(ip, remotePort))
+    LOG(INFO, "[CLIENT] Connecting to %s:%d...", ip.toString().c_str(), port);
+    if (!remoteNode.connect(ip, port))
     {
         LOG(WARNING, "[CLIENT] Failed to connect to %s:%d!",
-            hostname.c_str(), remotePort);
+            ip.toString().c_str(), port);
         return false;
     }
     LOG(INFO, "[CLIENT] Successfully connected to %s:%d!",
-        hostname.c_str(), remotePort);
+        ip.toString().c_str(), port);
     Esp32WiFiClientAdapter *adapter = new Esp32WiFiClientAdapter(remoteNode);
-    // add the new connction to the stack and record the returned excutor so
-    // we can clean it up later if needed.
+
+    // Add the new connction to the stack and record the returned excutor so
+    // we can clean it up later when needed.
     hubConnections_.insert(std::make_pair(adapter,
         openmrn_->add_gridconnect_port(adapter)));
+
     return true;
 }
 
-bool Esp32WiFiManager::connectToManualHubIfNeeded()
-{
-    // if we are in manual-auto or manual-only mode try and connect to the
-    // configured hub. NOTE: we are not checking for auto-manual here as
-    // this node may successfully connect to an mDNS remote hub instead.
-    if(tcpClientMode_ == SocketClientParams::SearchMode::MANUAL_AUTO ||
-       tcpClientMode_ == SocketClientParams::SearchMode::MANUAL_ONLY)
-    {
-        return connectToHub(tcpManualHostName_, tcpManualIP_, tcpManualPort_);
-    }
-    return false;
-}
-
-bool Esp32WiFiManager::connectToMDNSHubs()
+bool Esp32WiFiManager::connect_to_mdns_hub(const string &preferred_hub_hostname,
+    const string &serviceName, const string &serviceProtocol)
 {
     bool connected = false;
-    LOG(INFO, "[CLIENT] Scanning for mDNS service %s.%s",
-        tcpmDNSServiceNameNoProtocol_.c_str(), tcpmDNSServiceProtocol_.c_str());
-    // NOTE: this blocks for up to 3sec to collect results
-    int entries = MDNS.queryService(hubServiceNameNoProtocol_,
-        tcpmDNSServiceProtocol_);
-    for (int index = 0; index < entries; index++)
+    LOG(INFO, "[CLIENT] Scanning for mDNS service \"%s.%s\"",
+        serviceName.c_str(), serviceProtocol.c_str());
+    // Note: this call will block for up to 3sec to collect results.
+    int entries = MDNS.queryService(serviceName.c_str(),
+        serviceProtocol.c_str());
+    for (int index = 0; index < entries && !connected; index++)
     {
-        // check if this is a preferred hub, this will internally check if we
-        // have a preferred hub or not.
-        if (!isPreferredHub(MDNS.hostname(index)))
+        // If we have a preferred hub hostname check if this match is for it.
+        if (preferred_hub_hostname.length() > 0 &&
+            preferred_hub_hostname.compare(MDNS.hostname(index).c_str()) != 0)
         {
-            LOG(VERBOSE, "[CLIENT] Found %s but it is not our preferred host.",
-                MDNS.hostname(index).c_str());
+            LOG(INFO, "[CLIENT] Discovered \"%s\" but it is not our "
+                "preferred hub \"%s\".",
+                MDNS.hostname(index).c_str(),
+                preferred_hub_hostname.c_str());
             continue;
         }
-        // attempt to connect to the remote hub, this will internally check if
-        // we are already connected or not.
-        if (connectToHub(MDNS.hostname(index), MDNS.IP(index),
-            MDNS.port(index)))
+
+        // Attempt to connect to the remote hub.
+        if (connect_to_hub(MDNS.IP(index), MDNS.port(index)))
         {
+            // store our last connected host and port
+            cfg_.link_config().last_address().ip_address().write(configFd_,
+                MDNS.IP(index).toString().c_str());
+            cfg_.link_config().last_address().port().write(configFd_,
+                MDNS.port(index));
             connected = true;
         }
     }
     return connected;
 }
 
+void Esp32WiFiManager::shutdown_hub(const string &serviceName,
+    const string &serviceProtocol)
+{
+    // If we have a hub socket we need to clean up any allocated resources.
+    if (hub_)
+    {
+        LOG(INFO, "[HUB] Removing mDNS advertisement %s.%s",
+            serviceName.c_str(), serviceProtocol.c_str());
+
+        // Note: not using MDNS wrapper as it doesn't expose this method.
+        mdns_service_remove(serviceName.c_str(), serviceProtocol.c_str());
+    }
+
+    // cleanup the configured hub socket listener.
+    hub_.reset(nullptr);
+}
+
+void Esp32WiFiManager::start_hub(const string &serviceName,
+    const string &serviceProtocol)
+{
+    uint16_t hub_port = CDI_READ_TRIMMED(cfg_.hub_config().port, configFd_);
+    LOG(INFO, "[HUB] Starting TCP/IP listener on port %d", hub_port);
+    hub_.reset(new GcTcpHub(openmrn_->stack()->can_hub(), hub_port));
+
+    while(!hub_->is_started())
+    {
+        vTaskDelay(pdMS_TO_TICKS(250));
+    }
+
+    LOG(INFO, "[HUB] Advertising %s.%s:%d via mDNS",
+        serviceName.c_str(), serviceProtocol.c_str(), hub_port);
+    // Advertise this node with the mDNS service name so other nodes can find
+    // it via queryService.
+    MDNS.addService(serviceName.c_str(), serviceProtocol.c_str(), hub_port);
+}
+
+void Esp32WiFiManager::disconnect_from_hubs()
+{
+    for (const auto &pair : hubConnections_)
+    {
+        LOG(INFO, "[CLIENT] Disconnecting from hub: %s:%d",
+            pair.first->remoteIP().toString().c_str(),
+            pair.first->remotePort());
+        openmrn_->remove_port(pair.second);
+        pair.first->stop();
+        delete pair.first;
+    }
+    hubConnections_.clear();
+}
+
+#define SPLIT_MDNS_SERVICE_NAME(service_name, service_protocol) \
+    if(service_name.length() && service_name.find('.', 0) != string::npos) \
+    { \
+        string::size_type split_loc = service_name.find('.', 0); \
+        service_protocol = service_name.substr(split_loc + 1); \
+        service_name.resize(split_loc); \
+    }
+
 void *Esp32WiFiManager::wifi_manager_task(void *param)
 {
     Esp32WiFiManager *wifi = static_cast<Esp32WiFiManager *>(param);
 
-    // set this flag to indicate we are running.
-    wifi->wifiTaskRunning_ = true;
+    wifi->start_wifi_system();
 
-    // set this flag to ensure we loop at least once before shutdown.
-    wifi->wifiTaskShutdownReq_ = false;
+    // Cache of the currently running configuration, these will be updated
+    // if/when configReloadRequested_ is set to true by the apply_configuration
+    // method.
+    bool hub_enabled = false;
+    bool reconnect_to_last_hub = true;
+    IPAddress last_hub_ip = INADDR_NONE;
+    uint16_t last_hub_port = TcpClientDefaultParams::DEFAULT_PORT;
+    SocketClientParams::SearchMode client_mode =
+        SocketClientParams::SearchMode::AUTO_MANUAL;
+    string hub_service_name = TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN;
+    string hub_service_protocol = TcpDefs::MDNS_PROTOCOL_TCP;
+    string tcp_service_name = TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN;
+    string tcp_service_protocol = TcpDefs::MDNS_PROTOCOL_TCP;
+    string auto_hub_hostname = "";
+    IPAddress manual_hub_ip = INADDR_NONE;
+    string manual_hub_host = "";
+    uint16_t manual_hub_port = TcpClientDefaultParams::DEFAULT_PORT;
 
-    // reset this to default
-    wifi->hubSocket_ = nullptr;
+    // Helpers for the nested CDI entries.
+    const HubConfiguration &hub = wifi->cfg_.hub_config();
+    const TcpClientConfig<TcpClientDefaultParams> &link_cfg =
+        wifi->cfg_.link_config();
+    const TcpManualAddress<TcpClientDefaultParams> &manaddr =
+        link_cfg.manual_address();
+    const TcpAutoAddress<TcpClientDefaultParams> &autoaddr =
+        link_cfg.auto_address();
+    const TcpManualAddress<TcpClientDefaultParams> &last_hub =
+        link_cfg.last_address();
 
-    // Add this task to the WDT
-    esp_task_wdt_add(wifi->wifiTaskHandle_);
-
-    // check if we need to manage the MDNS services
-    if (wifi->manageWiFi_)
+    // Used to track our last wake-up tick count so we can process only every
+    // CONNECTION_CHECK_TICK_INTERVAL ticks.
+    TickType_t last_wake_up_tick = xTaskGetTickCount();
+    while (true)
     {
-        // start the MDNS system now that we have an IP address
-        MDNS.begin(wifi->hostname_.c_str());
-    }
-
-    // if we are a hub we need to setup the mDNS entry to advertise that we can
-    // accept connections from other client nodes
-    if (wifi->hubEnabled_)
-    {
-        LOG(INFO, "[HUB] Starting TCP/IP listener on port %d", wifi->hubPort_);
-        wifi->hubSocket_ = new SocketListener(wifi->hubPort_,
-            [wifi](int socket)
-            {
-                Esp32WiFiClientAdapter *newClient =
-                    new Esp32WiFiClientAdapter(WiFiClient(socket));
-                LOG(VERBOSE, "[HUB] New WiFi connection: %s",
-                    newClient->remoteIP().toString().c_str());
-                wifi->clientConnections_.insert(std::make_pair(newClient,
-                    wifi->openmrn_->add_gridconnect_port(newClient)));
-            }
-        );
-        LOG(INFO, "[HUB] Configuring mDNS broadcast %s.%s:%d",
-            wifi->hubServiceNameNoProtocol_.c_str(),
-            wifi->hubServiceProtocol_.c_str(),
-            wifi->hubPort_);
-        // Broadcast this node's hostname with the mDNS service name
-        // for a TCP GridConnect endpoint.
-        MDNS.addService(wifi->hubServiceNameNoProtocol_,
-            wifi->hubServiceProtocol_, wifi->hubPort_);
-    }
-
-    // cache parameters we are using often
-    SocketClientParams::SearchMode client_mode = wifi->tcpClientMode_;
-
-    TickType_t next_mdns_scan_tick = 0;
-    while (!wifi->wifiTaskShutdownReq_)
-    {
-        // tracking list for dead connections, this is common to both the hub
-        // mode and client mode.
-        std::vector<Esp32WiFiClientAdapter *> deadConnections;
-
-        // Feed the watchdog so it doesn't reset the ESP32
-        esp_task_wdt_reset();
-
-        // if this node is a hub verify that all connected clients are still
-        // connected, any that have disconnected we need to remove from the
-        // stack.
-        if (wifi->hubEnabled_)
+        if(wifi->configReloadRequested_)
         {
-            for (const auto &pair : wifi->clientConnections_)
+            // Since the config has changed since we started, cleanup any
+            // existing connections before loading the new config.
+            wifi->shutdown_hub(hub_service_name, hub_service_protocol);
+            wifi->disconnect_from_hubs();
+
+            // Load the new configuration so we can start using it.
+            hub_enabled = CDI_READ_TRIMMED(hub.enabled, wifi->configFd_);
+            hub_service_name = hub.service_name().read(wifi->configFd_);
+            hub_service_protocol = TcpDefs::MDNS_PROTOCOL_TCP;
+            SPLIT_MDNS_SERVICE_NAME(hub_service_name, hub_service_protocol)
+
+            auto_hub_hostname = autoaddr.host_name().read(wifi->configFd_);
+            tcp_service_name = autoaddr.service_name().read(wifi->configFd_);
+            tcp_service_protocol = TcpDefs::MDNS_PROTOCOL_TCP;
+            SPLIT_MDNS_SERVICE_NAME(tcp_service_name, tcp_service_protocol)
+
+            client_mode = (SocketClientParams::SearchMode)CDI_READ_TRIMMED(
+                link_cfg.search_mode, wifi->configFd_);
+            
+            manual_hub_host = manaddr.ip_address().read(wifi->configFd_);
+            manual_hub_port = CDI_READ_TRIMMED(manaddr.port, wifi->configFd_);
+
+            // This can make the wifi much more responsive. Since we are
+            // plugged in we don't care about the increased power usage. This
+            // should be disabled when on battery via CDI.
+            WiFi.setSleep(CDI_READ_TRIMMED(wifi->cfg_.wifi_sleep,
+                wifi->configFd_));
+
+            reconnect_to_last_hub = CDI_READ_TRIMMED(link_cfg.reconnect,
+                wifi->configFd_);
+            string last_hub_ip_str =
+                last_hub.ip_address().read(wifi->configFd_);
+            last_hub_port = CDI_READ_TRIMMED(last_hub.port, wifi->configFd_);
+            // if we have a last hub address convert it to an IP address, if
+            // not leave as default so it doesn't get used.
+            last_hub_ip = INADDR_NONE;
+            if(last_hub_ip_str.length() > 0)
             {
-                // Feed the watchdog so it doesn't reset the ESP32
-                esp_task_wdt_reset();
-                if (!pair.first->connected())
+                last_hub_ip.fromString(last_hub_ip_str.c_str());
+            }
+
+            // Verify the updated configuration to make sure it is valid.
+            if (client_mode != SocketClientParams::SearchMode::AUTO_ONLY)
+            {
+                // Reset to default so we can resolve the hostname to an IP
+                // if/when we need it.
+                manual_hub_ip = INADDR_NONE;
+
+                // If the manual hostname is not provided (or is blank) or we
+                // do not have a valid manual port force settings to AUTO_ONLY.
+                if (manual_hub_host == "" || manual_hub_port == 0)
                 {
-                    // connection has died, clean it up
-                    wifi->openmrn_->remove_port(pair.second);
-                    deadConnections.push_back(pair.first);
+                    LOG(WARNING, "Invalid configuration detected, missing the "
+                        "manual hub hostname or port, switching to AUTO_ONLY "
+                        "mode.");
+                    client_mode = SocketClientParams::SearchMode::AUTO_ONLY;
                 }
+            }
+
+            LOG(INFO, "Esp32WiFiManager Configuration:");
+            LOG(INFO, "Hub (enabled:%s, port: %d, mDNS: \"%s.%s\")",
+                BOOLEAN_DISPLAY_STRINGS[hub_enabled],
+                CDI_READ_TRIMMED(hub.port, wifi->configFd_),
+                hub_service_name.c_str(), hub_service_protocol.c_str());
+            LOG(INFO, "Client (search-mode: %s, reconnect: %s, last-hub: "
+                "%s:%d, auto-addr-mDNS: \"%s.%s\", auto-pref-hub: \"%s\", "
+                "manual-hub: \"%s:%d\")",
+                CLIENT_SEARCH_MODE_STRINGS[client_mode],
+                BOOLEAN_DISPLAY_STRINGS[reconnect_to_last_hub],
+                last_hub_ip.toString().c_str(), last_hub_port,
+                tcp_service_name.c_str(), tcp_service_protocol.c_str(),
+                auto_hub_hostname.c_str(), manual_hub_ip.toString().c_str(),
+                manual_hub_port);
+            LOG(INFO, "WiFi-Sleep: %s",
+                BOOLEAN_DISPLAY_STRINGS[WiFi.getSleep()]);
+
+            // If this node is configured as a hub, start the listener.
+            if(hub_enabled)
+            {
+                wifi->start_hub(hub_service_name, hub_service_protocol);
+            }
+            wifi->configReloadRequested_ = false;
+        }
+
+        if (wifi->hubConnections_.empty())
+        {
+            // Flag to track our connection state.
+            bool connected = false;
+
+            // if we are to reconnect to our last hub and we have a valid
+            // address from the configuration try and connect.
+            if(reconnect_to_last_hub && last_hub_ip != INADDR_NONE)
+            {
+                connected = wifi->connect_to_hub(last_hub_ip,
+                    last_hub_port);
+            }
+
+            // If we have a manual hostname try and we have not
+            // successfully resolved it to an IP address try to resolve
+            // it now.
+            if (manual_hub_host.length() > 0 &&
+                manual_hub_ip == INADDR_NONE &&
+                !manual_hub_ip.fromString(manual_hub_host.c_str()))
+            {
+                // Note this call may block up to 2sec.
+                manual_hub_ip = MDNS.queryHost(manual_hub_host.c_str());
+
+                // Check if MDNS resolver was able to resolve it to a valid
+                // ip address.
+                if(manual_hub_ip == INADDR_NONE)
+                {
+                    LOG(WARNING,
+                        "[CLIENT] Unable to resolve the manually configured "
+                        "hostname \"%s\" to an IP.",
+                        manual_hub_host.c_str());
+                }
+            }
+
+            // Check if we are in manual-auto or manual-only and attempt to
+            // connect to the manually configured hub if we successfully
+            // resolved the hostname to an ip.
+            if(!connected &&
+                (client_mode == SocketClientParams::SearchMode::MANUAL_AUTO ||
+                client_mode == SocketClientParams::SearchMode::MANUAL_ONLY) &&
+                manual_hub_ip != INADDR_NONE)
+            {
+                connected = wifi->connect_to_hub(manual_hub_ip,
+                    manual_hub_port);
+            }
+
+            // If we didn't connected to a manually configured hub and we
+            // are in one of the auto modes try and connect to an mDNS
+            // discovered hub.
+            if (!connected &&
+                client_mode != SocketClientParams::SearchMode::MANUAL_ONLY)
+            {
+                connected = wifi->connect_to_mdns_hub(auto_hub_hostname,
+                    tcp_service_name, tcp_service_protocol);
+            }
+
+            // If we still have not connected to a hub, are in AUTO_MANUAL
+            // mode and have a manual hub try and connect to it.
+            if (!connected &&
+                client_mode == SocketClientParams::SearchMode::AUTO_MANUAL &&
+                manual_hub_ip != INADDR_NONE)
+            {
+                // If we didn't connect to any hubs via mDNS, try and
+                // connect to a manually configured hub.
+                // NOTE: there is no check that we connected successfully
+                // here as we will loop through and check again for
+                // automatic entries and re-enter this block if we don't
+                // connect to one.
+                connected = wifi->connect_to_hub(manual_hub_ip,
+                    manual_hub_port);
+            }
+
+            // No luck connecting to any hubs, log a message and try again
+            // on next iteration.
+            if(!connected)
+            {
+                LOG(WARNING, "[CLIENT] Failed to connect to any hubs.");
             }
         }
 
-        // if sufficient ticks have passed since our last mDNS scan and we
-        // do not have any connections to hubs, perform an mDNS scan and
-        // connect to any "new" endpoints.
-        auto current_tick_count = xTaskGetTickCount();
-        if (current_tick_count >= next_mdns_scan_tick)
-        {
-            next_mdns_scan_tick = current_tick_count + MDNS_SCAN_INTERVAL;
-            if (wifi->hubConnections_.empty())
-            {
-                // TODO: currently this code does not process the reconnect
-                // flag declared in the CDI. However, if a connection is
-                // established to a hub and that connection goes down it will
-                // attempt to reconnect.
-
-                bool connected = wifi->connectToManualHubIfNeeded();
-                // if we haven't connected to a hub and we are in an auto mode
-                // try and connect to an mDNS discovered hub.
-                if (!connected &&
-                    client_mode != SocketClientParams::SearchMode::MANUAL_ONLY)
-                {
-                    connected = wifi->connectToMDNSHubs();
-                }
-
-                // if we have not connected to a hub and we are in AUTO_MANUAL
-                // mode and have a manual hostname try and connect to it.
-                if (!connected &&
-                    client_mode == SocketClientParams::SearchMode::AUTO_MANUAL)
-                {
-                    // if we didn't connect to any hubs via mDNS, try and
-                    // connect to a manually configured hub.
-                    // NOTE: there is no check that we connected successfully
-                    // here as we will loop through and check again for
-                    // automatic entries and re-enter this block if we don't
-                    // connect to one.
-                    wifi->connectToHub(wifi->tcpManualHostName_,
-                        wifi->tcpManualIP_, wifi->tcpManualPort_);
-                }
-            }
-        }
-
-        // validate any hub connections to ensure they are all still active
+        // Validate any hub connections to ensure they are all still active
         // any that are dead we remove from the stack
+        std::vector<Esp32WiFiClientAdapter *> deadHubConnections;
         for (const auto &pair : wifi->hubConnections_)
         {
-            // Feed the watchdog so it doesn't reset the ESP32
-            esp_task_wdt_reset();
-
             if (!pair.first->connected())
             {
                 // connection has died, try to reconnect
@@ -567,48 +651,26 @@ void *Esp32WiFiManager::wifi_manager_task(void *param)
                 {
                     // remote hub is gone, remove it from the stack
                     wifi->openmrn_->remove_port(pair.second);
-                    deadConnections.push_back(pair.first);
+                    deadHubConnections.push_back(pair.first);
                 }
             }
         }
-
-        // if we identified any dead connections above, clean them up.
-        for (auto client : deadConnections)
+        LOG(VERBOSE, "[CLIENT] %d active connections, %d pending cleanup.",
+            wifi->hubConnections_.size() - deadHubConnections.size(),
+            deadHubConnections.size());
+        for (auto client : deadHubConnections)
         {
-            // Feed the watchdog so it doesn't reset the ESP32
-            esp_task_wdt_reset();
-
-            auto it = wifi->clientConnections_.find(client);
-            if (it != wifi->clientConnections_.end())
+            auto it = wifi->hubConnections_.find(client);
+            if (it != wifi->hubConnections_.end())
             {
-                wifi->clientConnections_.erase(it);
-            }
-            else
-            {
-                it = wifi->hubConnections_.find(client);
-                if (it != wifi->hubConnections_.end())
-                {
-                    wifi->hubConnections_.erase(it);
-                }
+                wifi->hubConnections_.erase(it);
             }
             delete client;
         }
-        deadConnections.clear();
+
+        // go to sleep until the next check interval
+        vTaskDelayUntil(&last_wake_up_tick, CONNECTION_CHECK_TICK_INTERVAL);
     }
 
-    if (wifi->hubSocket_ != nullptr)
-    {
-        LOG(INFO, "[HUB] Shutting down TCP/IP listener");
-        wifi->hubSocket_->shutdown();
-        delete wifi->hubSocket_;
-        LOG(INFO, "[HUB] Removing mDNS broadcast %s.%s",
-            wifi->hubServiceNameNoProtocol_.c_str(),
-            wifi->hubServiceProtocol_.c_str());
-        // not using MDNS wrapper as it doesn't expose this method
-        mdns_service_remove(wifi->hubServiceNameNoProtocol_.c_str(),
-            wifi->hubServiceProtocol_.c_str());
-    }
-
-    wifi->wifiTaskRunning_ = false;
     return nullptr;
 }

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
@@ -113,6 +113,7 @@ private:
 
     /// Background task used by the Esp32WiFiManager to maintain health of any
     /// connections to other nodes.
+    /// @param param is a pointer to the Esp32WiFiManager instance.
     static void *wifi_manager_task(void *param);
 
     /// @return true if we are already connected to the provided IPAddress.
@@ -128,36 +129,32 @@ private:
     bool connect_to_hub(const IPAddress ip, const uint16_t port);
 
     /// Attempts to connect to an mDNS discovered hub.
+    /// @param preferred_hub_hostname is the hostname of the hub this node
+    /// should prefer if found, can be blank.
+    /// @param serviceName is the mDNS service name to search for.
+    /// @param serviceProtocol is the mDNS service protocol to search for.
     /// @return true if we successfully connected to a hub, false otherwise.
     bool connect_to_mdns_hub(const std::string &preferred_hub_hostname,
         const std::string &serviceName, const std::string &serviceProtocol);
 
     /// Performs an orderly shutdown of the hub on this node, any connections
     /// will be closed and removed from the stack.
+    /// @param serviceName is the previously advertised mDNS service name.
+    /// @param serviceProtocol is the previously advertised mDNS service
+    /// protocol.
     void shutdown_hub(const std::string &serviceName,
         const std::string &serviceProtocol);
 
     /// Starts @ref SocketListener for the hub on this node and advertises the
     /// provided mDNS service name details.
-    void start_hub(const std::string &serviceName,
+    /// @param hub_port is the port to start the GcTcpHub on.
+    /// @param serviceName is the mDNS service name to advertise.
+    /// @param serviceProtocol is the mDNS service protocol to advertise.
+    void start_hub(const uint16_t hub_port, const std::string &serviceName,
         const std::string &serviceProtocol);
 
     /// Performs orderly shutdown of any outbound connections from this node.
     void disconnect_from_hubs();
-
-    /// Priority to use for the wifi_manager_task. This is currently set to
-    /// one priority level higher than the arduino-esp32 loopTask. The task
-    /// will primarily be in a sleep state so there will be limited impact on
-    /// the loopTask.
-    static constexpr UBaseType_t WIFI_TASK_PRIORITY = 2;
-
-    /// Stack size for the wifi_manager_task.
-    static constexpr uint32_t WIFI_TASK_STACK_SIZE = 2560L;
-
-    /// Interval at which to all TCP/IP connections and establish new outbound
-    /// connections if required.
-    static constexpr TickType_t CONNECTION_CHECK_TICK_INTERVAL =
-        pdMS_TO_TICKS(30000);
 
     /// Handle for the wifi_manager_task that manages the WiFi stack, including
     /// periodic health checks of the connected hubs or clients.

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
@@ -1,0 +1,316 @@
+/** \copyright
+ * Copyright (c) 2019, Mike Dunston
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file Esp32WiFiManager.hxx
+ *
+ * ESP32 WiFi Manager
+ *
+ * @author Mike Dunston
+ * @date 4 February 2019
+ */
+
+#ifndef _FREERTOS_DRIVERS_ESP32_ESP32WIFIMGR_HXX_
+#define _FREERTOS_DRIVERS_ESP32_ESP32WIFIMGR_HXX_
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <ESPmDNS.h>
+#include <WString.h>
+#include <vector>
+
+#include "freertos_drivers/esp32/Esp32WiFiClientAdapter.hxx"
+#include "openlcb/ConfigRepresentation.hxx"
+#include "openlcb/ConfiguredTcpConnection.hxx"
+#include "openlcb/SimpleStack.hxx"
+#include "openlcb/TcpDefs.hxx"
+#include "utils/macros.h"
+#include "utils/SocketClientParams.hxx"
+#include "utils/socket_listener.hxx"
+
+using openlcb::Uint8ConfigEntry;
+using openlcb::Uint16ConfigEntry;
+using openlcb::StringConfigEntry;
+using openlcb::TcpClientDefaultParams;
+using openlcb::TcpClientConfig;
+using openlcb::TcpDefs;
+
+/// <map> of possible keys and descriptive values to show to the user for
+/// the search_mode field.
+static constexpr const char *BOOLEAN_MAP =
+    "<relation><property>0</property><value>No</value></relation>"
+    "<relation><property>1</property><value>Yes</value></relation>";
+
+/// Visible name for the WiFi Power Savings mode.
+static constexpr const char *WIFI_POWER_SAVE_NAME = "WiFi Power Savings Mode";
+
+/// Visible description for the WiFi Power Savings mode.
+static constexpr const char *WIFI_POWER_SAVE_DESC = 
+    "When enabled this allows the ESP32 WiFi radio to use power savings mode "
+    "which puts the radio to sleep except to receive beacon updates from the "
+    "connected SSID. This should generally not need to be enabled unless you "
+    "are powering the ESP32 from a battery.";
+
+/// Visible name for the Hub Configuration group.
+static constexpr const char *HUB_NAME = "Hub Configuration";
+
+/// Visible description for the Hub Configuration group.
+static constexpr const char *HUB_DESC = 
+    "Configuration settings for an OpenLCB Hub";
+
+/// Visible name for the hub_mode field.
+static constexpr const char *HUB_MODE_NAME = "Enable Hub Mode";
+
+/// Visible description for the hub_mode field.
+static constexpr const char *HUB_MODE_DESC = 
+    "Defines this node as a hub which can accept connections";
+
+/// Visible name for the hub_listener_port field.
+static constexpr const char *HUB_LISTENER_PORT_NAME =
+    "Hub Listener Port";
+
+/// Visible name for the hub_listener_port field.
+static constexpr const char *HUB_LISTENER_PORT_DESC = 
+    "Defines the TCP/IP listener port this node will use when operating as a "
+    "hub. Most of the time this does not need to be changed.";
+
+/// Visible name for the link_config group.
+static constexpr const char *LINK_NAME = "Node Connect Configuration";
+
+/// Visible name for the link_config group.
+static constexpr const char *LINK_DESC =
+    "Configures how this node will connect to other nodes.";
+
+CDI_GROUP(HubConfiguration);
+CDI_GROUP_ENTRY(enabled, Uint8ConfigEntry,
+    Name(HUB_MODE_NAME), Description(HUB_MODE_DESC), Min(0), Max(1),
+    Default(0), MapValues(BOOLEAN_MAP));
+CDI_GROUP_ENTRY(port, Uint16ConfigEntry,
+    Name(HUB_LISTENER_PORT_NAME),
+    Description(HUB_LISTENER_PORT_DESC),
+    Min(1), Max(65535), Default(TcpClientDefaultParams::DEFAULT_PORT))
+CDI_GROUP_ENTRY(service_name, StringConfigEntry<48>,
+    Name(TcpClientDefaultParams::SERVICE_NAME),
+    Description(TcpClientDefaultParams::SERVICE_DESCR));
+CDI_GROUP_END();
+
+CDI_GROUP(WiFiConfiguration);
+CDI_GROUP_ENTRY(wifi_sleep, Uint8ConfigEntry,
+    Name(WIFI_POWER_SAVE_NAME), Description(WIFI_POWER_SAVE_DESC),
+    Min(0), Max(1), Default(0), MapValues(BOOLEAN_MAP));
+CDI_GROUP_ENTRY(hub_config, HubConfiguration,
+    Name(HUB_NAME),
+    Description(HUB_DESC));
+CDI_GROUP_ENTRY(link_config, TcpClientConfig<TcpClientDefaultParams>,
+    Name(LINK_NAME),
+    Description(LINK_DESC));
+CDI_GROUP_END();
+
+class Esp32WiFiManager : public ConfigUpdateListener
+{
+public:
+    /// Constructor.
+    ///
+    /// @param ssid is the WiFi AP to connect to.
+    /// @param password is the password for the WiFi AP being connected to.
+    /// @param hostname_prefix is the beginning part of the hostname that will
+    /// be advertised via mDNS and to the WiFi AP.
+    /// @param node_id is this node's unique ID, the last 32 bits are appended
+    /// to the hostname_prefix to generate a unique hostname.
+    /// @param cfg is the WiFiConfiguration instance used for this node. This
+    /// will be monitored for changes and the WiFi behavior altered
+    /// accordingly.
+    Esp32WiFiManager(const char *ssid, const char *password,
+        const char *hostname_prefix, OpenMRN *stack,
+        const openlcb::NodeID node_id, const WiFiConfiguration &cfg);
+
+    /// Updates the WiFiConfiguration settings used by this node.
+    ///
+    /// @param fd is the file descriptor used for the configuration settings.
+    /// @param initial_load is set to true when this node loads the
+    /// configuration for the first time, otherwise it is an update to the
+    /// configuration and may require a restart.
+    /// @param done is the control used by the caller to track when all config
+    /// consumers have completed their updates.
+    ///
+    /// @return UPDATED when the configuration has been successfully updated,
+    /// or REBOOT_NEEDED if the node needs to reboot for configuration to take
+    /// effect.
+    ConfigUpdateListener::UpdateAction apply_configuration(int fd,
+        bool initial_load, BarrierNotifiable *done) OVERRIDE;
+    void factory_reset(int fd) OVERRIDE;
+
+private:
+    /// Default constructor.
+    Esp32WiFiManager();
+
+    /// Starts the WiFi system and initiates the SSID connection process.
+    void startWiFiSystem();
+
+    /// Starts the Esp32WiFiManager, this manages the WiFi subsystem as well as
+    /// all interactions with other nodes.
+    void startWiFiTask();
+
+    /// Stops the Esp32WiFiManager, this will disable the WiFi subsystem and
+    /// all related interactions with other nodes.
+    void stopWiFiTask();
+
+    /// Background task used by the Esp32WiFiManager to maintain health of any
+    /// connections to other nodes.
+    static void *wifi_manager_task(void *param);
+
+    /// @return true if we are already connected to the provided IPAddress.
+    /// @param hostname is the remote hostname to be checked.
+    /// @param ip is the remote IPAddress to be checked.
+    bool connectedTo(const String hostname, const IPAddress ip);
+
+    /// @return true if the passed hostname is our preferred hub or if we have
+    /// no preference.
+    /// @param hostname is the hostname to be checked.
+    bool isPreferredHub(const String hostname);
+
+    /// Connects to a remote hub if we are not already connected to it.
+    /// @param hubHostname is the hostname for the remote hub.
+    /// @param ip is the remote hub ip address.
+    /// @param remotePort is the port on the hub to connect to.
+    /// @return true if the connection to the hub was successful or if already
+    /// connected to that hub, false otherwise.
+    bool connectToHub(String hubHostname, IPAddress ip, uint16_t remotePort);
+
+    /// Attempts to connect to a manually configured hub if this node is
+    /// configured to do so.
+    /// @return true if we successfully connected to the hub or if we need
+    /// to try mDNS.
+    bool connectToManualHubIfNeeded();
+
+    /// Attempts to connect to any mDNS identified hubs that we are not already
+    /// connected to.
+    /// @return true if we successfully connected to at least one hub, false
+    /// otherwise.
+    bool connectToMDNSHubs();
+
+    /// Priority to use for the wifi_manager_task. This is currently set to 1
+    /// which matches the arduino-esp32 loop() task priority.
+    static constexpr UBaseType_t WIFI_TASK_PRIORITY = 1;
+
+    /// Stack size for the wifi_manager_task.
+    static constexpr uint32_t WIFI_TASK_STACK_SIZE = 2048L;
+
+    /// Handle for the wifi_manager_task that manages the WiFi stack, including
+    /// periodic health checks of the connected hubs or clients.
+    TaskHandle_t wifiTaskHandle_;
+
+    /// Map of connections to any hubs that are to be maintained.
+    std::map<Esp32WiFiClientAdapter *, Executable *> hubConnections_;
+
+    /// Map of connections from other nodes to be monitored.
+    std::map<Esp32WiFiClientAdapter *, Executable *> clientConnections_;
+
+    /// Internal flag to tell the wifi_manager_task to shutdown.
+    bool wifiTaskShutdownReq_{false};
+
+    /// Internal flag used by the wifi_manager_task to indicate it is running.
+    bool wifiTaskRunning_{false};
+
+    /// Dynamically generated hostname for this node.
+    String hostname_;
+
+    /// User provided SSID to connect to.
+    const char *ssid_;
+
+    /// User provided password for the SSID to connect to.
+    const char *password_;
+
+    /// Persistent configuration that will be used for this node's WiFi usage.
+    const WiFiConfiguration cfg_;
+
+    /// This is internally used to enable the management of the WiFi stack, in
+    /// some environments this may be managed externally.
+    bool manageWiFi_;
+
+    /// OpenMRN stack for the Arduino system
+    OpenMRN *openmrn_;
+
+    /// Cached copy of this nodes wifi_sleep value. If this is true the WiFi
+    /// radio can go to into low power mode to conserve power. This is likely
+    /// only necessary for battery powered ESP32 devices.
+    bool wifiSleepMode_{false};
+
+    /// Cached copy of this nodes hub_config.enabled value, if this is
+    /// true this node will advertise itself as a hub via mDNS and accept
+    /// incoming TCP/IP connections.
+    bool hubEnabled_{false};
+
+    /// Cached copy of this nodes hub_config.port
+    uint16_t hubPort_{TcpClientDefaultParams::DEFAULT_PORT};
+
+    /// Cached copy of this nodes hub_config.service_name
+    String hubServiceName_{TcpDefs::MDNS_SERVICE_NAME_HUB_TCP};
+
+    /// Cached copy of this nodes hub_config.service_name split to not have
+    /// the protocol.
+    String hubServiceNameNoProtocol_{TcpDefs::MDNS_SERVICE_NAME_HUB};
+
+    /// Cached copy of this nodes hub_config.service_name split to only be
+    /// the protocol.
+    String hubServiceProtocol_{TcpDefs::MDNS_PROTOCOL_TCP};
+
+    /// Listener for this node when active as a hub.
+    SocketListener *hubSocket_;
+
+    /// Cached copy of this nodes link_config.search_mode
+    SocketClientParams::SearchMode tcpClientMode_{
+        SocketClientParams::SearchMode::AUTO_MANUAL};
+
+    /// Cached copy of this nodes link_config.auto_address.service_name
+    String tcpmDNSServiceName_{TcpDefs::MDNS_SERVICE_NAME_GRIDCONNECT_CAN};
+
+    /// Cached copy of this nodes link_config.auto_address.service_name
+    /// split to not have the protocol.
+    String tcpmDNSServiceNameNoProtocol_{TcpDefs::MDNS_SERVICE_NAME_HUB};
+
+    /// Cached copy of this nodes link_config.auto_address.service_name
+    /// split to only be the protocol.
+    String tcpmDNSServiceProtocol_{TcpDefs::MDNS_PROTOCOL_TCP};
+
+    /// Cached copy of this nodes link_config.auto_address.host_name
+    String tcpAutoHostName_{""};
+
+    /// Cached copy of this nodes link_config.manual_address.ip_address
+    String tcpManualHostName_{""};
+
+    /// Cached copy of this nodes link_config.manual_address.port
+    int tcpManualPort_{TcpClientDefaultParams::DEFAULT_PORT};
+
+    /// cached copy of the IPAddress for this nodes
+    /// link_config.manual_address.ip_address.
+    IPAddress tcpManualIP_;
+
+    /// Interval at which to perform mDNS scan for remote hubs
+    static constexpr TickType_t MDNS_SCAN_INTERVAL = pdMS_TO_TICKS(30000);
+
+    DISALLOW_COPY_AND_ASSIGN(Esp32WiFiManager);
+};
+#endif // _FREERTOS_DRIVERS_ESP32_ESP32WIFIMGR_HXX_

--- a/src/os/OS.cxx
+++ b/src/os/OS.cxx
@@ -1,0 +1,81 @@
+/** \copyright
+ * Copyright (c) 2019, Mike Dunston
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ * 
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file OS.cxx
+ * This file represents a C++ language abstraction of common operating
+ * system calls.
+ *
+ * @author Mike Dunston
+ * @date 22 Feb 2019
+ */
+
+#if defined (ESP32)
+
+#include "os/os.h"
+#include <Arduino.h>
+#include <freertos/task.h>
+#include <map>
+
+// since vTaskSetApplicationTaskTag is not enabled by default on ESP32 use a
+// std::map as a holder for thread private data.
+static std::map<os_thread_t, ThreadPriv *> threadPrivHolder;
+
+extern "C" {
+ThreadPriv *getCurrentThreadPriv()
+{
+    os_thread_t threadHandle = xTaskGetCurrentTaskHandle();
+    ThreadPriv *priv = nullptr;
+    if(threadPrivHolder.find(threadHandle) == threadPrivHolder.end())
+    {
+        // no thread priv allocated previously, allocate it now
+        // this should only happen for threads not started/owned by OpenMRN.
+        priv = (ThreadPriv *)malloc(sizeof(ThreadPriv));
+        priv->entry = nullptr;
+        priv->arg = nullptr;
+        priv->selectEventBit = 0;
+        threadPrivHolder[threadHandle] = priv;
+    }
+    else
+    {
+        priv = threadPrivHolder[threadHandle];
+    }
+    return priv;
+}
+
+void saveThreadPriv(ThreadPriv *priv)
+{
+    os_thread_t threadHandle = xTaskGetCurrentTaskHandle();
+    threadPrivHolder[threadHandle] = priv;
+}
+
+void eraseCurrentThreadPriv()
+{
+    os_thread_t threadHandle = xTaskGetCurrentTaskHandle();
+    threadPrivHolder.erase(threadHandle);
+}
+
+} // extern "C"
+#endif

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -47,6 +47,9 @@
 #include <task.h>
 #include <semphr.h>
 #include <event_groups.h>
+#elif defined(ESP32)
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 #elif defined(ESP_NONOS) || defined(ARDUINO)
 #else
 #include <pthread.h>
@@ -123,7 +126,16 @@ typedef struct {
     unsigned counter;
 } os_sem_t;
 
+#if defined(ESP32)
+typedef TaskHandle_t os_thread_t; /**< thread handle */
+typedef struct thread_priv
+{
+    void *(*entry)(void*); /**< thread entry point */
+    void *arg; /** argument to thread */
+} ThreadPriv; /**< thread private data */
+#else
 typedef unsigned os_thread_t;
+#endif
 typedef void *os_mq_t; /**< message queue handle */
 
 #else
@@ -317,6 +329,8 @@ OS_INLINE os_thread_t os_thread_self(void)
 {
 #if defined (__FreeRTOS__)
     return xTaskGetCurrentTaskHandle();
+#elif defined(ESP32)
+    return NULL;
 #elif defined(__EMSCRIPTEN__) || defined(ESP_NONOS) || defined(ARDUINO)
     return 0xdeadbeef;
 #else

--- a/src/utils/GridConnectHub.cxx
+++ b/src/utils/GridConnectHub.cxx
@@ -404,7 +404,7 @@ struct GcHubPort : public Executable
     {
         LOG(VERBOSE, "gchub port %p", (Executable *)this);
         if (use_select) {
-#if !defined (ESP32) && defined(ARDUINO)
+#if (!defined (ESP32)) && defined(ARDUINO)
             DIE("select is not supported on Arduino");
 #else
             gcWrite_.reset(new HubDeviceSelect<HubFlow>(&gcHub_, fd, this));

--- a/src/utils/GridConnectHub.cxx
+++ b/src/utils/GridConnectHub.cxx
@@ -41,7 +41,7 @@
 #include "utils/Buffer.hxx"
 #include "utils/BufferPort.hxx"
 #include "utils/HubDevice.hxx"
-#ifndef ARDUINO
+#if defined (ESP32) || !defined(ARDUINO)
 #include "utils/HubDeviceSelect.hxx"
 #endif
 #include "utils/Hub.hxx"
@@ -404,7 +404,7 @@ struct GcHubPort : public Executable
     {
         LOG(VERBOSE, "gchub port %p", (Executable *)this);
         if (use_select) {
-#ifdef ARDUINO
+#if !defined (ESP32) && defined(ARDUINO)
             DIE("select is not supported on Arduino");
 #else
             gcWrite_.reset(new HubDeviceSelect<HubFlow>(&gcHub_, fd, this));

--- a/src/utils/HubDevice.hxx
+++ b/src/utils/HubDevice.hxx
@@ -56,7 +56,7 @@ public:
     /// How many bytes of stack should we allocate to the write thread's stack.
     static const int kWriteThreadStackSize = 1536;
     /// How many bytes of stack should we allocate to the read thread's stack.
-    static const int kReadThreadStackSize = 1536;
+    static const int kReadThreadStackSize = 2048;
 #endif
     /// Constructor.
     /// @param fd is the filedes to read/write

--- a/src/utils/HubDevice.hxx
+++ b/src/utils/HubDevice.hxx
@@ -47,10 +47,17 @@ template <class Data> class FdHubWriteFlow;
 class FdHubPortBase : public FdHubPortInterface, private Atomic
 {
 public:
+#ifndef ESP32
     /// How many bytes of stack should we allocate to the write thread's stack.
     static const int kWriteThreadStackSize = 1000;
     /// How many bytes of stack should we allocate to the read thread's stack.
     static const int kReadThreadStackSize = 1000;
+#else
+    /// How many bytes of stack should we allocate to the write thread's stack.
+    static const int kWriteThreadStackSize = 1536;
+    /// How many bytes of stack should we allocate to the read thread's stack.
+    static const int kReadThreadStackSize = 1536;
+#endif
     /// Constructor.
     /// @param fd is the filedes to read/write
     /// @param done will be called when this file is closed and removed from

--- a/src/utils/HubDevice.hxx
+++ b/src/utils/HubDevice.hxx
@@ -165,7 +165,7 @@ protected:
                         continue;
                     }
 // Now: we have an error.
-#if defined(__linux__)
+#if defined(__linux__) || defined(ESP32)
                     if (!ret)
                     {
                         LOG_ERROR("EOF reading fd %d", port_->fd_);
@@ -250,7 +250,7 @@ public:
                 continue;
             }
 // now: we have an error.
-#ifdef __linux__
+#if defined(__linux__) || defined(ESP32)
             if (!ret)
             {
                 LOG_ERROR("EOF writing fd %d", port_->fd_);

--- a/src/utils/HubDeviceSelect.hxx
+++ b/src/utils/HubDeviceSelect.hxx
@@ -39,7 +39,9 @@
 #include <fcntl.h>
 
 #include "executor/StateFlow.hxx"
+#ifndef ESP32
 #include "freertos/can_ioctl.h"
+#endif
 #include "utils/Hub.hxx"
 
 /// Generic template for the buffer traits. HubDeviceSelect will not compile on

--- a/src/utils/macros.h
+++ b/src/utils/macros.h
@@ -93,9 +93,9 @@ extern const char* g_death_file;
 
 #include <stdio.h>
 
-#define HASSERT(x) do { if (!(x)) { printf("Assertion failed in file " __FILE__ " line %d: assert(%s)", __LINE__, #x); g_death_file = __FILE__; g_death_lineno = __LINE__; abort();} } while(0)
+#define HASSERT(x) do { if (!(x)) { printf("Assertion failed in file " __FILE__ " line %d: assert(%s)\n", __LINE__, #x); g_death_file = __FILE__; g_death_lineno = __LINE__; abort();} } while(0)
 
-#define DIE(MSG) do { printf("Crashed in file " __FILE__ " line %d: " MSG, __LINE__); abort(); } while(0)
+#define DIE(MSG) do { printf("Crashed in file " __FILE__ " line %d: " MSG "\n", __LINE__); abort(); } while(0)
 
 #else
 

--- a/src/utils/socket_listener.cxx
+++ b/src/utils/socket_listener.cxx
@@ -68,7 +68,7 @@ static void* accept_thread_start(void* arg) {
 #ifndef ESP32
 static constexpr size_t listener_stack_size = 1000;
 #else
-static constexpr size_t listener_stack_size = 2048;
+static constexpr size_t listener_stack_size = 1536;
 #endif
 
 SocketListener::SocketListener(int port, connection_callback_t callback)


### PR DESCRIPTION
This introduces an ESP32 WiFi manager, this allows a node to be either a
hub or a client (or both!). This will simplify the ESP32 nodes
considerably as it will allow all WiFi details to be managed
automatically and expose some configuration parameters via CDI.

The WiFi stack is by default managed by the Esp32WiFiManager code but
can be managed by the caller by passing a null value for ssid, password
and hostname_prefix. When this mode of operation is in use it is
required that the caller has already started the WiFi stack, connected
to the SSID and started the mDNS service. This is not generally required
for most node types.

It is required to have a WiFiConfiguration CDI_GROUP declared and
passed into the constructor for the Esp32WiFiManager class. The
Esp32WiFiManager class will register itself as a configuration
listener and restart the background task if the configuration has
been updated.

The Esp32WiFiManager uses one background task when not operating as a
hub. If the hub mode is enabled a second task will be started internally
to accept connections on the configured TCP/IP socket. The background
task started by the Esp32WiFiManager monitors any established TCP/IP
connections. For inbound connections (when hub mode is active) if they
are no longer connected they will be cleaned up. For outbound
connections one attempt will be made to reconnect, if that attempt fails
the connection will be cleaned up. In addition to monitoring the
connection health, when the "Search mode" is set to one of the auto
modes an mDNS scan will be performed roughly every 30 seconds.

When the "Search mode" is configured with one of the "manual" options
selected, the configuration is checked to ensure that the manual
configuration settings have been configured. If they have not the
"Search mode" will be reset to "auto only".