### PR TITLE
Wraps arduino objects in namespace openmrn_arduino {}.

### DIFF
--- a/arduino/OpenMRN.cpp
+++ b/arduino/OpenMRN.cpp
@@ -41,8 +41,11 @@
 extern const char DEFAULT_WIFI_NAME[] __attribute__((weak)) = "defaultap";
 extern const char DEFAULT_PASSWORD[] __attribute__((weak)) = "defaultpw";
 
+namespace openmrn_arduino {
 
 OpenMRN::OpenMRN(openlcb::NodeID node_id)
 {
     init(node_id);
 }
+
+} // namespace openmrn_arduino

--- a/arduino/OpenMRN.h
+++ b/arduino/OpenMRN.h
@@ -49,6 +49,8 @@
 #include <esp_task.h>
 #include <esp_task_wdt.h>
 
+namespace openmrn_arduino {
+
 /// Default stack size to use for all OpenMRN tasks on the ESP32 platform.
 constexpr uint32_t OPENMRN_STACK_SIZE = 4096L;
 
@@ -57,6 +59,8 @@ constexpr uint32_t OPENMRN_STACK_SIZE = 4096L;
 /// (-1 and -2 respectively) of this default priority to ensure timely
 /// consumption of CAN frames from the hardware driver.
 constexpr UBaseType_t OPENMRN_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO;
+
+} // namespace openmrn_arduino
 
 #include "freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx"
 #include "freertos_drivers/esp32/Esp32HardwareSerialAdapter.hxx"
@@ -78,6 +82,8 @@ extern "C"
     extern const char DEFAULT_WIFI_NAME[];
     extern const char DEFAULT_PASSWORD[];
 }
+
+namespace openmrn_arduino {
 
 /// Bridge class that connects an Arduino API style serial port (sending CAN
 /// frames via gridconnect format) to the OpenMRN core stack. This can be
@@ -482,5 +488,9 @@ private:
     /// True if there is a separate thread running the executor.
     bool haveExecutorThread_{false};
 };
+
+} // namespace openmrn_arduino
+
+using openmrn_arduino::OpenMRN;
 
 #endif // _ARDUINO_OPENMRN_H_

--- a/src/freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx
+++ b/src/freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx
@@ -43,6 +43,8 @@
 #include <driver/gpio.h>
 #include <esp_task_wdt.h>
 
+namespace openmrn_arduino {
+
 /// ESP32 CAN bus status strings, used for periodic status reporting
 static const char *ESP32_CAN_STATUS_STRINGS[] = {
     "STOPPED",               // CAN_STATE_STOPPED
@@ -342,5 +344,9 @@ private:
     }
     DISALLOW_COPY_AND_ASSIGN(Esp32HardwareCan);
 };
+
+} // namespace openmrn_arduino
+
+using openmrn_arduino::Esp32HardwareCan;
 
 #endif /* _FREERTOS_DRIVERS_ARDUINO_ESP32HWCAN_HXX_ */

--- a/src/freertos_drivers/esp32/Esp32HardwareSerialAdapter.hxx
+++ b/src/freertos_drivers/esp32/Esp32HardwareSerialAdapter.hxx
@@ -38,6 +38,8 @@
 
 #include <HardwareSerial.h>
 
+namespace openmrn_arduino {
+
 class Esp32HardwareSerialAdapter
 {
 public:
@@ -83,5 +85,9 @@ private:
     /// HardwareSerial device being wrapped.
     HardwareSerial &serial_;
 };
+
+} // namespace openmrn_arduino
+
+using openmrn_arduino::Esp32HardwareSerialAdapter;
 
 #endif /* _FREERTOS_DRIVERS_ESP32_ESP32SERIAL_HXX_ */

--- a/src/freertos_drivers/esp32/Esp32WiFiClientAdapter.hxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiClientAdapter.hxx
@@ -39,6 +39,8 @@
 #include <Arduino.h>
 #include <WiFi.h>
 
+namespace openmrn_arduino {
+
 class Esp32WiFiClientAdapter
 {
 public:
@@ -126,5 +128,9 @@ private:
     /// WiFiClient being wrapped.
     WiFiClient client_;
 };
+
+} // namespace openmrn_arduino
+
+using openmrn_arduino::Esp32WiFiClientAdapter;
 
 #endif /* _FREERTOS_DRIVERS_ARDUINO_ESP32WIFI_HXX_ */

--- a/src/openlcb/SimpleStack.hxx
+++ b/src/openlcb/SimpleStack.hxx
@@ -61,7 +61,9 @@
 #include "utils/HubDeviceSelect.hxx"
 #endif
 
+namespace openmrn_arduino {
 class OpenMRN;
+}
 
 namespace openlcb
 {
@@ -258,7 +260,7 @@ public:
     /// (gone down and up).
     void restart_stack();
 
-    friend class ::OpenMRN;
+    friend class ::openmrn_arduino::OpenMRN;
 
     /// Donates the current thread to the executor. Never returns.
     /// @param delay_start if true, then prevents sending traffic to the bus


### PR DESCRIPTION
@atanisoft if you could review that would be sufficient as well.