### PR TITLE
Thread creation for ESP32

### DIFF
--- a/arduino/OpenMRN.h
+++ b/arduino/OpenMRN.h
@@ -364,18 +364,8 @@ public:
     void start_executor_thread()
     {
         haveExecutorThread_ = true;
-        xTaskCreate(openmrn_background_task, "OpenMRN", OPENMRN_STACK_SIZE,
-                    this, OPENMRN_TASK_PRIORITY, nullptr);
-        /// @todo: replace the above with the below once os_thread_create gets
-        /// implemented for the esp32.
-        // stack_->executor()->start_thread(
-        //     "OpenMRN", OPENMRN_TASK_PRIORITY, OPENMRN_STACK_SIZE);
-    }
-
-    static void openmrn_background_task(void *arg)
-    {
-        OpenMRN *me = static_cast<OpenMRN *>(arg);
-        me->stack_->executor()->thread_body();
+        stack_->executor()->start_thread(
+            "OpenMRN", OPENMRN_TASK_PRIORITY, OPENMRN_STACK_SIZE);
     }
 #endif
 

--- a/include/openmrn_features.h
+++ b/include/openmrn_features.h
@@ -82,6 +82,26 @@
 #define OPENMRN_FEATURE_SEM_TIMEDWAIT 1
 #endif
 
+#if defined(__FreeRTOS__) || defined(ESP32)
+/// Use FreeRTOS implementation for os_thread_create and keeping a list of live
+/// threads.
+#define OPENMRN_FEATURE_THREAD_FREERTOS 1
+#elif OPENMRN_FEATURE_SINGLE_THREADED
+#else
+/// Use pthread for os_thread_create.
+#define OPENMRN_FEATURE_THREAD_PTHREAD 1
+#if !defined (__MINGW32__) && !defined (__MACH__)
+/// Use pthread_setname for setting the newly created thread's name.
+#define OPENMRN_HAVE_PTHREAD_SETNAME 1
+#endif
+#if !defined(__linux__) && !defined(__MACH__)
+/// Use pthread_attr for setting the stack size of newly created threads.
+/// Linux/Unix allocates stack as needed.
+#define OPENMRN_FEATURE_PTHREAD_SETSTACK 1
+#endif
+#endif
+
+
 
 
 #endif // _INCLUDE_OPENMRN_FEATURES_


### PR DESCRIPTION
- Adds selection feature macro for which os_thread_create implementation should be compiled.
- Updates arduino esp32 version to use os_thread_create for creating the background thread.