### PR TITLE
Updates for ESP32 reboot + Arduino fix

### DIFF
--- a/arduino/OpenMRNLite.cpp
+++ b/arduino/OpenMRNLite.cpp
@@ -34,10 +34,6 @@
 
 #include <OpenMRNLite.h>
 
-#ifdef HAVE_FILESYSTEM
-#include "utils/FileUtils.hxx"
-#endif
-
 extern const char DEFAULT_WIFI_NAME[] __attribute__((weak)) = "defaultap";
 extern const char DEFAULT_WIFI_PASSWORD[] __attribute__((weak)) = "defaultpw";
 

--- a/arduino/OpenMRNLite.cpp
+++ b/arduino/OpenMRNLite.cpp
@@ -44,4 +44,16 @@ OpenMRN::OpenMRN(openlcb::NodeID node_id)
     init(node_id);
 }
 
+#ifdef ESP32
+extern "C" {
+
+/// Reboots the ESP32 via the arduino-esp32 provided restart function.
+void reboot()
+{
+    ESP.restart();
+}
+
+}
+#endif // ESP32
+
 } // namespace openmrn_arduino

--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -43,6 +43,7 @@
 #include "openlcb/SimpleStack.hxx"
 #include "utils/GridConnectHub.hxx"
 #include "utils/Uninitialized.hxx"
+#include "utils/FileUtils.hxx"
 
 #if defined(ESP32)
 
@@ -71,11 +72,6 @@ constexpr UBaseType_t OPENMRN_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO;
 #define HAVE_FILESYSTEM
 
 #endif // ESP32
-
-#if defined(HAVE_FILESYSTEM)
-string read_file_to_string(const string &filename);
-void write_string_to_file(const string &filename, const string &data);
-#endif // HAVE_FILESYSTEM
 
 extern "C"
 {

--- a/src/utils/FileUtils.cxx
+++ b/src/utils/FileUtils.cxx
@@ -55,6 +55,7 @@ string read_file_to_string(const string &filename)
 
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 
 /// Opens a file, reads the entire contents, stores it in a c++ std::string and
 /// returns this string. Helper function in some client applications. Exits the


### PR DESCRIPTION
With #245 being merged the arduino build was broken due to a missing include for errno.h and there were also duplicate function definitions which were no longer necessary.

Additionally the ESP32 now supports proper node reboot (#244).