### PR TITLE
Reinitialize stack upon successful uplink creation, fixes #257.

### DIFF
--- a/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
@@ -730,9 +730,17 @@ void Esp32WiFiManager::start_uplink()
 // Converts the passed fd into a GridConnect port and adds it to the stack.
 void Esp32WiFiManager::on_uplink_created(int fd, Notifiable *on_exit)
 {
+    LOG(INFO, "[UPLINK] Connected to hub, configuring GridConnect port.");
+
     const bool use_select =
         (config_gridconnect_tcp_use_select() == CONSTANT_TRUE);
+
+    // create the GridConnect port from the provided socket fd.
     create_gc_port_for_can_hub(stack_->can_hub(), fd, on_exit, use_select);
+
+    // restart the stack to kick off alias allocation and send node init
+    // packets.
+    stack_->restart_stack();
 }
 
 } // namespace openmrn_arduino


### PR DESCRIPTION
When connecting to an uplink we need to restart the stack to ensure we
reallocate our alias and announce the node on the bus. Added log message
for successful uplink connection since SocketClient doesn't send a
LogMessage for this event.

Fixes #257.