### PR TITLE
TCP interface

### DIFF
--- a/src/freertos_drivers/common/CpuLoad.hxx
+++ b/src/freertos_drivers/common/CpuLoad.hxx
@@ -208,7 +208,7 @@ private:
         uint32_t ex_count = service()->executor()->sequence();
         LOG(INFO,
             "Ex %d|FreeHeap %d|Buf %d|Load: avg %3d max streak %d max of 16 %d",
-            (int)ex_count - executorLastCount_, (int)os_get_free_heap(),
+            (int)(ex_count - executorLastCount_), (int)os_get_free_heap(),
             (int)mainBufferPool->total_size(), l->get_load(),
             l->get_max_consecutive(), l->get_peak_over_16_counts());
         executorLastCount_ = ex_count;

--- a/src/openlcb/ConfigEntry.cxx
+++ b/src/openlcb/ConfigEntry.cxx
@@ -37,6 +37,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include "utils/logging.h"
+#include "utils/FdUtils.hxx"
 
 namespace openlcb
 {
@@ -45,36 +46,14 @@ void ConfigEntryBase::repeated_read(int fd, void *buf, size_t size) const
 {
     int ret = lseek(fd, offset_, SEEK_SET);
     ERRNOCHECK("seek_config", ret);
-    uint8_t *dst = static_cast<uint8_t *>(buf);
-    while (size)
-    {
-        ssize_t ret = ::read(fd, dst, size);
-        ERRNOCHECK("read_config", ret);
-        if (ret == 0)
-        {
-            DIE("Unexpected EOF reading the config file.");
-        }
-        size -= ret;
-        dst += ret;
-    }
+    FdUtils::repeated_read(fd, buf, size);
 }
 
 void ConfigEntryBase::repeated_write(int fd, const void *buf, size_t size) const
 {
     int ret = lseek(fd, offset_, SEEK_SET);
     ERRNOCHECK("seek_config", ret);
-    const uint8_t *dst = static_cast<const uint8_t *>(buf);
-    while (size)
-    {
-        ssize_t ret = ::write(fd, dst, size);
-        ERRNOCHECK("write_config", ret);
-        if (ret == 0)
-        {
-            DIE("Unexpected EOF writing the config file.");
-        }
-        size -= ret;
-        dst += ret;
-    }
+    FdUtils::repeated_write(fd, buf, size);
 }
 
 } // namespace openlcb

--- a/src/openlcb/Defs.hxx
+++ b/src/openlcb/Defs.hxx
@@ -62,6 +62,13 @@ struct NodeHandle
     NodeHandle(NodeID _id, NodeAlias _alias) : id(_id), alias(_alias) {}
     NodeHandle() : id(0), alias(0) {}
 
+    /** Resets node handle to global (broadcast) handle. */
+    void clear()
+    {
+        id = 0;
+        alias = 0;
+    }
+
     /** Compares two NodeHandle instances.
      * @param o object to compare to
      * @return boolean result of compare

--- a/src/openlcb/If.cxx
+++ b/src/openlcb/If.cxx
@@ -80,6 +80,12 @@ void error_to_data(uint16_t error_code, void* data) {
     p[1] = error_code & 0xff;
 }
 
+uint16_t data_to_error(const void *data)
+{
+    const uint8_t *p = (const uint8_t *)data;
+    return (((uint16_t)p[0]) << 8) | p[1];
+}
+
 string error_to_buffer(uint16_t error_code, uint16_t mti)
 {
     string ret(4, '\0');

--- a/src/openlcb/If.hxx
+++ b/src/openlcb/If.hxx
@@ -107,6 +107,9 @@ extern string error_to_buffer(uint16_t error_code);
 /** Writes an error code into a payload object at a given pointer. */
 extern void error_to_data(uint16_t error_code, void* data);
 
+/** Parses an error code from a payload object at a given pointer. */
+extern uint16_t data_to_error(const void *data);
+
 /** Appends an error to the end of an existing buffer. */
 extern void append_error_to_buffer(uint16_t error_code, Payload* p);
 
@@ -151,6 +154,11 @@ struct GenMessage
 {
     GenMessage()
         : src({0, 0}), dst({0, 0}), flagsSrc(0), flagsDst(0) {}
+
+    void clear()
+    {
+        reset((Defs::MTI)0, 0, EMPTY_PAYLOAD);
+    }
 
     void reset(Defs::MTI mti, NodeID src, NodeHandle dst, string payload)
     {
@@ -224,7 +232,7 @@ struct GenMessage
     /** Returns the NMRAnet-defined priority band, in the range of 0..3. */
     unsigned priority()
     {
-        return (mti & Defs::MTI_PRIORITY_MASK) >> Defs::MTI_PRIORITY_SHIFT;
+        return Defs::mti_priority(mti);
     }
 
     enum DstFlags {
@@ -319,13 +327,6 @@ public:
      * removed from the data structures.
      */
     virtual void delete_local_node(Node *node) = 0;
-        /*
-    {
-        HASSERT(0);
-        auto it = localNodes_.find(node->node_id());
-        HASSERT(it != localNodes_.end());
-        localNodes_.erase(it);
-        }*/
 
     /** Looks up a node ID in the local nodes' registry. This function must be
      * called from the interface's executor.

--- a/src/openlcb/IfCan.hxx
+++ b/src/openlcb/IfCan.hxx
@@ -83,8 +83,8 @@ public:
      * @param local_nodes_count is the maximum number of virtual nodes that
      * this interface will support. */
     IfCan(ExecutorBase *executor, CanHubFlow *device,
-          int local_alias_cache_size, int remote_alias_cache_size,
-          int local_nodes_count);
+        int local_alias_cache_size, int remote_alias_cache_size,
+        int local_nodes_count);
 
     ~IfCan();
 
@@ -122,7 +122,7 @@ public:
     void delete_local_node(Node *node) override;
 
 private:
-    void canonicalize_handle(NodeHandle* h);
+    void canonicalize_handle(NodeHandle *h);
 
     friend class CanFrameWriteFlow; // accesses the device and the hubport.
 
@@ -166,7 +166,7 @@ struct NodeCanonicalizeRequest
 {
     /// Requests a NodeHandle to be canonicalized, i.e. look up node ID from
     /// alias.
-    void reset(Node* node, NodeHandle handle)
+    void reset(Node *node, NodeHandle handle)
     {
         srcNode = node;
         this->handle = handle;
@@ -174,7 +174,7 @@ struct NodeCanonicalizeRequest
     }
 
     /// Caller node (in order to talk to the bus)
-    Node* srcNode;
+    Node *srcNode;
     /// Destination node handle to canonicalize. At request time the alias
     /// should vbe filled in; at response time the id will be filled in as
     /// well.
@@ -260,7 +260,8 @@ private:
     class ReplyHandler : public MessageHandler
     {
     public:
-        /// Constructor. @param parent is the looku flow that owns this handler.
+        /// Constructor. @param parent is the lookup flow that owns this
+        /// handler.
         ReplyHandler(NodeIdLookupFlow *parent)
             : parent_(parent)
         {

--- a/src/openlcb/IfTcp.cxx
+++ b/src/openlcb/IfTcp.cxx
@@ -1,0 +1,207 @@
+/** \copyright
+ * Copyright (c) 2017, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file IfTcp.cxx
+ *
+ * OpenLCB interface implementation for native TCP connection.
+ *
+ * @author Balazs Racz
+ * @date 16 Apr 2017
+ */
+
+#include "openlcb/IfTcp.hxx"
+#include "openlcb/IfImpl.hxx"
+#include "openlcb/IfTcpImpl.hxx"
+
+namespace openlcb
+{
+
+void IfTcp::delete_local_node(Node *node)
+{
+    remove_local_node_from_map(node);
+}
+
+void IfTcp::add_owned_flow(Executable *e)
+{
+    ownedFlows_.emplace_back(e);
+}
+
+void IfTcp::delete_owned_flow(Destructable *d)
+{
+    for (auto it = ownedFlows_.begin(); it != ownedFlows_.end(); ++it)
+    {
+        if (it->get() == d)
+        {
+            ownedFlows_.erase(it);
+            return;
+        }
+    }
+    LOG_ERROR("Deleting nonexistent owned flow.");
+}
+
+bool IfTcp::matching_node(NodeHandle expected, NodeHandle actual)
+{
+    if (expected.id && actual.id)
+    {
+        return expected.id == actual.id;
+    }
+    // Cannot reconcile.
+    LOG(VERBOSE, "Cannot reconcile expected and actual NodeHandles for "
+                 "equality testing.");
+    return false;
+}
+
+void IfTcp::add_network_fd(int fd, Notifiable *on_error)
+{
+    // What are the cases we need to support:
+    //
+    // - the remote server closing the socket. on_error shall be called and the
+    //   port destructed.
+    //
+    // - the IfTcp being destructed (presumably not on the main executor). We
+    //   need to unregister the port, shutdown the socket, flush the data, then
+    //   delete this. The destructor of HubDeviceSelect triggers the barrier
+    //   callback inline.
+    //
+    // The contract with HubDeviceSelect is that by the time the on_error
+    // notifiable is called, the HubDeviceSelect has been unregistered,
+    // flushed, and can be deleted, even if we are on the main executor.
+    //
+    struct RemotePort : public Executable
+    {
+        RemotePort(IfTcp *parent, Notifiable *on_error)
+            : parent_(parent)
+            , onError_(on_error)
+        {
+        }
+        ~RemotePort()
+        {
+            // auto* p = port_->write_port();
+            // LOG_ERROR("remoteport::delete %p %p", p, this);
+            deleting_ = true;
+            port_.reset();
+            // LOG_ERROR("remoteport::delete done %p", p);
+        }
+        IfTcp *parent_;
+        std::unique_ptr<TcpHubDeviceSelect> port_;
+        Notifiable *onError_;
+        bool deleting_{false};
+        void notify() override
+        {
+            // auto* p = port_->write_port();
+            // LOG(VERBOSE, "remoteport::notify %d %p %p", deleting_, p, this);
+            if (onError_)
+            {
+                onError_->notify();
+                onError_ = nullptr;
+            }
+            if (!deleting_) // avoids duplicate destruction.
+            {
+                parent_->executor()->add(this);
+            }
+        }
+
+        void run() override
+        {
+            if (deleting_ || !port_)
+            {
+                return;
+            }
+            if (!port_->write_done())
+            {
+                // yield
+                parent_->executor()->add(this);
+                return;
+            }
+            parent_->delete_owned_flow(this);
+        }
+    };
+    RemotePort *p = new RemotePort(this, on_error);
+    p->port_.reset(new TcpHubDeviceSelect(device_, fd, p));
+    add_owned_flow(p);
+}
+
+/// Component that drops incoming addressed messages that are not destined for
+/// a local node.
+class LocalMessageFilter : public MessageHandler, public Destructable
+{
+public:
+    LocalMessageFilter(If *iface)
+        : iface_(iface)
+    {
+    }
+
+    void send(Buffer<GenMessage> *b, unsigned prio) override
+    {
+        auto id = b->data()->dst.id;
+        if (id)
+        {
+            auto *dst = iface_->lookup_local_node(id);
+            if (dst)
+            {
+                b->data()->dstNode = dst;
+            }
+            else
+            {
+                b->unref();
+                return;
+            }
+        }
+        iface_->dispatcher()->send(b, prio);
+    }
+
+private:
+    If *iface_;
+};
+
+IfTcp::IfTcp(NodeID gateway_node_id, HubFlow *device, int local_nodes_count)
+    : If(device->service()->executor(), local_nodes_count)
+    , device_(device)
+{
+    add_owned_flow(new VerifyNodeIdHandler(this));
+    seq_ = new ClockBaseSequenceNumberGenerator;
+    add_owned_flow(seq_);
+    auto filter = new LocalMessageFilter(this);
+    add_owned_flow(filter);
+    recvFlow_ = new TcpRecvFlow(filter);
+    add_owned_flow(recvFlow_);
+    sendFlow_ = new TcpSendFlow(this, gateway_node_id, device, recvFlow_, seq_);
+    add_owned_flow(sendFlow_);
+    globalWriteFlow_ = sendFlow_;
+    addressedWriteFlow_ = sendFlow_;
+    device_->register_port(recvFlow_);
+}
+
+IfTcp::~IfTcp()
+{
+    device_->unregister_port(recvFlow_);
+    while (!ownedFlows_.empty())
+    {
+        ownedFlows_.resize(ownedFlows_.size() - 1);
+    }
+}
+
+} // namespace openlcb

--- a/src/openlcb/IfTcp.cxxtest
+++ b/src/openlcb/IfTcp.cxxtest
@@ -1,0 +1,1057 @@
+#include <unistd.h>
+
+#include "openlcb/IfTcp.hxx"
+#include "openlcb/IfTcpImpl.hxx"
+#include "openlcb/PIPClient.hxx"
+#include "openlcb/ProtocolIdentification.hxx"
+#include "utils/FdUtils.hxx"
+#include "utils/HubDeviceSelect.hxx"
+#include "utils/async_if_test_helper.hxx"
+
+using ::testing::_;
+using ::testing::SaveArg;
+using ::testing::StrictMock;
+
+namespace openlcb
+{
+
+TEST(TcpRenderingTest, render_global_message)
+{
+    GenMessage msg;
+    msg.src.id = 0x050102030405ULL;
+    msg.dst.id = 0;
+    msg.mti = Defs::MTI_EVENT_REPORT;
+    msg.payload = eventid_to_buffer(0x0102030405060708ULL);
+    string data;
+
+    TcpDefs::render_tcp_message(msg, 0x101112131415ULL, 0x42, &data);
+    EXPECT_EQ(string("\x80\x00"                          // flags
+                     "\x00\x00\x1C"                      // length: 28
+                     "\x10\x11\x12\x13\x14\x15"          // gateway node ID
+                     "\x00\x00\x00\x00\x00\x42"          // timestamp / seq no
+                     "\x05\xB4"                          // MTI
+                     "\x05\x01\x02\x03\x04\x05"          // src node ID
+                     "\x01\x02\x03\x04\x05\x06\x07\x08", // payload: event ID
+                  28 + 5),
+        data);
+}
+
+TEST(TcpRenderingTest, render_addressed_message)
+{
+    GenMessage msg;
+    msg.reset(Defs::MTI_IDENT_INFO_REPLY, 0x050102030405ULL,
+        {0x151112131415ULL, 0}, "abcdefghijklmn");
+    string data;
+
+    TcpDefs::render_tcp_message(msg, 0x101112131415ULL, 0x42, &data);
+    EXPECT_EQ(string("\x80\x00"                 // flags
+                     "\x00\x00\x28"             // length: 28
+                     "\x10\x11\x12\x13\x14\x15" // gateway node ID
+                     "\x00\x00\x00\x00\x00\x42" // timestamp / seq no
+                     "\x0A\x08"                 // MTI
+                     "\x05\x01\x02\x03\x04\x05" // src node ID
+                     "\x15\x11\x12\x13\x14\x15" // dst node ID
+                     "abcdefghijklmn",          // payload: data for ident
+                  14 + 26 + 5),
+        data);
+}
+
+TEST(TcpParsingTest, parse_global_message)
+{
+    string s("\x80\x00"                          // flags
+             "\x00\x00\x1C"                      // length: 28
+             "\x10\x11\x12\x13\x14\x15"          // gateway node ID
+             "\x00\x00\x00\x00\x00\x42"          // timestamp / seq no
+             "\x05\xB4"                          // MTI
+             "\x05\x01\x02\x03\x04\x05"          // src node ID
+             "\x01\x02\x03\x04\x05\x06\x07\x08", // payload: event ID
+        28 + 5);
+    GenMessage msg;
+    EXPECT_TRUE(TcpDefs::parse_tcp_message(s, &msg));
+    EXPECT_EQ(0x050102030405ULL, msg.src.id);
+    EXPECT_EQ(0u, msg.src.alias);
+    EXPECT_EQ(0ULL, msg.dst.id);
+    EXPECT_EQ(0u, msg.dst.alias);
+    EXPECT_EQ(Defs::MTI_EVENT_REPORT, msg.mti);
+    EXPECT_EQ(8u, msg.payload.size());
+    EXPECT_EQ(0x0102030405060708ULL, data_to_eventid(msg.payload.data()));
+}
+
+TEST(TcpParsingTest, parse_addressed_message)
+{
+    string s("\x80\x00"                 // flags
+             "\x00\x00\x28"             // length: 28
+             "\x10\x11\x12\x13\x14\x15" // gateway node ID
+             "\x00\x00\x00\x00\x00\x42" // timestamp / seq no
+             "\x0A\x08"                 // MTI
+             "\x05\x01\x02\x03\x04\x05" // src node ID
+             "\x15\x11\x12\x13\x14\x15" // dst node ID
+             "abcdefghijklmn",          // payload: data for ident
+        14 + 26 + 5);
+    GenMessage msg;
+    EXPECT_TRUE(TcpDefs::parse_tcp_message(s, &msg));
+    EXPECT_EQ(0x050102030405ULL, msg.src.id);
+    EXPECT_EQ(0u, msg.src.alias);
+    EXPECT_EQ(0x151112131415ULL, msg.dst.id);
+    EXPECT_EQ(0u, msg.dst.alias);
+    EXPECT_EQ(Defs::MTI_IDENT_INFO_REPLY, msg.mti);
+    EXPECT_EQ(14u, msg.payload.size());
+    EXPECT_EQ("abcdefghijklmn", msg.payload);
+}
+
+class TestSequenceGenerator : public SequenceNumberGenerator
+{
+public:
+    long long get_sequence_number() override
+    {
+        return seq_++;
+    }
+
+    long long seq_{42};
+};
+
+class SingleTcpIfTestBase : public ::testing::Test
+{
+protected:
+    ~SingleTcpIfTestBase()
+    {
+        for (auto *buf : sentFrames_)
+        {
+            buf->unref();
+        }
+    }
+
+    vector<Buffer<HubData> *> sentFrames_;
+    class FakeSend : public HubPortInterface
+    {
+    public:
+        FakeSend(vector<Buffer<HubData> *> *output)
+            : output_(output)
+        {
+        }
+
+        void send(Buffer<HubData> *buf, unsigned prio) override
+        {
+            output_->push_back(buf);
+        }
+
+    private:
+        vector<Buffer<HubData> *> *output_;
+    } fakeSendTarget_{&sentFrames_};
+
+    void wait()
+    {
+        wait_for_main_executor();
+    }
+};
+
+class TcpSendFlowTest : public SingleTcpIfTestBase
+{
+protected:
+    HubPortInterface *fakeSource_ = (HubPortInterface *)123456;
+    TestSequenceGenerator seq_;
+    static constexpr uint64_t GW_NODE_ID = 0x101112131415ULL;
+    LocalIf localIf_{10};
+    TcpSendFlow sendFlow_{
+        &localIf_, GW_NODE_ID, &fakeSendTarget_, fakeSource_, &seq_};
+};
+
+TEST_F(TcpSendFlowTest, create)
+{
+}
+
+TEST_F(TcpSendFlowTest, flow_send_frame)
+{
+    auto *buf = sendFlow_.alloc();
+    buf->data()->reset(Defs::MTI_EVENT_REPORT, 0x050102030405ULL,
+        eventid_to_buffer(0x0102030405060708ULL));
+    sendFlow_.send(buf);
+    wait();
+    ASSERT_EQ(1u, sentFrames_.size());
+    EXPECT_EQ(string("\x80\x00"                          // flags
+                     "\x00\x00\x1C"                      // length: 28
+                     "\x10\x11\x12\x13\x14\x15"          // gateway node ID
+                     "\x00\x00\x00\x00\x00\x2a"          // timestamp / seq no
+                     "\x05\xB4"                          // MTI
+                     "\x05\x01\x02\x03\x04\x05"          // src node ID
+                     "\x01\x02\x03\x04\x05\x06\x07\x08", // payload: event ID
+                  28 + 5),
+        string(*sentFrames_[0]->data()));
+
+    EXPECT_EQ(fakeSource_, sentFrames_[0]->data()->skipMember_);
+
+    // Send another to check sequence numbers being used.
+    buf = sendFlow_.alloc();
+    buf->data()->reset(Defs::MTI_EVENT_REPORT, 0x050102030405ULL,
+        eventid_to_buffer(0x0102030405060708ULL));
+    sendFlow_.send(buf);
+    wait();
+    ASSERT_EQ(2u, sentFrames_.size());
+    EXPECT_EQ(string("\x80\x00"                          // flags
+                     "\x00\x00\x1C"                      // length: 28
+                     "\x10\x11\x12\x13\x14\x15"          // gateway node ID
+                     "\x00\x00\x00\x00\x00\x2b"          // timestamp / seq no
+                     "\x05\xB4"                          // MTI
+                     "\x05\x01\x02\x03\x04\x05"          // src node ID
+                     "\x01\x02\x03\x04\x05\x06\x07\x08", // payload: event ID
+                  28 + 5),
+        string(*sentFrames_[1]->data()));
+}
+
+class MockHubPortService : public FdHubPortService
+{
+public:
+    MockHubPortService(int fd)
+        : FdHubPortService(&g_executor, fd)
+    {
+        barrier_.reset(EmptyNotifiable::DefaultInstance());
+    }
+
+    MOCK_METHOD0(report_write_error, void());
+    MOCK_METHOD0(report_read_error, void());
+};
+
+class TcpRecvFlowTest : public TcpSendFlowTest
+{
+protected:
+    TcpRecvFlowTest()
+    {
+        // ERRNOCHECK("socketpair", socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+        ERRNOCHECK("pipe", ::pipe(fds));
+        ERRNOCHECK("fcntl",
+            fcntl(fds[0], F_SETFL, fcntl(fds[0], F_GETFL, 0) | O_NONBLOCK));
+        hubPortService_.reset(
+            new ::testing::StrictMock<MockHubPortService>(fds[0]));
+        recvFlow_.reset(new FdToTcpParser(
+            hubPortService_.get(), &fakeSendTarget_, fakeSource_));
+    }
+
+    ~TcpRecvFlowTest()
+    {
+        run_x([this]() { recvFlow_->shutdown(); });
+        ::close(fds[0]);
+        ::close(fds[1]);
+        wait();
+    }
+
+    /// Waits until the receiver has found count many packets or a timeout
+    /// occurs.
+    void wait_for_packets(unsigned count)
+    {
+        unsigned msec = 0;
+        while (sentFrames_.size() < count && (msec < 1000))
+        {
+            usleep(2000);
+            msec += 2;
+        }
+        ASSERT_EQ(count, sentFrames_.size());
+    }
+
+    void test_frames_correct()
+    {
+        ASSERT_EQ(expectedFrames_.size(), sentFrames_.size());
+        for (unsigned i = 0; i < expectedFrames_.size(); ++i)
+        {
+            EXPECT_EQ(expectedFrames_[i], *sentFrames_[i]->data());
+        }
+    }
+
+    string create_frame(unsigned payload_length, unsigned salt = 13)
+    {
+        openlcb::GenMessage msg;
+        string pl(payload_length, ' ');
+        for (unsigned i = 0; i < payload_length; ++i)
+        {
+            pl.at(i) = 'a' + ((salt * i) % 26);
+        }
+        NodeHandle dst;
+        dst.id = 0x0102030405;
+        msg.reset(
+            openlcb::Defs::MTI_TRACTION_CONTROL_COMMAND, TEST_NODE_ID, dst, pl);
+        string rendered;
+        TcpDefs::render_tcp_message(
+            msg, GW_NODE_ID, seq_.get_sequence_number(), &rendered);
+        expectedFrames_.push_back(rendered);
+        return rendered;
+    }
+
+    void send_frame(const string &f, unsigned chunk_len = 1000)
+    {
+        unsigned ofs = 0;
+        while (ofs < f.size())
+        {
+            unsigned len = std::min(chunk_len, (unsigned)f.size() - ofs);
+            FdUtils::repeated_write(fds[1], f.data() + ofs, len);
+            ofs += len;
+            usleep(2000);
+        }
+    }
+
+    static constexpr uint64_t TEST_NODE_ID = 0x101212231225ULL;
+    /// Stores a copy of frames that we sent.
+    std::vector<string> expectedFrames_;
+
+    int fds[2];
+    std::unique_ptr<MockHubPortService> hubPortService_;
+    std::unique_ptr<FdToTcpParser> recvFlow_;
+};
+
+TEST_F(TcpRecvFlowTest, zeroframes)
+{
+    wait_for_packets(0);
+    test_frames_correct();
+}
+
+TEST_F(TcpRecvFlowTest, singleshortframe)
+{
+    wait_for_packets(0);
+    test_frames_correct();
+
+    auto s = create_frame(35);
+    send_frame(s);
+    wait_for_packets(1);
+    test_frames_correct();
+}
+
+TEST_F(TcpRecvFlowTest, singleshortframe_in_fragments)
+{
+    wait_for_packets(0);
+    test_frames_correct();
+
+    auto s = create_frame(35);
+    send_frame(s, 7);
+    wait_for_packets(1);
+    test_frames_correct();
+
+    s = create_frame(23);
+    send_frame(s, 3);
+    wait_for_packets(2);
+    test_frames_correct();
+
+    s = create_frame(75);
+    send_frame(s, 15);
+    wait_for_packets(3);
+    test_frames_correct();
+}
+
+TEST_F(TcpRecvFlowTest, joined_large_fragment)
+{
+    wait_for_packets(0);
+    test_frames_correct();
+
+    auto s = create_frame(35);
+    s += create_frame(40, 2);
+    s += create_frame(8, 4);
+    s += create_frame(8, 5);
+
+    send_frame(s, 1000);
+    wait_for_packets(4);
+    test_frames_correct();
+}
+
+TEST_F(TcpRecvFlowTest, joined_small_fragment)
+{
+    wait_for_packets(0);
+    test_frames_correct();
+
+    auto s = create_frame(35);
+    s += create_frame(40, 2);
+    s += create_frame(8, 4);
+    s += create_frame(8, 5);
+
+    send_frame(s, 2);
+    wait_for_packets(4);
+    test_frames_correct();
+}
+
+TEST_F(TcpRecvFlowTest, jumbo_frame)
+{
+    wait_for_packets(0);
+    test_frames_correct();
+
+    auto s = create_frame(3000);
+    send_frame(s);
+    wait_for_packets(1);
+    test_frames_correct();
+}
+
+TEST_F(TcpRecvFlowTest, joined_small_overflow)
+{
+    wait_for_packets(0);
+    test_frames_correct();
+
+    auto s = create_frame(300 - 2 - TcpDefs::MIN_ADR_MESSAGE_SIZE);
+    // here the second frame will have the first two bytes arriving with the
+    // initial read.
+    ASSERT_EQ(298u, s.size());
+    s += create_frame(40, 2);
+    send_frame(s);
+    wait_for_packets(2);
+    test_frames_correct();
+}
+
+TEST_F(TcpRecvFlowTest, error_exit)
+{
+    auto s = create_frame(35);
+    send_frame(s);
+    wait_for_packets(1);
+    test_frames_correct();
+
+    //::shutdown(fds[1], SHUT_RDWR);
+    EXPECT_CALL(*hubPortService_, report_read_error());
+    ::close(fds[1]);
+    usleep(2000);
+    wait();
+}
+
+class MockHubPort : public HubPortInterface
+{
+public:
+    MOCK_METHOD2(send, void(const string &message, unsigned priority));
+
+    void send(Buffer<HubData> *b, unsigned priority) override
+    {
+        send(*b->data(), priority);
+        b->unref();
+    }
+};
+
+class TcpIfTest : public ::testing::Test
+{
+protected:
+    static int local_node_count;
+
+    TcpIfTest()
+    {
+        device_.register_port(&listenPort_);
+    }
+
+    ~TcpIfTest()
+    {
+        device_.unregister_port(&listenPort_);
+        wait();
+    }
+
+    void wait()
+    {
+        wait_for_main_executor();
+    }
+
+    /// Instructs the mock device to save the next sent packet.
+    void capture_next_packet()
+    {
+        lastPacket_.clear();
+        EXPECT_CALL(listenPort_, send(_, _)).WillOnce(SaveArg<0>(&lastPacket_));
+    }
+
+    /// Instructs the mock device to ignore all sent packets.
+    void ignore_all_packets()
+    {
+        EXPECT_CALL(listenPort_, send(_, _)).Times(AtLeast(0));
+    }
+
+    /// Instructs the mock device to ignore all sent packets.
+    void capture_all_packets()
+    {
+        EXPECT_CALL(listenPort_, send(_, _))
+            .WillRepeatedly(WithArg<0>(
+                Invoke([this](const string &d) { allPackets_.push_back(d); })));
+    }
+
+    /// Creates a GenMessage, renders it to binary format, and injects it as if
+    /// it came as an input from the network.
+    /// @param args same arguments as GenMessage::reset(). Example
+    /// reset(Defs::MTI_EVENT_REPORT, TEST_NODE_ID,
+    ///       eventid_to_buffer(UINT64_C(0x0102030405060708)));
+    template <typename... Args> void generate_input_message(Args &&... args)
+    {
+        GenMessage msg;
+        msg.reset(std::forward<Args>(args)...);
+        auto *b = device_.alloc();
+        TcpDefs::render_tcp_message(msg, INPUT_GW_NODE_ID, 0x42, b->data());
+        b->data()->skipMember_ = &listenPort_;
+        device_.send(b);
+        wait();
+    }
+
+    /// Creates a GenMessage and sends it out via the IfTcp.
+    /// @param args same arguments as GenMessage::reset(). Example
+    /// reset(Defs::MTI_EVENT_REPORT, TEST_NODE_ID,
+    ///       eventid_to_buffer(UINT64_C(0x0102030405060708)));
+    template <typename... Args> void generate_output_message(Args &&... args)
+    {
+        generate_output_message(&ifTcp_, std::forward<Args>(args)...);
+    }
+
+    /// Creates a GenMessage and sends it out via the IfTcp.
+    /// @param args same arguments as GenMessage::reset(). Example
+    /// reset(Defs::MTI_EVENT_REPORT, TEST_NODE_ID,
+    ///       eventid_to_buffer(UINT64_C(0x0102030405060708)));
+    template <typename... Args>
+    void generate_output_message(IfTcp *iface, Args &&... args)
+    {
+        auto *f = iface->global_message_write_flow();
+        auto *b = f->alloc();
+        b->data()->reset(std::forward<Args>(args)...);
+        f->send(b);
+        wait();
+    }
+
+#define expect_packet_is(pkt, x...)                                            \
+    do                                                                         \
+    {                                                                          \
+        GenMessage actual;                                                     \
+        actual.clear();                                                        \
+        EXPECT_TRUE(TcpDefs::parse_tcp_message(pkt, &actual));                 \
+        GenMessage expected;                                                   \
+        expected.reset(x);                                                     \
+        EXPECT_EQ(expected.mti, actual.mti);                                   \
+        EXPECT_EQ(expected.src, actual.src);                                   \
+        EXPECT_EQ(expected.dst.id, actual.dst.id);                             \
+        EXPECT_EQ(expected.payload, actual.payload);                           \
+    } while (0)
+
+    HubFlow device_{&g_service};
+    ::testing::StrictMock<MockHubPort> listenPort_;
+    /// Stores the data from capture_next_packet.
+    string lastPacket_;
+    /// Stores data from capture all packets.
+    vector<string> allPackets_;
+
+    static constexpr NodeID TEST_NODE_ID = 0x101212231225ULL;
+    static constexpr NodeID REMOTE_NODE_ID = 0x050902030405ULL;
+    static constexpr NodeID INPUT_GW_NODE_ID = 0x101112131415ULL;
+    static constexpr NodeID GW_NODE_ID = 0x101112131415ULL;
+
+    IfTcp ifTcp_{GW_NODE_ID, &device_, local_node_count};
+};
+
+constexpr NodeID TcpIfTest::TEST_NODE_ID;
+constexpr NodeID TcpIfTest::REMOTE_NODE_ID;
+constexpr NodeID TcpIfTest::INPUT_GW_NODE_ID;
+constexpr NodeID TcpIfTest::GW_NODE_ID;
+
+int TcpIfTest::local_node_count = 9;
+
+class TcpNodeTest : public TcpIfTest
+{
+protected:
+    TcpNodeTest()
+    {
+        capture_next_packet();
+        ownedNode_.reset(new DefaultNode(&ifTcp_, TEST_NODE_ID));
+        node_ = ownedNode_.get();
+        wait();
+        Mock::VerifyAndClear(&listenPort_);
+        expect_packet_is(lastPacket_, Defs::MTI_INITIALIZATION_COMPLETE,
+            TEST_NODE_ID, node_id_to_buffer(TEST_NODE_ID));
+    }
+
+    std::unique_ptr<DefaultNode> ownedNode_;
+    Node *node_;
+};
+
+TEST_F(TcpIfTest, create)
+{
+}
+
+TEST_F(TcpIfTest, send_message_global)
+{
+    capture_next_packet();
+    auto *f = ifTcp_.global_message_write_flow();
+    auto b = f->alloc();
+    b->data()->reset(Defs::MTI_EVENT_REPORT, 0x050102030405ULL,
+        eventid_to_buffer(0x0102030405060708ULL));
+    f->send(b);
+    wait();
+    EXPECT_EQ(28u + 5u, lastPacket_.size());
+    expect_packet_is(lastPacket_, Defs::MTI_EVENT_REPORT, 0x050102030405ULL,
+        eventid_to_buffer(0x0102030405060708ULL));
+    lastPacket_.erase(11, 6);                   // kill sequence number.
+    EXPECT_EQ(string("\x80\x00"                 // flags
+                     "\x00\x00\x1C"             // length: 28
+                     "\x10\x11\x12\x13\x14\x15" // gateway node ID
+                     // missing seq no
+                     "\x05\xB4"                          // MTI
+                     "\x05\x01\x02\x03\x04\x05"          // src node ID
+                     "\x01\x02\x03\x04\x05\x06\x07\x08", // payload: event ID
+                  28 + 5 - 6),
+        lastPacket_);
+}
+
+TEST_F(TcpIfTest, send_message_addressed)
+{
+    capture_next_packet();
+    generate_output_message(Defs::MTI_IDENT_INFO_REPLY, 0x050102030405ULL,
+        NodeHandle({0x151112131415ULL, 0}), "abcdefghijklmn");
+    EXPECT_EQ(14u + 26 + 5, lastPacket_.size());
+    lastPacket_.erase(11, 6);                   // kill sequence number.
+    EXPECT_EQ(string("\x80\x00"                 // flags
+                     "\x00\x00\x28"             // length: 28
+                     "\x10\x11\x12\x13\x14\x15" // gateway node ID
+                     // missing seq no
+                     "\x0A\x08"                 // MTI
+                     "\x05\x01\x02\x03\x04\x05" // src node ID
+                     "\x15\x11\x12\x13\x14\x15" // dst node ID
+                     "abcdefghijklmn",          // payload: data for ident
+                  14 + 26 + 5 - 6),
+        lastPacket_);
+}
+
+TEST_F(TcpIfTest, send_short_event)
+{
+    capture_next_packet();
+    // this is not a standards compliant message but should still work.
+    generate_output_message(Defs::MTI_EVENT_REPORT, TEST_NODE_ID, "abcde");
+    expect_packet_is(
+        lastPacket_, Defs::MTI_EVENT_REPORT, TEST_NODE_ID, "abcde");
+}
+
+TEST_F(TcpIfTest, global_loopback)
+{
+    StrictMock<MockMessageHandler> h;
+    EXPECT_CALL(
+        h, handle_message(
+               Pointee(AllOf(Field(&GenMessage::mti, Defs::MTI_EVENT_REPORT),
+                   // Field(&GenMessage::payload, NotNull()),
+                   Field(&GenMessage::payload,
+                                 IsBufferValue(UINT64_C(0x0102030405060708))))),
+               _));
+    ifTcp_.dispatcher()->register_handler(&h, 0, 0);
+
+    capture_next_packet();
+    generate_output_message(Defs::MTI_EVENT_REPORT, TEST_NODE_ID,
+        eventid_to_buffer(UINT64_C(0x0102030405060708)));
+}
+
+TEST_F(TcpIfTest, receive_message)
+{
+    static constexpr NodeID REMOTE_NODE_ID = 0x050902030405ULL;
+    StrictMock<MockMessageHandler> h;
+    EXPECT_CALL(
+        h,
+        handle_message(
+            Pointee(AllOf(Field(&GenMessage::mti, Defs::MTI_EVENT_REPORT),
+                // Field(&GenMessage::payload, NotNull()),
+                Field(&GenMessage::src, Field(&NodeHandle::id, REMOTE_NODE_ID)),
+                Field(&GenMessage::payload,
+                              IsBufferValue(UINT64_C(0x0102030405060708))))),
+            _));
+    ifTcp_.dispatcher()->register_handler(&h, 0, 0);
+
+    /// Renders a TCP message for an event report and sends it to the hub.
+    generate_input_message(Defs::MTI_EVENT_REPORT, REMOTE_NODE_ID,
+        eventid_to_buffer(0x0102030405060708ULL));
+}
+
+TEST_F(TcpIfTest, drop_wrong_addressed_message)
+{
+    StrictMock<MockMessageHandler> h;
+    ifTcp_.dispatcher()->register_handler(&h, 0, 0);
+
+    generate_input_message(Defs::MTI_PROTOCOL_SUPPORT_INQUIRY, REMOTE_NODE_ID,
+        NodeHandle({INPUT_GW_NODE_ID, 0}), EMPTY_PAYLOAD);
+}
+
+TEST_F(TcpNodeTest, init)
+{
+    // The expectation verifying node init complete is in the constructor.
+}
+
+TEST_F(TcpNodeTest, verify_global)
+{
+    capture_next_packet();
+    generate_input_message(
+        Defs::MTI_VERIFY_NODE_ID_GLOBAL, REMOTE_NODE_ID, EMPTY_PAYLOAD);
+    expect_packet_is(lastPacket_, Defs::MTI_VERIFIED_NODE_ID_NUMBER,
+        TEST_NODE_ID, node_id_to_buffer(TEST_NODE_ID));
+}
+
+TEST_F(TcpNodeTest, verify_global_with_address)
+{
+    capture_next_packet();
+    generate_input_message(Defs::MTI_VERIFY_NODE_ID_GLOBAL, REMOTE_NODE_ID,
+        node_id_to_buffer(TEST_NODE_ID));
+    expect_packet_is(lastPacket_, Defs::MTI_VERIFIED_NODE_ID_NUMBER,
+        TEST_NODE_ID, node_id_to_buffer(TEST_NODE_ID));
+
+    lastPacket_.clear();
+    generate_input_message(Defs::MTI_VERIFY_NODE_ID_GLOBAL, REMOTE_NODE_ID,
+        node_id_to_buffer(TEST_NODE_ID + 1));
+    // no output here.
+}
+
+TEST_F(TcpNodeTest, verify_addressed)
+{
+    capture_next_packet();
+    generate_input_message(Defs::MTI_VERIFY_NODE_ID_ADDRESSED, REMOTE_NODE_ID,
+        NodeHandle(TEST_NODE_ID), EMPTY_PAYLOAD);
+    expect_packet_is(lastPacket_, Defs::MTI_VERIFIED_NODE_ID_NUMBER,
+        TEST_NODE_ID, node_id_to_buffer(TEST_NODE_ID));
+
+    lastPacket_.clear();
+    generate_input_message(Defs::MTI_VERIFY_NODE_ID_ADDRESSED, REMOTE_NODE_ID,
+        NodeHandle(TEST_NODE_ID + 1), EMPTY_PAYLOAD);
+    // no output here.
+}
+
+TEST_F(TcpNodeTest, verify_addressed_with_address)
+{
+    capture_next_packet();
+    generate_input_message(Defs::MTI_VERIFY_NODE_ID_GLOBAL, REMOTE_NODE_ID,
+        NodeHandle(TEST_NODE_ID), node_id_to_buffer(TEST_NODE_ID));
+    expect_packet_is(lastPacket_, Defs::MTI_VERIFIED_NODE_ID_NUMBER,
+        TEST_NODE_ID, node_id_to_buffer(TEST_NODE_ID));
+}
+
+TEST_F(TcpNodeTest, verify_addressed_with_wrong_address)
+{
+    capture_next_packet();
+    generate_input_message(Defs::MTI_VERIFY_NODE_ID_ADDRESSED, REMOTE_NODE_ID,
+        NodeHandle(TEST_NODE_ID), node_id_to_buffer(TEST_NODE_ID + 1));
+    expect_packet_is(lastPacket_, Defs::MTI_VERIFIED_NODE_ID_NUMBER,
+        TEST_NODE_ID, node_id_to_buffer(TEST_NODE_ID));
+
+    lastPacket_.clear();
+    generate_input_message(Defs::MTI_VERIFY_NODE_ID_ADDRESSED, REMOTE_NODE_ID,
+        NodeHandle(TEST_NODE_ID + 1), node_id_to_buffer(TEST_NODE_ID));
+    // should have no output.
+}
+
+TEST_F(TcpNodeTest, addressed_loopback)
+{
+    StrictMock<MockMessageHandler> h;
+    EXPECT_CALL(
+        h,
+        handle_message(
+            Pointee(AllOf(
+                Field(&GenMessage::mti, Defs::MTI_EVENTS_IDENTIFY_ADDRESSED),
+                Field(&GenMessage::payload,
+                    IsBufferValue(UINT64_C(0x0102030405060708))),
+                Field(&GenMessage::src, Field(&NodeHandle::id, REMOTE_NODE_ID)),
+                Field(&GenMessage::dst, Field(&NodeHandle::id, TEST_NODE_ID)),
+                Field(&GenMessage::dstNode, node_))),
+            _));
+    ifTcp_.dispatcher()->register_handler(&h, 0, 0);
+
+    generate_output_message(Defs::MTI_EVENTS_IDENTIFY_ADDRESSED, REMOTE_NODE_ID,
+        NodeHandle(TEST_NODE_ID),
+        eventid_to_buffer(UINT64_C(0x0102030405060708)));
+    // There should be nothing sent to the bus.
+}
+
+class RemoteTcpIfTest : public TcpIfTest
+{
+protected:
+    RemoteTcpIfTest()
+    {
+        // We expect write failures to occur but we want to handle them where
+        // the error occurs rather than in a SIGPIPE handler.
+        signal(SIGPIPE, SIG_IGN);
+        ERRNOCHECK("socketpair", socketpair(AF_UNIX, SOCK_STREAM, 0, fds_));
+    }
+
+    ~RemoteTcpIfTest()
+    {
+        wait();
+    }
+
+    int fds_[2];
+};
+
+TEST_F(RemoteTcpIfTest, create)
+{
+}
+
+TEST_F(RemoteTcpIfTest, connect)
+{
+    ifTcp_.add_network_fd(fds_[0]);
+}
+
+TEST_F(RemoteTcpIfTest, connect_close_1)
+{
+    ifTcp_.add_network_fd(fds_[0]);
+    wait();
+    LOG_ERROR("start_close");
+    ::close(fds_[1]);
+    LOG_ERROR("closed");
+    wait();
+    LOG_ERROR("closed-wait");
+}
+
+TEST_F(RemoteTcpIfTest, connect_close_0)
+{
+    ifTcp_.add_network_fd(fds_[0]);
+    wait();
+    ::close(fds_[0]);
+    wait();
+}
+
+TEST_F(RemoteTcpIfTest, output_packet)
+{
+    ifTcp_.add_network_fd(fds_[0]);
+    capture_next_packet();
+    generate_output_message(Defs::MTI_EVENT_REPORT, TEST_NODE_ID,
+        eventid_to_buffer(UINT64_C(0x0102030405060708)));
+    usleep(1000);
+    wait();
+    ERRNOCHECK("fcntl",
+        fcntl(fds_[1], F_SETFL, fcntl(fds_[1], F_GETFL, 0) | O_NONBLOCK));
+    char buf[100];
+    ssize_t ret = ::read(fds_[1], buf, sizeof(buf));
+    ASSERT_LT(0, ret);
+    string remote_packet(buf, ret);
+    EXPECT_EQ(lastPacket_, remote_packet);
+}
+
+TEST_F(RemoteTcpIfTest, input_packet)
+{
+    ifTcp_.add_network_fd(fds_[0]);
+    string s("\x80\x00"                          // flags
+             "\x00\x00\x1C"                      // length: 28
+             "\x10\x11\x12\x13\x14\x15"          // gateway node ID
+             "\x00\x00\x00\x00\x00\x42"          // timestamp / seq no
+             "\x05\xB4"                          // MTI
+             "\x05\x01\x02\x03\x04\x05"          // src node ID
+             "\x01\x02\x03\x04\x05\x06\x07\x08", // payload: event ID
+        28 + 5);
+    StrictMock<MockMessageHandler> h;
+    EXPECT_CALL(
+        h, handle_message(
+               Pointee(AllOf(Field(&GenMessage::mti, Defs::MTI_EVENT_REPORT),
+                   // Field(&GenMessage::payload, NotNull()),
+                   Field(&GenMessage::src,
+                                 Field(&NodeHandle::id, 0x050102030405ULL)),
+                   Field(&GenMessage::payload,
+                                 IsBufferValue(UINT64_C(0x0102030405060708))))),
+               _));
+    ifTcp_.dispatcher()->register_handler(&h, 0, 0);
+
+    capture_next_packet();
+    FdUtils::repeated_write(fds_[1], s.data(), s.size());
+    wait();
+    expect_packet_is(lastPacket_, Defs::MTI_EVENT_REPORT, 0x050102030405ULL,
+        eventid_to_buffer(0x0102030405060708ULL));
+    ERRNOCHECK("fcntl",
+        fcntl(fds_[1], F_SETFL, fcntl(fds_[1], F_GETFL, 0) | O_NONBLOCK));
+    char buf[100];
+    // We check that nothing came back.
+    ssize_t ret = ::read(fds_[1], buf, sizeof(buf));
+    auto e = errno;
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(EAGAIN, e);
+}
+
+class MultiTcpIfTest : public TcpIfTest
+{
+protected:
+    MultiTcpIfTest()
+    {
+#ifdef __linux__
+        // We expect write failures to occur but we want to handle them where
+        // the error occurs rather than in a SIGPIPE handler.
+        signal(SIGPIPE, SIG_IGN);
+#endif
+    }
+
+    ~MultiTcpIfTest()
+    {
+        wait();
+    }
+
+    friend struct ClientIf;
+
+    struct ClientIf
+    {
+        ClientIf(MultiTcpIfTest *parent, NodeID node_id)
+            : parent_(parent)
+            , nodeId_(node_id)
+        {
+            ERRNOCHECK("socketpair", socketpair(AF_UNIX, SOCK_STREAM, 0, fds_));
+            ERRNOCHECK("fcntl", fcntl(fds_[0], F_SETFL,
+                                    fcntl(fds_[0], F_GETFL, 0) | O_NONBLOCK));
+            ERRNOCHECK("fcntl", fcntl(fds_[1], F_SETFL,
+                                    fcntl(fds_[1], F_GETFL, 0) | O_NONBLOCK));
+            ifTcp_.add_network_fd(fds_[1]);
+            parent->ifTcp_.add_network_fd(fds_[0]);
+        }
+        int fds_[2];
+        MultiTcpIfTest *parent_;
+        NodeID nodeId_;
+        HubFlow device_{&g_service};
+        IfTcp ifTcp_{nodeId_, &device_, parent_->local_node_count};
+    };
+
+    void add_client(NodeID node_id)
+    {
+        clients_.emplace_back(new ClientIf(this, node_id));
+    }
+
+    vector<std::unique_ptr<ClientIf>> clients_;
+};
+
+TEST_F(MultiTcpIfTest, create_empty)
+{
+}
+
+TEST_F(MultiTcpIfTest, create_with_port_and_send_message)
+{
+    add_client(TEST_NODE_ID + 1);
+    capture_next_packet();
+    generate_output_message(Defs::MTI_EVENT_REPORT, TEST_NODE_ID,
+        eventid_to_buffer(UINT64_C(0x0102030405060708)));
+    usleep(1000);
+}
+
+TEST_F(MultiTcpIfTest, create_with_ports)
+{
+    add_client(TEST_NODE_ID + 1);
+    add_client(TEST_NODE_ID + 2);
+    add_client(TEST_NODE_ID + 3);
+    wait();
+}
+
+TEST_F(MultiTcpIfTest, receive_broadcast_from_hub)
+{
+    add_client(TEST_NODE_ID + 1);
+    add_client(TEST_NODE_ID + 2);
+    add_client(TEST_NODE_ID + 3);
+    wait();
+    capture_next_packet();
+    StrictMock<MockMessageHandler> h0, h1, h2;
+    EXPECT_CALL(
+        h0,
+        handle_message(
+            Pointee(AllOf(Field(&GenMessage::mti, Defs::MTI_EVENT_REPORT),
+                Field(&GenMessage::src, Field(&NodeHandle::id, TEST_NODE_ID)),
+                Field(&GenMessage::payload,
+                              IsBufferValue(UINT64_C(0x0102030405060708))))),
+            _));
+    EXPECT_CALL(
+        h1,
+        handle_message(
+            Pointee(AllOf(Field(&GenMessage::mti, Defs::MTI_EVENT_REPORT),
+                Field(&GenMessage::src, Field(&NodeHandle::id, TEST_NODE_ID)),
+                Field(&GenMessage::payload,
+                              IsBufferValue(UINT64_C(0x0102030405060708))))),
+            _));
+    EXPECT_CALL(
+        h2,
+        handle_message(
+            Pointee(AllOf(Field(&GenMessage::mti, Defs::MTI_EVENT_REPORT),
+                Field(&GenMessage::src, Field(&NodeHandle::id, TEST_NODE_ID)),
+                Field(&GenMessage::payload,
+                              IsBufferValue(UINT64_C(0x0102030405060708))))),
+            _));
+
+    clients_[0]->ifTcp_.dispatcher()->register_handler(&h0, 0, 0);
+    clients_[1]->ifTcp_.dispatcher()->register_handler(&h1, 0, 0);
+    clients_[2]->ifTcp_.dispatcher()->register_handler(&h2, 0, 0);
+
+    generate_output_message(Defs::MTI_EVENT_REPORT, TEST_NODE_ID,
+        eventid_to_buffer(UINT64_C(0x0102030405060708)));
+    wait();
+}
+
+TEST_F(MultiTcpIfTest, hub_routes_global)
+{
+    add_client(TEST_NODE_ID + 1);
+    add_client(TEST_NODE_ID + 2);
+    add_client(TEST_NODE_ID + 3);
+    wait();
+    capture_next_packet();
+    // Here we add the expectation to the central, client0 and client2. The
+    // input will come from client1.
+    StrictMock<MockMessageHandler> h0, h, h2;
+    EXPECT_CALL(
+        h0, handle_message(
+                Pointee(AllOf(Field(&GenMessage::mti, Defs::MTI_EVENT_REPORT),
+                    Field(&GenMessage::src,
+                                  Field(&NodeHandle::id, TEST_NODE_ID + 1)),
+                    Field(&GenMessage::payload, IsBufferValue(UINT64_C(
+                                                    0x0102030405060708))))),
+                _));
+    EXPECT_CALL(
+        h, handle_message(
+               Pointee(AllOf(Field(&GenMessage::mti, Defs::MTI_EVENT_REPORT),
+                   Field(&GenMessage::src,
+                                 Field(&NodeHandle::id, TEST_NODE_ID + 1)),
+                   Field(&GenMessage::payload,
+                                 IsBufferValue(UINT64_C(0x0102030405060708))))),
+               _));
+    EXPECT_CALL(
+        h2, handle_message(
+                Pointee(AllOf(Field(&GenMessage::mti, Defs::MTI_EVENT_REPORT),
+                    Field(&GenMessage::src,
+                                  Field(&NodeHandle::id, TEST_NODE_ID + 1)),
+                    Field(&GenMessage::payload, IsBufferValue(UINT64_C(
+                                                    0x0102030405060708))))),
+                _));
+
+    clients_[0]->ifTcp_.dispatcher()->register_handler(&h0, 0, 0);
+    ifTcp_.dispatcher()->register_handler(&h, 0, 0);
+    clients_[2]->ifTcp_.dispatcher()->register_handler(&h2, 0, 0);
+
+    generate_output_message(&clients_[1]->ifTcp_, Defs::MTI_EVENT_REPORT,
+        TEST_NODE_ID + 1, eventid_to_buffer(UINT64_C(0x0102030405060708)));
+    wait();
+}
+
+// here we use a high level protocol handler and a high level protocol client
+// to have two nodes talk to each other via a hub.
+TEST_F(MultiTcpIfTest, hub_routes_addressed)
+{
+    add_client(REMOTE_NODE_ID + 0);
+    add_client(REMOTE_NODE_ID + 1);
+    add_client(REMOTE_NODE_ID + 2);
+
+    capture_all_packets();
+    DefaultNode nc(&ifTcp_, TEST_NODE_ID);
+    DefaultNode n0(&clients_[0]->ifTcp_, REMOTE_NODE_ID + 0);
+    DefaultNode n1(&clients_[1]->ifTcp_, REMOTE_NODE_ID + 1);
+    DefaultNode n2(&clients_[2]->ifTcp_, REMOTE_NODE_ID + 2);
+    wait();
+    usleep(1000);
+    expect_packet_is(allPackets_[0], Defs::MTI_INITIALIZATION_COMPLETE,
+        TEST_NODE_ID, node_id_to_buffer(TEST_NODE_ID));
+    expect_packet_is(allPackets_[1], Defs::MTI_INITIALIZATION_COMPLETE,
+        REMOTE_NODE_ID + 0, node_id_to_buffer(REMOTE_NODE_ID + 0));
+    expect_packet_is(allPackets_[2], Defs::MTI_INITIALIZATION_COMPLETE,
+        REMOTE_NODE_ID + 1, node_id_to_buffer(REMOTE_NODE_ID + 1));
+    expect_packet_is(allPackets_[3], Defs::MTI_INITIALIZATION_COMPLETE,
+        REMOTE_NODE_ID + 2, node_id_to_buffer(REMOTE_NODE_ID + 2));
+    EXPECT_EQ(4u, allPackets_.size());
+
+    StrictMock<MockMessageHandler> h1;
+    clients_[0]->ifTcp_.dispatcher()->register_handler(&h1, 0, 0);
+    EXPECT_CALL(h1,
+        handle_message(Pointee(AllOf(Field(&GenMessage::mti,
+                                         Defs::MTI_PROTOCOL_SUPPORT_INQUIRY),
+                           Field(&GenMessage::payload, Eq("")),
+                           Field(&GenMessage::src, Field(&NodeHandle::id,
+                                                       REMOTE_NODE_ID + 2)),
+                           Field(&GenMessage::dst, Field(&NodeHandle::id,
+                                                       REMOTE_NODE_ID + 0)),
+                           Field(&GenMessage::dstNode, &n0))),
+                    _));
+
+    PIPClient pip_client(&clients_[2]->ifTcp_);
+    uint64_t pip_data =
+        Defs::DATAGRAM | Defs::MEMORY_CONFIGURATION | Defs::TRACTION_FDI;
+    ProtocolIdentificationHandler pip_handler(&n0, pip_data);
+    wait();
+    SyncNotifiable sync_n;
+    pip_client.request(NodeHandle(NodeID(REMOTE_NODE_ID + 0)), &n2, &sync_n);
+    usleep(1000);
+    wait();
+    EXPECT_LE(5u, allPackets_.size());
+    expect_packet_is(allPackets_[4], Defs::MTI_PROTOCOL_SUPPORT_INQUIRY,
+        n2.node_id(), NodeHandle(NodeID(REMOTE_NODE_ID + 0)), EMPTY_PAYLOAD);
+
+    sync_n.wait_for_notification();
+    EXPECT_EQ(PIPClient::OPERATION_SUCCESS, pip_client.error_code());
+    EXPECT_EQ(pip_data, pip_client.response());
+    EXPECT_EQ(6u, allPackets_.size());
+}
+
+} // namespace openlcb

--- a/src/openlcb/IfTcp.hxx
+++ b/src/openlcb/IfTcp.hxx
@@ -1,0 +1,132 @@
+/** \copyright
+ * Copyright (c) 2017, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file IfTcp.hxx
+ *
+ * OpenLCB interface implementation for native TCP connection.
+ *
+ * @author Balazs Racz
+ * @date 16 Apr 2017
+ */
+
+#ifndef _OPENLCB_IFTCP_HXX_
+#define _OPENLCB_IFTCP_HXX_
+
+#include "openlcb/If.hxx"
+#include "utils/Hub.hxx"
+
+namespace openlcb
+{
+
+/// This is not used at the moment, as TCP packet routing is not supported yet.
+struct TcpMessage
+{
+    /// Destination node, or {0,0} for broadcast. Helper function for routing.
+    NodeHandle dst;
+    /// Rendered string for the message payload. Includes the header (flags and
+    /// length as well).
+    string data;
+};
+
+class ClockBaseSequenceNumberGenerator;
+class TcpSendFlow;
+class TcpRecvFlow;
+
+/// Network interface class for a character stream link that speaks the
+/// (point-to-point) TcpTransfer protocol. This is the class that needs to be
+/// given to the virtual node (Node*) on the constructor. The If class provides
+/// the API and owns all of the implementation for sending and receiving
+/// messages to/from this network link.
+///
+/// Today the IfTcp class supports a dumb hub on the device end. This allows
+/// creating servers although without any advanced routing logic.
+class IfTcp : public If
+{
+public:
+    /// Creates a TCP interface.
+    /// @param gateway_node_id will be stamped on outgoing messages as the
+    /// gateway's node ID.
+    /// @param device is a Hub to send the TCP packets to / receive input
+    /// from. The interface will register itself into this hub. The executor of
+    /// this device will be used for processing the packets in this interface.
+    /// @param local_nodes_count is the maximum number of virtual nodes that
+    /// this interface will support.
+    IfTcp(NodeID gateway_node_id, HubFlow *device, int local_nodes_count);
+
+    /// Destructor.
+    ~IfTcp();
+
+    /** Transfers ownership of a module to the interface. It will be brought
+     * down in the destructor. The destruction order is guaranteed such that
+     * all supporting structures are still available when the flow is destryed,
+     * but incoming messages can not come in anymore.
+     *
+     * @todo(balazs.racz) revise whether this needs to be virtual. */
+    void add_owned_flow(Executable *e) override;
+    /** Transfers ownership of a module to the interface. It will be brought
+     * down in the destructor. The destruction order is guaranteed such that
+     * all supporting structures are still available when the flow is destryed,
+     * but incoming messages can not come in anymore. */
+    void add_owned_flow(Destructable *e)
+    {
+        ownedFlows_.emplace_back(e);
+    }
+    /// Finds a given pointer in the owned flows list, deletes it and removes
+    /// it from the list.
+    void delete_owned_flow(Destructable *d);
+    /** Removes a local node from this interface. This function must be called
+     * from the interface's executor.
+     *
+     * @param node is the node to delete. The node will not be freed, just
+     * removed from the data structures.
+     */
+    void delete_local_node(Node *node) override;
+    /** @return true if the two node handles match as far as we can tell
+     * without doing any network traffic. */
+    bool matching_node(NodeHandle expected, NodeHandle actual) override;
+
+    /// Adds a network client connection to the device.
+    /// @param fd is the socket going towards the client
+    /// @param on_error will be invoked when a socket error is encountered.
+    void add_network_fd(int fd, Notifiable *on_error = nullptr);
+
+private:
+    /// Where to send traffic to.
+    HubFlow *device_;
+    /// Various implementation control flows that this interface owns.
+    std::vector<std::unique_ptr<Destructable>> ownedFlows_;
+    /// Sequence number generator for outgoing TCP packets.
+    ClockBaseSequenceNumberGenerator *seq_;
+    /// Flow used for converting GenMessage into the binary
+    /// representation. Owned by ownedFlows_.
+    TcpSendFlow *sendFlow_;
+    /// Flow for parsing incoming messages. Owned by ownedFlows_.
+    TcpRecvFlow *recvFlow_;
+};
+
+} // namespace openlcb
+
+#endif // _OPENLCB_IFTCP_HXX_

--- a/src/openlcb/IfTcpImpl.hxx
+++ b/src/openlcb/IfTcpImpl.hxx
@@ -1,0 +1,613 @@
+/** \copyright
+ * Copyright (c) 2017, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file IfTcpImpl.hxx
+ *
+ * Internal implementation flows for the Tcp interface
+ *
+ * @author Balazs Racz
+ * @date 16 Apr 2017
+ */
+
+#ifndef _OPENLCB_IFTCPIMPL_HXX_
+#define _OPENLCB_IFTCPIMPL_HXX_
+
+#include "openlcb/If.hxx"
+#include "utils/Hub.hxx"
+#include "utils/HubDeviceSelect.hxx"
+
+namespace openlcb
+{
+
+/// Static class for constants and utilities related to the TCP transport
+/// protocol.
+class TcpDefs
+{
+public:
+    /// Renders a TCP message into a single buffer, ready to transmit.
+    /// @param msg is the OpenLCB message to render.
+    /// @param gateway_node_id will be populated into the message header as the
+    /// message source (last sending node ID).
+    /// @param sequence is a 48-bit millisecond value that's monotonic.
+    /// @param target is the buffer into which to render the message.
+    static void render_tcp_message(const GenMessage &msg,
+        NodeID gateway_node_id, long long sequence, string *tgt)
+    {
+        bool has_dst = Defs::get_mti_address(msg.mti);
+        HASSERT(tgt);
+        string &target = *tgt;
+        target.assign(HDR_LEN + msg.payload.size() +
+                (has_dst ? MSG_ADR_PAYLOAD_OFS : MSG_GLOBAL_PAYLOAD_OFS),
+            '\0');
+        uint16_t flags = FLAGS_OPENLCB_MSG;
+        error_to_data(flags, &target[HDR_FLAG_OFS]);
+        unsigned sz = target.size() - HDR_SIZE_END;
+        target[HDR_SIZE_OFS] = (sz >> 16) & 0xff;
+        target[HDR_SIZE_OFS + 1] = (sz >> 8) & 0xff;
+        target[HDR_SIZE_OFS + 2] = sz & 0xff;
+        node_id_to_data(gateway_node_id, &target[HDR_GATEWAY_OFS]);
+        node_id_to_data(sequence, &target[HDR_TIMESTAMP_OFS]);
+        error_to_data(msg.mti, &target[HDR_LEN + MSG_MTI_OFS]);
+        node_id_to_data(msg.src.id, &target[HDR_LEN + MSG_SRC_OFS]);
+        if (has_dst)
+        {
+            node_id_to_data(msg.dst.id, &target[HDR_LEN + MSG_DST_OFS]);
+            memcpy(&target[HDR_LEN + MSG_ADR_PAYLOAD_OFS], msg.payload.data(),
+                msg.payload.size());
+        }
+        else
+        {
+            memcpy(&target[HDR_LEN + MSG_GLOBAL_PAYLOAD_OFS],
+                msg.payload.data(), msg.payload.size());
+        }
+    }
+
+    /// Guesses the length of a tcp message from looking at the prefix of the
+    /// payload.
+    ///
+    /// @param data is the prefix of the incoming stream.
+    /// @param len is the number of available bytes in this prefix.
+    /// @return -1 if there is not enough bytes in the prefix yet to know the
+    /// length. Otherwise the total number of bytes that constitute this
+    /// packet.
+    static int get_tcp_message_len(const void *data, size_t len)
+    {
+        if (len < HDR_SIZE_END)
+        {
+            return -1;
+        }
+        const uint8_t *src = static_cast<const uint8_t *>(data);
+        uint32_t sz = src[HDR_SIZE_OFS];
+        sz <<= 8;
+        sz |= src[HDR_SIZE_OFS + 1];
+        sz <<= 8;
+        sz |= src[HDR_SIZE_OFS + 2];
+        return sz + HDR_SIZE_END;
+    }
+
+    /// Parses a TCP message format (from binary payload) into a general
+    /// OpenLCB message.
+    /// @param src the rendered TCP message.
+    /// @param tgt the output generic message
+    /// @return false if the message is not well formatted or
+    /// it is not an OpenLCB message.
+    static bool parse_tcp_message(const string &src, GenMessage *tgt)
+    {
+        int expected_size = get_tcp_message_len(src.data(), src.size());
+        if (expected_size > (int)src.size() || expected_size < MIN_MESSAGE_SIZE)
+        {
+            LOG(WARNING, "Incomplete or incorrectly formatted TCP message.");
+            return false;
+        }
+        uint16_t flags = data_to_error(&src[0]);
+        if ((flags & FLAGS_OPENLCB_MSG) == 0)
+        {
+            return false;
+        }
+        HASSERT((flags & FLAGS_CHAINING) == 0);
+        tgt->flagsDst = 0;
+        tgt->flagsSrc = 0;
+        if (flags & FLAGS_FRAGMENT_NOT_FIRST)
+        {
+            tgt->set_flag_dst(GenMessage::DSTFLAG_NOT_FIRST_MESSAGE);
+        }
+        if (flags & FLAGS_FRAGMENT_NOT_LAST)
+        {
+            tgt->set_flag_dst(GenMessage::DSTFLAG_NOT_LAST_MESSAGE);
+        }
+        const char *msg = &src[HDR_LEN];
+        // We have already checked the size to be long enough for a global
+        // message with 0 bytes payload. So source address and MTI is ok to
+        // parse now.
+        tgt->mti = (Defs::MTI)data_to_error(msg + MSG_MTI_OFS);
+        tgt->src.clear();
+        tgt->dst.clear();
+        tgt->src.id = data_to_node_id(msg + MSG_SRC_OFS);
+        // now contains the length of the message after the header.
+        int payload_bytes = expected_size - HDR_LEN;
+        int payload_ofs;
+        if (Defs::get_mti_address(tgt->mti))
+        {
+            payload_ofs = MSG_ADR_PAYLOAD_OFS;
+            tgt->dst.id = data_to_node_id(msg + MSG_DST_OFS);
+        }
+        else
+        {
+            payload_ofs = MSG_GLOBAL_PAYLOAD_OFS;
+        }
+        payload_bytes -= payload_ofs;
+        if (payload_bytes < 0)
+        {
+            LOG(WARNING, "TCP message to short.");
+            return false;
+        }
+        tgt->payload.assign(msg + payload_ofs, payload_bytes);
+        return true;
+    }
+
+    /// @param tcp_payload is a message holding a TCP protocol frame.
+    /// @return the OpenLCB priority in range 0..3 or uint_max if the message
+    /// is broken.
+    static unsigned guess_priority(const string &tcp_payload)
+    {
+        if (tcp_payload.size() < ABS_MTI_OFS + 2)
+        {
+            return UINT_MAX;
+        }
+        auto mti = (Defs::MTI)data_to_error(tcp_payload.data() + ABS_MTI_OFS);
+        return Defs::mti_priority(mti);
+    }
+
+    enum
+    {
+        /// Bit in the uint16 flags field in the header that signals frames that
+        /// carry an OpenLCB message.
+        FLAGS_OPENLCB_MSG = 0x8000,
+        /// Chaining bit in the uint16 flags field. Means (according to the old
+        /// draft) that there will be anopther header embedded inside this.
+        FLAGS_CHAINING = 0x4000,
+        /// Reserved bits in the flags field. Check as zero.
+        FLAGS_RESVD1_ZERO_CHECK = 0x3000,
+        /// "not first" fragmenting bit in the flags field.
+        FLAGS_FRAGMENT_NOT_FIRST = 0x0800,
+        /// "not last" fragmenting bit in the flags field.
+        FLAGS_FRAGMENT_NOT_LAST = 0x0400,
+        /// Reserved bits in the flags field. Ignore (by the standard).
+        FLAGS_RESVD2_IGNORED = 0x03FF,
+
+        /// Offset in the header of the flags field.
+        HDR_FLAG_OFS = 0,
+        /// Offset in the header of the size field.
+        HDR_SIZE_OFS = 2,
+        /// Offset in the header of the source gateway field.
+        HDR_GATEWAY_OFS = 2 + 3,
+        /// Offset in the header of the end of the size field.
+        HDR_SIZE_END = HDR_GATEWAY_OFS,
+        /// Offset in the header of the timestamp (seq no) field.
+        HDR_TIMESTAMP_OFS = 2 + 3 + 6,
+        /// Total length of the fixed header.
+        HDR_LEN = 2 + 3 + 6 + 6,
+
+        /// Offset in the message (=after the header) of the MTI field.
+        MSG_MTI_OFS = 0,
+        /// Offset in the message (=after the header) of the src node ID field.
+        MSG_SRC_OFS = 2,
+        /// Offset in the message (=after the header) of the dst node ID field
+        /// (for addressed MTI only).
+        MSG_DST_OFS = 2 + 6,
+        /// Offset in the message (=after the header) of the message payload
+        /// (for addressed MTI only).
+        MSG_ADR_PAYLOAD_OFS = 2 + 6 + 6,
+
+        /// Offset in the message (=after the header) of the message payload
+        /// (for global MTI only).
+        MSG_GLOBAL_PAYLOAD_OFS = MSG_DST_OFS,
+
+        /// Minimum length of a valid message.
+        MIN_MESSAGE_SIZE = MSG_GLOBAL_PAYLOAD_OFS + HDR_LEN,
+        /// Minimum length of a valid message that has an addressed MTI.
+        MIN_ADR_MESSAGE_SIZE = MSG_ADR_PAYLOAD_OFS + HDR_LEN,
+
+        /// Offset from the header of the MTI field in the message. Assumes no
+        /// chaining.
+        ABS_MTI_OFS = HDR_LEN + MSG_MTI_OFS,
+    };
+
+private:
+    /// No usable constructor; this is a static-only class.
+    TcpDefs();
+};
+
+///   Virtual clock interface. Implementations are not required to be
+///   thread-safe.
+class SequenceNumberGenerator : public Destructable
+{
+public:
+    /// Returns the next strictly monotonic sequence number.
+    virtual long long get_sequence_number() = 0;
+};
+
+/// Implementation of sequence number generator that uses the real clock. Not
+/// thread-safe.
+class ClockBaseSequenceNumberGenerator : public SequenceNumberGenerator
+{
+public:
+    /// @return next sequence number based on clock time.
+    long long get_sequence_number() override
+    {
+        long long current_time_ms = os_get_time_monotonic() / 1000000;
+        if (current_time_ms > sequence_)
+        {
+            sequence_ = current_time_ms;
+        }
+        else
+        {
+            ++sequence_;
+        }
+        return sequence_;
+    }
+
+private:
+    /// Sequence number of last sent message.
+    long long sequence_ = 0;
+};
+
+/// This flow renders outgoing OpenLCB messages to their TCP stream
+/// representation.
+class TcpSendFlow : public MessageStateFlowBase
+{
+public:
+    /// Constructor.
+    ///
+    /// @param service the owning TCP interface.
+    /// @param gateway_node_id our own node ID that will be put into the gateway
+    /// node ID field of outgoing TCP messages.
+    /// @param send_target where to send rendered TCP messages (this is usually
+    /// either the device FD flow or a hub with the binary rendered packets).
+    /// @param skip_member outgoing packets will get their skipMember_ set to
+    /// this value. Usually the matching read flow of the interface to avoid
+    /// undesired echo.
+    /// @param sequence how to generate sequence numbers for the outgoing
+    /// packets.
+    TcpSendFlow(If *service, NodeID gateway_node_id,
+        HubPortInterface *send_target, HubPortInterface *skip_member,
+        SequenceNumberGenerator *sequence)
+        : MessageStateFlowBase(service)
+        , sendTarget_(send_target)
+        , skipMember_(skip_member)
+        , gatewayId_(gateway_node_id)
+        , sequenceNumberGenerator_(sequence)
+    {
+    }
+
+private:
+    /// Handler where dequeueing of messages to be sent starts.
+    /// @return next state
+    Action entry() override
+    {
+        auto id = nmsg()->dst.id;
+        if (id)
+        {
+            auto *n = iface()->lookup_local_node(id);
+            if (n)
+            {
+                // Addressed message loopback.
+                auto *b = transfer_message();
+                b->data()->dstNode = n;
+                iface()->dispatcher()->send(b, priority());
+                return release_and_exit();
+            }
+        }
+        return allocate_and_call(sendTarget_, STATE(render_src_message));
+    }
+
+    /// Callback state after allocation succeeded. Renders the message to binary
+    /// payload into the allocated buffer, send the message and exits the
+    /// processing.
+    /// @return back to the base state.
+    Action render_src_message()
+    {
+        auto b = get_buffer_deleter(get_allocation_result(sendTarget_));
+        TcpDefs::render_tcp_message(*nmsg(), gatewayId_,
+            sequenceNumberGenerator_->get_sequence_number(), b->data());
+        b->data()->skipMember_ = skipMember_;
+        sendTarget_->send(b.release(), nmsg()->priority());
+
+        // Checks and performs global loopback.
+        if (!nmsg()->dst.id)
+        {
+            iface()->dispatcher()->send(transfer_message(), priority());
+        }
+        return release_and_exit();
+    }
+
+    /// @return the abstract message we are trying to send.
+    GenMessage *nmsg()
+    {
+        return message()->data();
+    }
+
+    /// @return owning interface object.
+    If *iface()
+    {
+        return static_cast<If *>(service());
+    }
+
+    /// Where to send the rendered messages to.
+    HubPortInterface *sendTarget_;
+    /// This value will be populated to the skipMember_ field.
+    HubPortInterface *skipMember_;
+    /// Populated into the source gateway field of the outgoing messages.
+    NodeID gatewayId_;
+    /// Responsible for generating the sequence numbers of the outgoing
+    /// messages.
+    SequenceNumberGenerator *sequenceNumberGenerator_;
+};
+
+/// This flow is listening to data from a TCP connection, segments the incoming
+/// data into TcpMessages based on the incoming size, and forwards packets
+/// containing the TCP message as string payload.
+class FdToTcpParser : public StateFlowBase
+{
+public:
+    /// Constructor.
+    /// @param s the parent (owning) service that holds the different flows
+    /// together.
+    /// @param dst where to forward the segmented packets.
+    /// @param skipMember all forwarded messages will have their skipMember set
+    /// to this value. Usually the output port.
+    FdToTcpParser(FdHubPortService *s, HubPortInterface *dst,
+        HubPortInterface *skipMember)
+        : StateFlowBase(s)
+        , dst_(dst)
+        , skipMember_(skipMember)
+    {
+        HASSERT(s->fd() >= 0);
+        bufEnd_ = 0;
+        bufOfs_ = 0;
+        start_flow(STATE(start_msg));
+    }
+
+    /// Stops listening and terminates the flow.
+    void shutdown()
+    {
+        auto *e = this->service()->executor();
+        if (e->is_selected(&helper_))
+        {
+            e->unselect(&helper_);
+            helper_.remaining_ = 0;
+        }
+        set_terminated();
+        notify_barrier();
+    }
+
+private:
+    /// @return the typed service
+    FdHubPortService *device()
+    {
+        return static_cast<FdHubPortService *>(service());
+    }
+
+    /// In this state the internal buffer (bufOfs_) points at the beginning of a
+    /// message.
+    /// @return next state.
+    Action start_msg()
+    {
+        msg_.clear();
+        expectedLen_ = -1;
+        return parse_bytes();
+    }
+
+    /// Intermediate state where we are
+    /// - figuring out what is the length of the message we are parsing
+    /// - allocating the output buffer
+    /// - copying bytes of the message from the internal buffer into the output
+    ///   buffer
+    /// @return next state
+    Action parse_bytes()
+    {
+        if (bufEnd_ <= bufOfs_)
+        {
+            return call_immediately(STATE(read_more_bytes));
+        }
+        int available = bufEnd_ - bufOfs_;
+        if (expectedLen_ < 0)
+        {
+            // We have bytes in the read buffer but don't know the expected
+            // size yet, so none in the assembly buffer. Let's guess at the
+            // desired size of the assembly buffer.
+            expectedLen_ =
+                TcpDefs::get_tcp_message_len(buffer_ + bufOfs_, available);
+            if (expectedLen_ < 0)
+            {
+                // failed. Not enough bytes. Maybe move existing bytes to the
+                // beginning of the buffer and try to read more bytes.
+                if (bufOfs_ > (READ_BUFFER_SIZE / 2))
+                {
+                    memmove(buffer_, buffer_ + bufOfs_, available);
+                    bufEnd_ -= bufOfs_;
+                    bufOfs_ = 0;
+                }
+                return call_immediately(STATE(read_more_bytes));
+            }
+        }
+        // now: we have an expected length.
+        DASSERT(expectedLen_ > 0);
+        if (msg_.empty())
+        {
+            msg_.reserve(expectedLen_);
+        }
+        // Copy some bytes to the assembly buffer.
+        int needed = expectedLen_ - msg_.size();
+        if (needed > available)
+        {
+            needed = available;
+        }
+        msg_.append((const char *)(buffer_ + bufOfs_), needed);
+        bufOfs_ += needed;
+        if (msg_.size() >= (unsigned)expectedLen_)
+        {
+            // we're done.
+            return send_entry();
+        }
+        else
+        {
+            HASSERT(bufOfs_ >= bufEnd_);
+            return call_immediately(STATE(read_more_bytes));
+        }
+    }
+
+    /// Helper state to call the stateflow kernel to read bytes from the fd into
+    /// the internal buffer.
+    /// @return next state
+    Action read_more_bytes()
+    {
+        if (bufEnd_ <= bufOfs_)
+        {
+            bufOfs_ = 0;
+            bufEnd_ = 0;
+        }
+        return read_single(&helper_, device()->fd(), buffer_ + bufEnd_,
+            READ_BUFFER_SIZE - bufEnd_, STATE(read_done), READ_PRIO);
+    }
+
+    /// Callback state when the kernel read is completed.
+    /// @return next state
+    Action read_done()
+    {
+        if (helper_.hasError_)
+        {
+            notify_barrier();
+            set_terminated();
+            device()->report_read_error();
+            return exit();
+        }
+        bufEnd_ = READ_BUFFER_SIZE - helper_.remaining_;
+        return parse_bytes();
+    }
+
+    /// Sends an assembled message (1) to the destination flow.
+    /// @return next state.
+    Action send_entry()
+    {
+        return allocate_and_call(dst_, STATE(have_alloc_msg));
+    }
+
+    /// Sends an assembled message (2) to the destination flow.
+    /// @return next state.
+    Action have_alloc_msg()
+    {
+        auto *b = get_allocation_result(dst_);
+        auto prio = TcpDefs::guess_priority(msg_);
+        b->data()->assign(std::move(msg_));
+        b->data()->skipMember_ = skipMember_;
+        /// @todo (balazs.racz): there should be some form of throttling here,
+        /// ot not read more bytes from the tcp socket than how much RAM we
+        /// have available.
+        dst_->send(b, prio);
+        return call_immediately(STATE(start_msg));
+    }
+
+    /// Calls into the parent flow's barrier notify, but makes sure to
+    /// only do this once in the lifetime of *this.
+    void notify_barrier()
+    {
+        if (barrierOwned_)
+        {
+            barrierOwned_ = false;
+            device()->barrier_.notify();
+        }
+    }
+
+    /// We attempt to read this many bytes in one go from the FD.
+    static constexpr unsigned READ_BUFFER_SIZE = 300;
+    /// If we have to guess at the size of the packet, we start by allocating
+    /// this many bytes.
+    static constexpr unsigned DEFAULT_PACKET_SIZE =
+        TcpDefs::MIN_ADR_MESSAGE_SIZE + 16;
+    static constexpr unsigned MIN_SIZE_GUESS = TcpDefs::HDR_SIZE_END;
+    /// What priority to use for reads from fds.
+    static constexpr unsigned READ_PRIO = Selectable::MAX_PRIO;
+
+    /// Temporary buffer to read into from the FD.
+    uint8_t buffer_[READ_BUFFER_SIZE];
+    /// true iff pending parent->barrier_.notify()
+    uint8_t barrierOwned_{1};
+    /// Offset of the end in the read buffer.
+    uint16_t bufEnd_;
+    /// First active byte (offset of the beginning) in the read buffer.
+    uint16_t bufOfs_;
+    /// How many bytes we think the current message will be. -1 if we don't
+    /// know yet.
+    int expectedLen_;
+    /// Assembly buffer. Holds the captured message so far.
+    string msg_;
+    /// Where to send parsed messages to.
+    HubPortInterface *dst_;
+    /// Parsed messages will be initialized to this skipMember_.
+    HubPortInterface *skipMember_;
+    StateFlowSelectHelper helper_{this};
+};
+
+using TcpHubDeviceSelect = HubDeviceSelect<HubFlow, FdToTcpParser>;
+
+/// Simple stateless translator for incoming TCP messages from binary format
+/// into the structured format. Drops everything to the floor that is not a
+/// valid TCP message. Performs synchronous allocation and keeps the done
+/// callback passed along.
+class TcpRecvFlow : public HubPortInterface, public Destructable
+{
+public:
+    /// @param target is where to send the parsed messages. Usually the
+    /// interface's dispatcher flow.
+    TcpRecvFlow(MessageHandler *target)
+        : target_(target)
+    {
+    }
+
+    /// Entry point for the incoming (binary) data. These are already segmented
+    /// correctly to openlcb-TCP packet boundaries.
+    /// @param data buffer
+    /// @param prio priority
+    void send(Buffer<HubData> *data, unsigned prio) override
+    {
+        auto src = get_buffer_deleter(data);
+        auto dst = get_buffer_deleter(target_->alloc());
+        dst->set_done(data->new_child());
+        if (TcpDefs::parse_tcp_message(*src->data(), dst->data()))
+        {
+            target_->send(dst.release(), prio);
+        }
+    }
+
+private:
+    /// Flow(interface) where to pass on the parsed GenMessage.
+    MessageHandler *target_;
+};
+
+} // namespace openlcb
+
+#endif // _OPENLCB_IFTCPIMPL_HXX_

--- a/src/openlcb/sources
+++ b/src/openlcb/sources
@@ -18,6 +18,7 @@ CXXSRCS += \
            If.cxx \
            IfCan.cxx \
            IfImpl.cxx \
+           IfTcp.cxx \
            NodeBrowser.cxx \
            NodeInitializeFlow.cxx \
            NonAuthoritativeEventProducer.cxx \

--- a/src/utils/FdUtils.hxx
+++ b/src/utils/FdUtils.hxx
@@ -1,0 +1,85 @@
+/** \copyright
+ * Copyright (c) 2018, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file FdUtils.hxx
+ *
+ * Helper functions for dealing with posix fds.
+ *
+ * @author Balazs Racz
+ * @date 18 Sep 2018
+ */
+
+#ifndef _UTILS_FD_UTILS_HXX_
+#define _UTILS_FD_UTILS_HXX_
+
+#include "utils/macros.h"
+
+struct FdUtils
+{
+    /// Performs a reliable read from the given FD. Crashes if the read fails.
+    ///
+    /// @param fd the file to read data from
+    /// @param buf the location to write data to
+    /// @param size how many bytes to read
+    static void repeated_read(int fd, void *buf, size_t size)
+    {
+        uint8_t *dst = static_cast<uint8_t *>(buf);
+        while (size)
+        {
+            ssize_t ret = ::read(fd, dst, size);
+            ERRNOCHECK("read", ret);
+            if (ret == 0)
+            {
+                DIE("Unexpected EOF reading the config file.");
+            }
+            size -= ret;
+            dst += ret;
+        }
+    }
+
+    /// Performs a reliable write to the given FD. Crashes if the write fails.
+    ///
+    /// @param fd the file to write data to
+    /// @param buf the location of the data to write
+    /// @param size how many bytes to write
+    static void repeated_write(int fd, const void *buf, size_t size)
+    {
+        const uint8_t *dst = static_cast<const uint8_t *>(buf);
+        while (size)
+        {
+            ssize_t ret = ::write(fd, dst, size);
+            ERRNOCHECK("write_config", ret);
+            if (ret == 0)
+            {
+                DIE("Unexpected EOF writing the config file.");
+            }
+            size -= ret;
+            dst += ret;
+        }
+    }
+};
+
+#endif // _UTILS_FD_UTILS_HXX_

--- a/src/utils/Hub.hxx
+++ b/src/utils/Hub.hxx
@@ -233,4 +233,37 @@ protected:
     int fd_{-1};
 };
 
+namespace openlcb
+{
+class FdToTcpParser;
+}
+
+/** Shared base class for thread-based and select-based hub devices. */
+class FdHubPortService : public FdHubPortInterface, public Service
+{
+public:
+    /// Callback from the write flow when it encounters an error.
+    virtual void report_write_error() = 0;
+
+    /// Callback from the readflow when it encounters an error.
+    virtual void report_read_error() = 0;
+
+protected:
+    // For barrier_.
+    template <class HFlow> friend class HubDeviceSelectReadFlow;
+    friend class openlcb::FdToTcpParser;
+
+    /// Constructor
+    /// @param exec executor for the service.
+    /// @param fd the device file descriptor
+    FdHubPortService(ExecutorBase *exec, int fd)
+        : FdHubPortInterface(fd)
+        , Service(exec)
+    {
+    }
+
+    /// This notifiable will be called (if not NULL) upon read or write error.
+    BarrierNotifiable barrier_;
+};
+
 #endif // _UTILS_HUB_HXX_

--- a/src/utils/HubDeviceSelect.hxx
+++ b/src/utils/HubDeviceSelect.hxx
@@ -127,34 +127,143 @@ struct SelectBufferInfo<Buffer<CanHubData>> {
     }
 };
 
+/// State flow implementing select-aware fd reads.
+template <class HFlow> class HubDeviceSelectReadFlow : public StateFlowBase
+{
+public:
+    /// Buffer type.
+    typedef typename HFlow::buffer_type buffer_type;
+
+    /// Constructor.
+    ///
+    /// @param device parent object.
+    HubDeviceSelectReadFlow(FdHubPortService *device,
+        typename HFlow::port_type *dst, typename HFlow::port_type *skip_member)
+        : StateFlowBase(device)
+        , b_(nullptr)
+        , dst_(dst)
+        , skipMember_(skip_member)
+    {
+        this->start_flow(STATE(allocate_buffer));
+    }
+
+    /// Unregisters the current flow from the hub.
+    void shutdown()
+    {
+        auto *e = this->service()->executor();
+        if (e->is_selected(&selectHelper_))
+        {
+            e->unselect(&selectHelper_);
+        }
+        set_terminated();
+        notify_barrier();
+    }
+
+    /// @return the parent object.
+    FdHubPortService *device()
+    {
+        return static_cast<FdHubPortService *>(this->service());
+    }
+
+    /// Allocates a new buffer for incoming data. @return next state.
+    Action allocate_buffer()
+    {
+        return this->allocate_and_call(dst_, STATE(try_read));
+    }
+
+    /// Attempts to read into the current buffer from the target
+    /// fd. @return next state.
+    Action try_read()
+    {
+        b_ = this->get_allocation_result(dst_);
+        b_->data()->skipMember_ = skipMember_;
+        SelectBufferInfo<buffer_type>::resize_target(b_);
+        if (SelectBufferInfo<buffer_type>::needs_read_fully())
+        {
+            return this->read_repeated(&selectHelper_, device()->fd(),
+                (void *)b_->data()->data(), b_->data()->size(),
+                STATE(read_done), 0);
+        }
+        else
+        {
+            return this->read_single(&selectHelper_, device()->fd(),
+                (void *)b_->data()->data(), b_->data()->size(),
+                STATE(read_done), 0);
+        }
+    }
+
+    /// Called when the stateflow read call(s) are completed.
+    /// @return next state.
+    Action read_done()
+    {
+        if (selectHelper_.hasError_)
+        {
+            /// Error reading the socket.
+            b_->unref();
+            notify_barrier();
+            set_terminated();
+            device()->report_read_error();
+            return exit();
+        }
+        SelectBufferInfo<buffer_type>::check_target_size(
+            b_, selectHelper_.remaining_);
+        dst_->send(b_, 0);
+        b_ = nullptr;
+        return this->call_immediately(STATE(allocate_buffer));
+    }
+
+private:
+    /** Calls into the parent flow's barrier notify, but makes sure to
+     * only do this once in the lifetime of *this. */
+    void notify_barrier()
+    {
+        if (barrierOwned_)
+        {
+            barrierOwned_ = false;
+            device()->barrier_.notify();
+        }
+    }
+
+    /// true iff pending parent->barrier_.notify()
+    bool barrierOwned_{true};
+    /// Helper object for read/write FD asynchronously.
+    StateFlowSelectHelper selectHelper_{this};
+    /// Buffer that we are currently filling.
+    buffer_type *b_;
+    /// Where do we forward the messages we created.
+    typename HFlow::port_type *dst_;
+    /// What should be the source port designation.
+    typename HFlow::port_type *skipMember_;
+};
+
 /// HubPort that connects a select-aware device to a strongly typed Hub.
 ///
 /// The device is given by either the path to the device or the fd to an opened
-/// device instance. The device will be put to nonblocking mode and all
-/// processing will be performed in the executor of the hub, by using
+/// device instance or socket. The device will be put to nonblocking mode and
+/// all processing will be performed in the executor of the hub, by using
 /// ExecutorBase::select(). No additional threads are started.
 ///
 /// Reads and writes will be performed in the units defined by the type of the
 /// hub: for string-typed hubs in 64 bytes units; for hubs of specific
 /// structures (such as CAN frame, dcc Packets or dcc Feedback structures) in
 /// the units ofthe size of the structure.
-template <class HFlow>
-class HubDeviceSelect : public FdHubPortInterface, private Atomic, public Service
+template <class HFlow, class ReadFlow = HubDeviceSelectReadFlow<HFlow>>
+class HubDeviceSelect : public FdHubPortService, private Atomic
 {
 public:
-
 #ifndef __WINNT__
     /// Creates a select-aware hub port for the device specified by `path'.
     HubDeviceSelect(
         HFlow *hub, const char *path, Notifiable *on_error = nullptr)
-        : FdHubPortInterface(::open(path, O_RDWR | O_NONBLOCK))
-        , Service(hub->service()->executor())
-        , barrier_(on_error ? on_error : EmptyNotifiable::DefaultInstance())
+        : FdHubPortService(
+              hub->service()->executor(), ::open(path, O_RDWR | O_NONBLOCK))
         , hub_(hub)
         , readFlow_(this)
         , writeFlow_(this)
     {
         HASSERT(fd_ >= 0);
+        barrier_.reset(
+            on_error ? on_error : EmptyNotifiable::DefaultInstance());
         barrier_.new_child();
         hub_->register_port(write_port());
     }
@@ -168,14 +277,14 @@ public:
     /// @param on_error notifiable that will be called when a write or read
     /// error is encountered.
     HubDeviceSelect(HFlow *hub, int fd, Notifiable *on_error = nullptr)
-        : FdHubPortInterface(fd)
-        , Service(hub->service()->executor())
-        , barrier_(on_error ? on_error : EmptyNotifiable::DefaultInstance())
+        : FdHubPortService(hub->service()->executor(), fd)
         , hub_(hub)
-        , readFlow_(this)
+        , readFlow_(this, hub, &writeFlow_)
         , writeFlow_(this)
     {
         HASSERT(fd_ >= 0);
+        barrier_.reset(
+            on_error ? on_error : EmptyNotifiable::DefaultInstance());
         barrier_.new_child();
 #ifdef __WINNT__
         unsigned long par = 1;
@@ -186,6 +295,7 @@ public:
         hub_->register_port(write_port());
     }
 
+    /// If the barrier has not been called yet, will notify it inline.
     virtual ~HubDeviceSelect()
     {
         if (fd_ >= 0) {
@@ -224,6 +334,8 @@ public:
     /// Removes the current write port from the registry of the source hub.
     void unregister_write_port()
     {
+        LOG(VERBOSE, "HubDeviceSelect::unregister write port %p %p",
+            write_port(), &writeFlow_);
         hub_->unregister_port(&writeFlow_);
         /* We put an empty message at the end of the queue. This will cause
          * wait until all pending messages are dealt with, and then ping the
@@ -233,105 +345,14 @@ public:
         writeFlow_.send(b);
     }
 
-protected:
-    /// State flow implementing select-aware fd reads.
-    class ReadFlow : public StateFlowBase
+    /// @return true if there is no pending data to write. Can be used to check
+    /// safe destruction.
+    bool write_done()
     {
-    public:
-        /// Buffer type.
-        typedef typename HFlow::buffer_type buffer_type;
+        return writeFlow_.is_waiting();
+    }
 
-        /// Constructor.
-        ///
-        /// @param device parent object.
-        ReadFlow(HubDeviceSelect *device)
-            : StateFlowBase(device)
-            , b_(nullptr)
-        {
-            this->start_flow(STATE(allocate_buffer));
-        }
-
-        /// Unregisters the current flow from the hub.
-        void shutdown()
-        {
-            auto* e = this->service()->executor();
-            if (e->is_selected(&selectHelper_)) {
-                e->unselect(&selectHelper_);
-            }
-            set_terminated();
-            notify_barrier();
-        }
-
-        /// @return the parent object.
-        HubDeviceSelect *device()
-        {
-            return static_cast<HubDeviceSelect *>(this->service());
-        }
-
-        /// Allocates a new buffer for incoming data. @return next state.
-        Action allocate_buffer()
-        {
-            return this->allocate_and_call(device()->hub(), STATE(try_read));
-        }
-
-        /// Attempts to read into the current buffer from the target
-        /// fd. @return next state.
-        Action try_read()
-        {
-            b_ = this->get_allocation_result(device()->hub());
-            b_->data()->skipMember_ = device()->write_port();
-            SelectBufferInfo<buffer_type>::resize_target(b_);
-            if (SelectBufferInfo<buffer_type>::needs_read_fully())
-            {
-                return this->read_repeated(&selectHelper_, device()->fd(),
-                    (void *)b_->data()->data(), b_->data()->size(),
-                    STATE(read_done), 0);
-            }
-            else
-            {
-                return this->read_single(&selectHelper_, device()->fd(),
-                    (void *)b_->data()->data(), b_->data()->size(),
-                    STATE(read_done), 0);
-            }
-        }
-
-        Action read_done()
-        {
-            if (selectHelper_.hasError_) {
-                /// Error reading the socket.
-                b_->unref();
-                notify_barrier();
-                set_terminated();
-                device()->report_read_error();
-                return exit();
-            }
-            SelectBufferInfo<buffer_type>::check_target_size(
-                b_, selectHelper_.remaining_);
-            device()->hub()->send(b_, 0);
-            b_ = nullptr;
-            return this->call_immediately(STATE(allocate_buffer));
-        }
-
-    private:
-        /** Calls into the parent flow's barrier notify, but makes sure to
-         * only do this once in the lifetime of *this. */
-        void notify_barrier()
-        {
-            if (barrierOwned_)
-            {
-                barrierOwned_ = false;
-                device()->barrier_.notify();
-            }
-        }
-
-        /// true iff pending parent->barrier_.notify()
-        bool barrierOwned_{true};
-        /// Helper object for read/write FD asynchronously.
-        StateFlowSelectHelper selectHelper_{this};
-        /// Buffer that we are currently filling.
-        buffer_type *b_;
-    };
-
+protected:
     /// Base stateflow for the WriteFlow.
     typedef StateFlow<typename HFlow::buffer_type, QList<1>> WriteFlowBase;
     /// State flow implementing select-aware fd writes.
@@ -344,7 +365,13 @@ protected:
         {
         }
 
-        /// Unregisters this oebject from the flows.
+        /// Destructor.
+        ~WriteFlow()
+        {
+            HASSERT(this->is_waiting());
+        }
+
+        /// Unregisters this object from the flows.
         void shutdown()
         {
             // The fd must be set to negative already to ensure the shutdown
@@ -392,11 +419,10 @@ protected:
     };
 
 protected:
-    friend class ReadFlow;  // for notifying barrier_
 
     /** The assumption here is that the write flow still has entries in its
      * queue that need to be removed. */
-    void report_write_error()
+    void report_write_error() override
     {
         readFlow_.shutdown();
         unregister_write_port();
@@ -409,7 +435,7 @@ protected:
     /** Callback from the ReadFlow when the read call has seen an error. The
      * read count will already have been taken out of the barrier, and the read
      * flow in terminated state. */
-    void report_read_error()
+    void report_read_error() override
     {
         unregister_write_port();
         if (fd_ >= 0) {
@@ -418,8 +444,6 @@ protected:
         }
     }
 
-    /// This notifiable will be called (if not NULL) upon read or write error.
-    BarrierNotifiable barrier_;
     /// Hub whose data we are trying to send.
     HFlow *hub_;
     /// StateFlow for reading data from the fd. Woken when data arrives.

--- a/src/utils/HubDeviceSelect.hxx
+++ b/src/utils/HubDeviceSelect.hxx
@@ -258,7 +258,7 @@ public:
         : FdHubPortService(
               hub->service()->executor(), ::open(path, O_RDWR | O_NONBLOCK))
         , hub_(hub)
-        , readFlow_(this)
+        , readFlow_(this, hub, &writeFlow_)
         , writeFlow_(this)
     {
         HASSERT(fd_ >= 0);

--- a/src/utils/async_if_test_helper.hxx
+++ b/src/utils/async_if_test_helper.hxx
@@ -302,6 +302,40 @@ namespace openlcb
 
 static const NodeID TEST_NODE_ID = 0x02010d000003ULL;
 
+class LocalIf : public If
+{
+public:
+    LocalIf(int local_nodes_count)
+        : If(&g_executor, local_nodes_count)
+    {
+    }
+
+    void add_owned_flow(Executable *e) override
+    {
+        ownedFlows_.emplace_back(e);
+    }
+
+    void delete_local_node(Node *node) override
+    {
+        remove_local_node_from_map(node);
+    }
+
+    bool matching_node(NodeHandle expected, NodeHandle actual) override
+    {
+        if (expected.id && actual.id)
+        {
+            return expected.id == actual.id;
+        }
+        // Cannot reconcile.
+        LOG(VERBOSE, "Cannot reconcile expected and actual NodeHandles for "
+                     "equality testing.");
+        return false;
+    }
+
+private:
+    std::vector<std::unique_ptr<Destructable>> ownedFlows_;
+};
+
 /** Test fixture base class with helper methods for exercising the asynchronous
  * interface code.
  *


### PR DESCRIPTION
Reverts "Revert \"TCP interface\""
Fixes compilation problems.

Original description: 

Implements an interface using the draft Tcp protocol. 
The new interface operates in conjunction with a Hub<string>, where each TCP rendered packet is in exactly one buffer traversing the Hub. A select-aware state flow is added that segments incoming bytes from an fd into packets of the Tcp protocol format with as little memory fragmentation as possible. This needed a new HubDeviceSelect (which is now templated on the read segmenting flow) and the equivalent code of create_gc_port_for_can_hub to handle graceful closing of sockets by the remote side, socket errors or teardown of the interface locally (in unit tests).
This scheme supports having multiple clients connected to a single hub, which is necessary for TCP servers. There is no filtering, i.e., all messages are passed on to every client.

The tcp interface itself converts between the Buffer<string> having the binary (wire) representation and the Buffer<GenMessage> which is the inmemory struct representation, taking care of loopback of global and addressed messages, as well as filtering incoming addressed messages.

Fragmented messages are not yet supported. The datagram service is not yet supported. Routing between a CAN interface and a TCP interface is not yet supported.

Unit tests are added for the following schemes:
- static parsing and rendering functions; sequence generator
- the transmit flow communicating with an FD.
- the receive flow reading from an FD using select; with various alignment cases as it is reassembling a single string from the FD.
- the interface, for sending and receiving addressed and global messages, including tests for loopback and filtering noninteresting addressed messages
- the interface handling of VerifyNodeID messages.
- a TcpIf and a loopback socket connected as a client, sending and receiving wire payload directly on the fd.
- a TcpIf as a hub, with three loopback sockets connected as clients and each having its own TcpIf instance, sending GenMessages between each other using the high-level APIs. 