### PR TITLE
verbose wifi logging for esp32

### DIFF
--- a/arduino/examples/ESP32CanLoadTest/ESP32CanLoadTest.ino
+++ b/arduino/examples/ESP32CanLoadTest/ESP32CanLoadTest.ino
@@ -278,6 +278,9 @@ void IRAM_ATTR onTimer()
 
 void setup()
 {
+#ifdef USE_WIFI
+    wifi_mgr.enable_verbose_logging();
+#endif    
     Serial.begin(115200L);
 
     timer = timerBegin(3, 80, true); // timer_id = 3; divider=80; countUp = true;

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
@@ -467,9 +467,9 @@ void Esp32WiFiManager::enable_verbose_logging()
     esp32VerboseLogging_ = true;
     esp_log_level_set("wifi", ESP_LOG_VERBOSE);
     esp_wifi_internal_set_log_level(WIFI_LOG_VERBOSE);
-    esp_wifi_internal_set_log_mod(WIFI_LOG_MODULE_ALL, WIFI_LOG_SUBMODULE_ALL, true);
+    esp_wifi_internal_set_log_mod(
+        WIFI_LOG_MODULE_ALL, WIFI_LOG_SUBMODULE_ALL, true);
 }
-
 
 // If the Esp32WiFiManager is setup to manage the WiFi system, the following
 // steps are executed:

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
@@ -36,7 +36,9 @@
 #include "os/MDNS.hxx"
 
 #include <esp_event_loop.h>
+#include <esp_log.h>
 #include <esp_wifi.h>
+#include <esp_wifi_internal.h>
 #include <mdns.h>
 #include <rom/crc.h>
 #include <tcpip_adapter.h>
@@ -460,6 +462,15 @@ void Esp32WiFiManager::process_wifi_event(int event_id)
     }
 }
 
+void Esp32WiFiManager::enable_verbose_logging()
+{
+    esp32VerboseLogging_ = true;
+    esp_log_level_set("wifi", ESP_LOG_VERBOSE);
+    esp_wifi_internal_set_log_level(WIFI_LOG_VERBOSE);
+    esp_wifi_internal_set_log_mod(WIFI_LOG_MODULE_ALL, WIFI_LOG_SUBMODULE_ALL, true);
+}
+
+
 // If the Esp32WiFiManager is setup to manage the WiFi system, the following
 // steps are executed:
 // 1) Start the TCP/IP adapter.
@@ -496,11 +507,19 @@ void Esp32WiFiManager::start_wifi_system()
     // Install event loop handler.
     ESP_ERROR_CHECK(esp_event_loop_init(wifi_event_handler, this));
 
+    if (esp32VerboseLogging_)
+    {
+        esp_log_level_set("wifi", ESP_LOG_VERBOSE);
+        esp_wifi_internal_set_log_level(WIFI_LOG_VERBOSE);
+        esp_wifi_internal_set_log_mod(
+            WIFI_LOG_MODULE_ALL, WIFI_LOG_SUBMODULE_ALL, true);
+    }
+
     // Start the WiFi adapter.
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     LOG(INFO, "[WiFi] Initializing WiFi stack");
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
-
+    
     // Set the WiFi mode to STATION.
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
 

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
@@ -507,6 +507,11 @@ void Esp32WiFiManager::start_wifi_system()
     // Install event loop handler.
     ESP_ERROR_CHECK(esp_event_loop_init(wifi_event_handler, this));
 
+    // Start the WiFi adapter.
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    LOG(INFO, "[WiFi] Initializing WiFi stack");
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
     if (esp32VerboseLogging_)
     {
         esp_log_level_set("wifi", ESP_LOG_VERBOSE);
@@ -515,11 +520,6 @@ void Esp32WiFiManager::start_wifi_system()
             WIFI_LOG_MODULE_ALL, WIFI_LOG_SUBMODULE_ALL, true);
     }
 
-    // Start the WiFi adapter.
-    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-    LOG(INFO, "[WiFi] Initializing WiFi stack");
-    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
-    
     // Set the WiFi mode to STATION.
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
 

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
@@ -135,6 +135,10 @@ public:
     /// @param event_id is the system_event_t.event_id value.
     void process_wifi_event(int event_id);
 
+    /// If called, setsthe ESP32 wifi stack to log verbose information to the
+    /// ESP32 serial port.
+    void enable_verbose_logging();
+
 private:
     /// Default constructor.
     Esp32WiFiManager();
@@ -212,6 +216,9 @@ private:
     /// Internal flag to request the wifi_manager_task reload configuration.
     bool configReloadRequested_{true};
 
+    /// if true, request esp32 wifi to do verbose logging.
+    bool esp32VerboseLogging_{false};
+    
     /// @ref GcTcpHub for this node's hub if enabled.
     std::unique_ptr<GcTcpHub> hub_;
 

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
@@ -218,7 +218,7 @@ private:
 
     /// if true, request esp32 wifi to do verbose logging.
     bool esp32VerboseLogging_{false};
-    
+
     /// @ref GcTcpHub for this node's hub if enabled.
     std::unique_ptr<GcTcpHub> hub_;
 


### PR DESCRIPTION
Adds an option to the esp32 wifi manager that enables verbose logging in the esp32 wifi stack.