### PR TITLE
Limits buffer memory between GC bridge and write flow.

### DIFF
--- a/include/nmranet_config.h
+++ b/include/nmranet_config.h
@@ -104,7 +104,6 @@ DECLARE_CONST(gridconnect_bridge_max_incoming_packets);
 /// output socket cannot send the data fast enough.
 DECLARE_CONST(gridconnect_bridge_max_outgoing_packets);
 
-
 /** Number of bytes of gridconnect data to buffer before sending off the
  * lowlevel system (such as TCP socket). */
 DECLARE_CONST(gridconnect_buffer_size);

--- a/include/nmranet_config.h
+++ b/include/nmranet_config.h
@@ -99,6 +99,11 @@ DECLARE_CONST(gridconnect_port_max_incoming_packets);
 ///  - tracks CAN frames coming from gridconnect ports
 /// it works (unlike the above)
 DECLARE_CONST(gridconnect_bridge_max_incoming_packets);
+/// Number of pending buffers (of type string) in the outgoing hub on a
+/// per-connection basis. This limit ensures that we don't leak memory if the
+/// output socket cannot send the data fast enough.
+DECLARE_CONST(gridconnect_bridge_max_outgoing_packets);
+
 
 /** Number of bytes of gridconnect data to buffer before sending off the
  * lowlevel system (such as TCP socket). */

--- a/src/utils/Buffer.hxx
+++ b/src/utils/Buffer.hxx
@@ -54,6 +54,7 @@
 
 class DynamicPool;
 class FixedPool;
+class LimitedPool;
 class Pool;
 template <class T> class Buffer;
 class BufferBase;
@@ -176,6 +177,9 @@ protected:
     /** Allow FixedPool access to our constructor */
     friend class FixedPool;
 
+    /** Allow LimitedPool access to our fields */
+    friend class LimitedPool;
+    
     DISALLOW_COPY_AND_ASSIGN(BufferBase);
 };
 
@@ -358,6 +362,8 @@ protected:
 private:
     /** Allow BufferBase to access this class */
     friend class BufferBase;
+    /** LimitedPool proxies to a base Pool. */
+    friend class LimitedPool;
 
     /** Allow Buffer to access this class */
     template <class T> friend class Buffer;

--- a/src/utils/Buffer.hxx
+++ b/src/utils/Buffer.hxx
@@ -179,7 +179,7 @@ protected:
 
     /** Allow LimitedPool access to our fields */
     friend class LimitedPool;
-    
+
     DISALLOW_COPY_AND_ASSIGN(BufferBase);
 };
 

--- a/src/utils/BufferPort.hxx
+++ b/src/utils/BufferPort.hxx
@@ -38,7 +38,7 @@
 
 #include "utils/LimitedPool.hxx"
 
-/// A wrapper class around a string-based Hub Port that buffersthe outgoing
+/// A wrapper class around a string-based Hub Port that buffers the outgoing
 /// bytes for a specified delay timer before sending the data off. This helps
 /// accumulate more data per TCP packet and increase transmission efficiency.
 ///

--- a/src/utils/BufferPort.hxx
+++ b/src/utils/BufferPort.hxx
@@ -82,7 +82,7 @@ public:
         }
         return true;
     }
-    
+
 private:
     Action entry() override
     {
@@ -102,12 +102,6 @@ private:
             {
                 timerPending_ = 1;
                 bufferTimer_.start(delayNsec_);
-            }
-            if (!tgtBuf_) {
-                // Will ensure we keep track of the skipMember_ inside as well.
-                tgtBuf_ = transfer_message();
-                // Invokes the caller's notify in case there is one set.
-                tgtBuf_->set_done(nullptr);
             }
             return release_and_exit();
         }
@@ -129,6 +123,7 @@ private:
         }
     }
 
+    /// State when the allocation of output buffer completed.
     Action buf_alloc_done()
     {
         tgtBuf_ = get_allocation_result(downstream_);
@@ -187,6 +182,8 @@ private:
         BufferPort *parent_; ///< what to notify upon timeout.
     } bufferTimer_{this}; ///< timer instance.
 
+    /// Pool implementation that limits the number of buffers allocateable to
+    /// the configuration option.
     LimitedPool outputPool_ {sizeof(*tgtBuf_),
         (unsigned)config_gridconnect_bridge_max_outgoing_packets()};
     /// Caches one output buffer to fill in the buffer flush method.

--- a/src/utils/BufferPort.hxx
+++ b/src/utils/BufferPort.hxx
@@ -182,7 +182,7 @@ private:
         BufferPort *parent_; ///< what to notify upon timeout.
     } bufferTimer_{this}; ///< timer instance.
 
-    /// Pool implementation that limits the number of buffers allocateable to
+    /// Pool implementation that limits the number of buffers allocatable to
     /// the configuration option.
     LimitedPool outputPool_ {sizeof(*tgtBuf_),
         (unsigned)config_gridconnect_bridge_max_outgoing_packets()};

--- a/src/utils/BufferPort.hxx
+++ b/src/utils/BufferPort.hxx
@@ -86,7 +86,8 @@ public:
 private:
     Action entry() override
     {
-        if (!tgtBuf_) {
+        if (!tgtBuf_)
+        {
             return allocate_and_call(downstream_, STATE(buf_alloc_done),
                 config_gridconnect_bridge_max_outgoing_packets() <= 1
                     ? nullptr

--- a/src/utils/LimitedPool.cxxtest
+++ b/src/utils/LimitedPool.cxxtest
@@ -1,0 +1,93 @@
+#include "utils/async_if_test_helper.hxx"
+
+#include "utils/LimitedPool.hxx"
+
+class LimitedPoolTest : public ::testing::Test
+{
+protected:
+    class AllocCb : public Executable
+    {
+    public:
+        AllocCb(LimitedPoolTest* parent) : parent_(parent) {}
+        void alloc_result(QMember *item) override
+        {
+            BufferBase* b = (BufferBase*) item;
+            parent_->pool.alloc_async_init(b, &parent_->buffer_);
+        }
+        void run() override
+        {
+            DIE("should not be called");
+        }
+    private:
+        LimitedPoolTest* parent_;
+    } allocCb_{this};
+
+    friend class AllocCb;
+    
+    BufferPtr<int> allocate_sync()
+    {
+        buffer_ = nullptr;
+        pool.alloc(&buffer_, &allocCb_);
+        EXPECT_TRUE(buffer_);
+        auto r = get_buffer_deleter(buffer_);
+        buffer_ = nullptr;
+        return r;
+    }
+
+    void allocate_fail()
+    {
+        buffer_ = nullptr;
+        pool.alloc(&buffer_, &allocCb_);
+        ASSERT_FALSE(buffer_);
+    }
+
+    typedef Buffer<int> buffer_type;
+    buffer_type* buffer_;
+    LimitedPool pool {sizeof(buffer_type), 2};
+};
+
+TEST_F(LimitedPoolTest, construct)
+{
+}
+
+TEST_F(LimitedPoolTest, allocate_success)
+{
+    EXPECT_EQ(2u, pool.free_items());
+    auto b1 = allocate_sync();
+    EXPECT_EQ(1u, pool.free_items());
+    auto b2 = allocate_sync();
+    EXPECT_EQ(0u, pool.free_items());
+
+    ASSERT_TRUE(b1.get());
+    ASSERT_TRUE(b2.get());
+}
+
+TEST_F(LimitedPoolTest, release)
+{
+    auto b1 = allocate_sync();
+    auto b2 = allocate_sync();
+    EXPECT_EQ(0u, pool.free_items());
+
+    b1.reset();
+    EXPECT_EQ(1u, pool.free_items());
+    
+    b2.reset();
+    EXPECT_EQ(2u, pool.free_items());
+
+    ASSERT_FALSE(b1.get());
+    ASSERT_FALSE(b2.get());
+}
+
+TEST_F(LimitedPoolTest, allocate_fail)
+{
+    auto b1 = allocate_sync();
+    auto b2 = allocate_sync();
+    allocate_fail();
+    
+    ASSERT_TRUE(b1.get());
+    ASSERT_TRUE(b2.get());
+    b1.reset(); // will cause next in line to get the buffer.
+    ASSERT_TRUE(buffer_);
+    buffer_->unref();
+    EXPECT_EQ(1u, pool.free_items());
+}

--- a/src/utils/LimitedPool.cxxtest
+++ b/src/utils/LimitedPool.cxxtest
@@ -5,25 +5,33 @@
 class LimitedPoolTest : public ::testing::Test
 {
 protected:
+    /// Helper class that represents the StateFlow trying to allocate an object
+    /// from the pool.
     class AllocCb : public Executable
     {
     public:
-        AllocCb(LimitedPoolTest* parent) : parent_(parent) {}
+        AllocCb(LimitedPoolTest *parent)
+            : parent_(parent)
+        {
+        }
         void alloc_result(QMember *item) override
         {
-            BufferBase* b = (BufferBase*) item;
+            BufferBase *b = (BufferBase *)item;
             parent_->pool.alloc_async_init(b, &parent_->buffer_);
         }
         void run() override
         {
             DIE("should not be called");
         }
+
     private:
-        LimitedPoolTest* parent_;
-    } allocCb_{this};
+        LimitedPoolTest *parent_;
+    } allocCb_ {this};
 
     friend class AllocCb;
-    
+
+    /// Allocates an object from the pool and expects the allocation to succeed.
+    /// @return the buffer allocated (with auto-delete wrapper).
     BufferPtr<int> allocate_sync()
     {
         buffer_ = nullptr;
@@ -34,6 +42,9 @@ protected:
         return r;
     }
 
+    /// Tries to allocate an object from the pool, and expects the allocation to
+    /// fail. The request will be enqueued, and at a later point the buffer will
+    /// show up in the buffer_ variable.
     void allocate_fail()
     {
         buffer_ = nullptr;
@@ -41,8 +52,12 @@ protected:
         ASSERT_FALSE(buffer_);
     }
 
+    /// Type of the buffer we are using for the test.
     typedef Buffer<int> buffer_type;
-    buffer_type* buffer_;
+    /// Temporary variable where the allocated buffers are deposited by the
+    /// AllocCb class.
+    buffer_type *buffer_;
+    /// Pool that we are testing.
     LimitedPool pool {sizeof(buffer_type), 2};
 };
 
@@ -70,7 +85,7 @@ TEST_F(LimitedPoolTest, release)
 
     b1.reset();
     EXPECT_EQ(1u, pool.free_items());
-    
+
     b2.reset();
     EXPECT_EQ(2u, pool.free_items());
 
@@ -83,7 +98,7 @@ TEST_F(LimitedPoolTest, allocate_fail)
     auto b1 = allocate_sync();
     auto b2 = allocate_sync();
     allocate_fail();
-    
+
     ASSERT_TRUE(b1.get());
     ASSERT_TRUE(b2.get());
     b1.reset(); // will cause next in line to get the buffer.

--- a/src/utils/LimitedPool.hxx
+++ b/src/utils/LimitedPool.hxx
@@ -1,0 +1,133 @@
+/** \copyright
+ * Copyright (c) 2019, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file LimitedPool.hxx
+ *
+ * Wrapper of an existing Pool that limits the number of buffers that can be
+ * allocated at a given time. This can be used on a per-flow basis to avoid
+ * infinite sized queues to build up.
+ *
+ * @author Balazs Racz
+ * @date 6 April 2019
+ */
+
+#ifndef _UTILS_LIMITEDPOOL_HXX_
+#define _UTILS_LIMITEDPOOL_HXX_
+
+#include "utils/Buffer.hxx"
+
+class LimitedPool : public Pool, private Atomic
+{
+public:
+    LimitedPool(unsigned entry_size, unsigned entry_count)
+        : itemSize_(entry_size)
+        , freeCount_(entry_count)
+    {
+    }
+
+    size_t free_items() override
+    {
+        return freeCount_;
+    }
+
+    /** Number of free items in the pool for a given allocation size.
+     * @param size size of interest
+     * @return number of free items in the pool for a given allocation size
+     */
+    size_t free_items(size_t size) override
+    {
+        return size == itemSize_ ? freeCount_ : 0;
+    }
+
+protected:
+    BufferBase *alloc_untyped(size_t size, Executable *flow) override
+    {
+        HASSERT(size == itemSize_);
+        if (!flow)
+        {
+            DIE("LimitedPool only supports async allocation.");
+        }
+        BufferBase *b = nullptr;
+        {
+            AtomicHolder h(this);
+            if (freeCount_ > 0)
+            {
+                --freeCount_;
+                b = base_pool()->alloc_untyped(size, nullptr);
+                HASSERT(b);
+                b->pool_ = this;
+            }
+        }
+        if (b)
+        {
+            flow->alloc_result(b);
+            return b;
+        }
+        else
+        {
+            waitingQueue_.insert(flow);
+            return nullptr;
+        }
+    }
+
+    void free(BufferBase *item) override
+    {
+        HASSERT(item->size() == itemSize_);
+        Executable *waiting = NULL;
+        {
+            AtomicHolder h(this);
+            waiting = static_cast<Executable *>(waitingQueue_.next().item);
+            if (!waiting)
+            {
+                ++freeCount_;
+            }
+        }
+        if (waiting)
+        {
+            waiting->alloc_result(item);
+        }
+        else
+        {
+            base_pool()->free(item);
+        }
+    }
+
+private:
+    /// @return the pool from which we should get the actual memory we have.
+    Pool *base_pool()
+    {
+        return mainBufferPool;
+    }
+
+    /// How many bytes each entry should be.
+    uint16_t itemSize_;
+    /// How many entries can still be allocated.
+    uint16_t freeCount_;
+    /// Async allocators waiting for free buffers.
+    Q waitingQueue_;
+};
+
+#endif // _UTILS_LIMITEDPOOL_HXX_

--- a/src/utils/constants.cxx
+++ b/src/utils/constants.cxx
@@ -148,5 +148,7 @@ DEFAULT_CONST(gridconnect_buffer_delay_usec, 300);
 DEFAULT_CONST(gridconnect_port_max_incoming_packets, 6);
 /// 1 = infinite, do not preallocate memory
 DEFAULT_CONST(gridconnect_bridge_max_incoming_packets, 1);
+/// 1 = infinite
+DEFAULT_CONST(gridconnect_bridge_max_outgoing_packets, 1);
 
 DEFAULT_CONST_FALSE(gridconnect_tcp_use_select);


### PR DESCRIPTION
Adds LimitedPool, an implementation of a BufferPool that allows only a fixed number of buffers to be allocated.

After this is exhausted, further allocations get blocked until some earlier buffer gets freed. This is similar to FixedPool except the memory is allocated and returned to mainBufferPool, so the overhead on a per-instance basis is much lower.

Adds LimitedPool to the BufferPort component which is responsible for sending gridconnect packets to the Hub's write flow. A link-time configuration option defines whether we should limit the number of filled-in packets sent to the write flow.

Without this limitation if the write flow gets backed up, there is an unlimited amount of RAM we use up in the queue of Buffers going out of the BufferPort and waiting on the input of the WriteFlow. With this limit the batching size will automatically adjust to the throughput that the WriteFlow can sustain.