### PR TITLE
Fixes selection of ELF file

### DIFF
--- a/arduino/Makefile
+++ b/arduino/Makefile
@@ -1,6 +1,6 @@
 all:
 
-ELFFILE=$(shell ls /tmp/arduino_build_*/*elf -r | tail -n 1)
+ELFFILE=$(shell ls /tmp/arduino_build_*/*elf -tr | tail -n 1)
 ESP32BINDIR=$(wildcard $(HOME)/.arduino15/packages/esp32/tools/xtensa-esp32-elf-gcc/*/bin/)
 
 PREFIX=$(ESP32BINDIR)/xtensa-esp32-elf-


### PR DESCRIPTION
Fixes selection of ELF file to be the latest by time instead of by alphabetical. This works around a problem when you have multiple sketches open and thus arduino has multiple build/cache directories in /tmp.