### PR TITLE
esp32: pin openmrn task to core 0

### DIFF
--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -352,15 +352,23 @@ public:
     }
 
 #ifndef OPENMRN_FEATURE_SINGLE_THREADED
+    static void thread_entry(void* arg) {
+        OpenMRN* p = (OpenMRN*) arg;
+        p->stack()->executor()->thread_body();
+    }
+
     void start_executor_thread()
     {
         haveExecutorThread_ = true;
-        stack_->executor()->start_thread(
-            "OpenMRN", OPENMRN_TASK_PRIORITY, OPENMRN_STACK_SIZE);
 #ifdef ESP32
+        xTaskCreatePinnedToCore(&thread_entry, "OpenMRN", OPENMRN_STACK_SIZE,
+            this, OPENMRN_TASK_PRIORITY, nullptr, 0);
         // Remove IDLE0 task watchdog, because the openmrn task sometimes gets
         // scheduled on CPU0 and can use 100% cpu.
         disableCore0WDT();
+#else
+        stack_->executor()->start_thread(
+            "OpenMRN", OPENMRN_TASK_PRIORITY, OPENMRN_STACK_SIZE);
 #endif        
     }
 #endif

--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -364,13 +364,13 @@ public:
 #ifdef ESP32
         xTaskCreatePinnedToCore(&thread_entry, "OpenMRN", OPENMRN_STACK_SIZE,
             this, OPENMRN_TASK_PRIORITY, nullptr, 0);
-        // Remove IDLE0 task watchdog, because the openmrn task sometimes gets
-        // scheduled on CPU0 and can use 100% cpu.
+        // Remove IDLE0 task watchdog, because the openmrn task sometimes uses
+        // 100% cpu and it is pinned to CPU 0.
         disableCore0WDT();
 #else
         stack_->executor()->start_thread(
             "OpenMRN", OPENMRN_TASK_PRIORITY, OPENMRN_STACK_SIZE);
-#endif        
+#endif
     }
 #endif
 

--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -352,8 +352,9 @@ public:
     }
 
 #ifndef OPENMRN_FEATURE_SINGLE_THREADED
-    static void thread_entry(void* arg) {
-        OpenMRN* p = (OpenMRN*) arg;
+    static void thread_entry(void *arg)
+    {
+        OpenMRN *p = (OpenMRN *)arg;
         p->stack()->executor()->thread_body();
     }
 


### PR DESCRIPTION
Esp32: pins executor thread to core 0. This avoid starving the loop() task
when the executor thread is busy but the kernel scheduler "forgets" it on core 1.

The esp32 FreeRTOS multi-processor scheduler is not very smart in the presence of pinned tasks. It is possible to get a priority inversion when a non-pinned higher-priority task gets scheduled onto the core where there is a pinned lower-priority task. In this case the other core could go down to as low as running the idle task instead of the higher-priority task being moved to the idle core and the lower priority task running on its pinned core.