### PR TITLE
arduino-esp32 1.0.2-rc2 (release candidate for 1.0.2) compatiblity fix

### DIFF
--- a/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
@@ -466,9 +466,14 @@ void Esp32WiFiManager::enable_verbose_logging()
 {
     esp32VerboseLogging_ = true;
     esp_log_level_set("wifi", ESP_LOG_VERBOSE);
+
+// arduino-esp32 1.0.2 uses ESP-IDF 3.2 which does not have these two methods
+// in the headers, they are only available in ESP-IDF 3.3.
+#if defined(WIFI_LOG_SUBMODULE_ALL)
     esp_wifi_internal_set_log_level(WIFI_LOG_VERBOSE);
     esp_wifi_internal_set_log_mod(
         WIFI_LOG_MODULE_ALL, WIFI_LOG_SUBMODULE_ALL, true);
+#endif // WIFI_LOG_SUBMODULE_ALL
 }
 
 // If the Esp32WiFiManager is setup to manage the WiFi system, the following
@@ -516,9 +521,13 @@ void Esp32WiFiManager::start_wifi_system()
     if (esp32VerboseLogging_)
     {
         esp_log_level_set("wifi", ESP_LOG_VERBOSE);
+// arduino-esp32 1.0.2 uses ESP-IDF 3.2 which does not have these two methods
+// in the headers, they are only available in ESP-IDF 3.3.
+#if defined(WIFI_LOG_SUBMODULE_ALL)
         esp_wifi_internal_set_log_level(WIFI_LOG_VERBOSE);
         esp_wifi_internal_set_log_mod(
             WIFI_LOG_MODULE_ALL, WIFI_LOG_SUBMODULE_ALL, true);
+#endif // WIFI_LOG_SUBMODULE_ALL
     }
 
     // Set the WiFi mode to STATION.

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
@@ -465,15 +465,7 @@ void Esp32WiFiManager::process_wifi_event(int event_id)
 void Esp32WiFiManager::enable_verbose_logging()
 {
     esp32VerboseLogging_ = true;
-    esp_log_level_set("wifi", ESP_LOG_VERBOSE);
-
-// arduino-esp32 1.0.2 uses ESP-IDF 3.2 which does not have these two methods
-// in the headers, they are only available in ESP-IDF 3.3.
-#if defined(WIFI_LOG_SUBMODULE_ALL)
-    esp_wifi_internal_set_log_level(WIFI_LOG_VERBOSE);
-    esp_wifi_internal_set_log_mod(
-        WIFI_LOG_MODULE_ALL, WIFI_LOG_SUBMODULE_ALL, true);
-#endif // WIFI_LOG_SUBMODULE_ALL
+    enable_esp_wifi_logging();
 }
 
 // If the Esp32WiFiManager is setup to manage the WiFi system, the following
@@ -520,14 +512,7 @@ void Esp32WiFiManager::start_wifi_system()
 
     if (esp32VerboseLogging_)
     {
-        esp_log_level_set("wifi", ESP_LOG_VERBOSE);
-// arduino-esp32 1.0.2 uses ESP-IDF 3.2 which does not have these two methods
-// in the headers, they are only available in ESP-IDF 3.3.
-#if defined(WIFI_LOG_SUBMODULE_ALL)
-        esp_wifi_internal_set_log_level(WIFI_LOG_VERBOSE);
-        esp_wifi_internal_set_log_mod(
-            WIFI_LOG_MODULE_ALL, WIFI_LOG_SUBMODULE_ALL, true);
-#endif // WIFI_LOG_SUBMODULE_ALL
+        enable_esp_wifi_logging();
     }
 
     // Set the WiFi mode to STATION.
@@ -770,6 +755,19 @@ void Esp32WiFiManager::on_uplink_created(int fd, Notifiable *on_exit)
     // restart the stack to kick off alias allocation and send node init
     // packets.
     stack_->restart_stack();
+}
+
+void Esp32WiFiManager::enable_esp_wifi_logging()
+{
+    esp_log_level_set("wifi", ESP_LOG_VERBOSE);
+
+// arduino-esp32 1.0.2 uses ESP-IDF 3.2 which does not have these two methods
+// in the headers, they are only available in ESP-IDF 3.3.
+#if defined(WIFI_LOG_SUBMODULE_ALL)
+    esp_wifi_internal_set_log_level(WIFI_LOG_VERBOSE);
+    esp_wifi_internal_set_log_mod(
+        WIFI_LOG_MODULE_ALL, WIFI_LOG_SUBMODULE_ALL, true);
+#endif // WIFI_LOG_SUBMODULE_ALL
 }
 
 } // namespace openmrn_arduino

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
@@ -181,6 +181,10 @@ private:
     /// @param on_exit is the Notifiable for when this socket has closed.
     void on_uplink_created(int fd, Notifiable *on_exit);
 
+    /// Enables the esp_wifi logging, including the esp_wifi_internal APIs when
+    /// available.
+    void enable_esp_wifi_logging();
+
     /// Handle for the wifi_manager_task that manages the WiFi stack, including
     /// periodic health checks of the connected hubs or clients.
     os_thread_t wifiTaskHandle_;


### PR DESCRIPTION
With v1.0.2-rc2 picking up ESP-IDF v3.2 there are a few adjustments
required for the esp_wifi module, specifically the log enabling APIs are
unavailable in ESP-IDF v3.2 as they were added in ESP-IDF v3.3.
arduino-esp32 1.0.1 and 1.0.2-rc1 were using beta versions of ESP-IDF
v3.3. Since v1.0.2 is soon to be released it is necessary to add a
compatibility check for this functionality that is not available.