### PR TITLE
Esp select cleanup

### DIFF
--- a/src/os/OSSelectWakeup.cxx
+++ b/src/os/OSSelectWakeup.cxx
@@ -12,8 +12,6 @@ void empty_signal_handler(int)
 
 #include "../vfs/esp_vfs.h"
 
-/// ID of the registered ESP32 VFS structure.
-static esp_vfs_id_t vfs_id;
 /// Protects the initialization of vfs_id.
 static pthread_once_t vfs_init_once = PTHREAD_ONCE_INIT;
 /// This per-thread key will store the OSSelectWakeup object that has been
@@ -89,7 +87,7 @@ void OSSelectWakeup::esp_wakeup()
 #if 0
     esp_vfs_select_triggered((SemaphoreHandle_t *)espSem_);
 #else
-    LOG(VERBOSE, "wakeup es %p %p lws %p", espSem_, *(unsigned*)espSem_, lwipSem_);
+    LOG(VERBOSE, "wakeup es %p %u lws %p", espSem_, *(unsigned*)espSem_, lwipSem_);
     if (espSem_)
     {
         esp_vfs_select_triggered((SemaphoreHandle_t *)espSem_);

--- a/src/utils/socket_listener.cxx
+++ b/src/utils/socket_listener.cxx
@@ -65,7 +65,7 @@ static void* accept_thread_start(void* arg) {
 
 #ifdef ESP32
 /// Stack size to use for the accept_thread_.
-static constexpr size_t listener_stack_size = 1536;
+static constexpr size_t listener_stack_size = 2048;
 #else
 /// Stack size to use for the accept_thread_.
 static constexpr size_t listener_stack_size = 1000;


### PR DESCRIPTION
Removing an unused var and fixing a log statement for the select code for the esp32 as well as bumping default stack size to 2kb for socket_listener (there is a 512b "pad" required by esp32 housekeeping)