### PR TITLE
Add TCP version of SimpleStack

### DIFF
--- a/applications/tcp_blink_client/targets/linux.host/main.cxx
+++ b/applications/tcp_blink_client/targets/linux.host/main.cxx
@@ -116,10 +116,6 @@ int appl_main(int argc, char *argv[])
         SocketClientParams::from_static(upstream_host, upstream_port),
         &connect_callback);
 
-    while (1)
-    {
-        sleep(1);
-    }
-
+    stack.loop_executor();
     return 0;
 }

--- a/applications/tcp_blink_client/targets/linux.host/main.cxx
+++ b/applications/tcp_blink_client/targets/linux.host/main.cxx
@@ -37,30 +37,23 @@
 #include "executor/Executor.hxx"
 #include "nmranet_config.h"
 #include "openlcb/BlinkerFlow.hxx"
-#include "openlcb/DefaultNode.hxx"
-#include "openlcb/EventService.hxx"
-#include "openlcb/IfTcp.hxx"
-#include "openlcb/NodeInitializeFlow.hxx"
-#include "openlcb/ProtocolIdentification.hxx"
+#include "openlcb/SimpleStack.hxx"
 #include "utils/HubDeviceSelect.hxx"
 #include "utils/SocketClient.hxx"
 #include "utils/SocketClientParams.hxx"
+#include "openlcb/SimpleNodeInfoMockUserFile.hxx"
+
+openlcb::MockSNIPUserFile snip_user_file("Default user name",
+                                         "Default user description");
+const char *const openlcb::SNIP_DYNAMIC_FILENAME = openlcb::MockSNIPUserFile::snip_user_file_path;
 
 const openlcb::NodeID NODE_ID = 0x050101011876;
 const openlcb::EventId EVENT_ID = 0x0501010118760000;
 
-Executor<5> g_executor("executor", 0, 2048);
 Executor<1> g_connect_executor("connect_executor", 0, 2048);
-Service g_service(&g_executor);
-HubFlow g_device(&g_service);
-openlcb::IfTcp g_if(NODE_ID, &g_device, config_local_nodes_count());
-openlcb::InitializeFlow g_init_flow(&g_if);
-openlcb::DefaultNode g_node(&g_if, NODE_ID);
-openlcb::EventService g_event_service(&g_if);
-constexpr uint64_t PIP_SUPPORT = openlcb::Defs::EVENT_EXCHANGE;
-openlcb::ProtocolIdentificationHandler g_pip_handler(&g_node, PIP_SUPPORT);
+openlcb::SimpleTcpStack stack(NODE_ID);
 
-BlinkerFlow blinker(&g_node, EVENT_ID);
+BlinkerFlow blinker(stack.node(), EVENT_ID);
 
 int upstream_port = 12000;
 const char *upstream_host = "localhost";
@@ -106,9 +99,8 @@ void connect_callback(int fd, Notifiable *on_error)
 {
     LOG(INFO, "Connected to hub.");
     // we leak this.
-    new HubDeviceSelect<HubFlow>(&g_device, fd, on_error);
-    // will delete itself
-    new openlcb::ReinitAllNodes(&g_if);
+    new HubDeviceSelect<HubFlow>(stack.tcp_hub(), fd, on_error);
+    stack.restart_stack();
 }
 
 /** Entry point to application.
@@ -119,7 +111,7 @@ void connect_callback(int fd, Notifiable *on_error)
 int appl_main(int argc, char *argv[])
 {
     parse_args(argc, argv);
-    SocketClient socket_client(&g_service, &g_connect_executor,
+    SocketClient socket_client(stack.service(), &g_connect_executor,
         &g_connect_executor,
         SocketClientParams::from_static(upstream_host, upstream_port),
         &connect_callback);

--- a/src/openlcb/SimpleStack.cxx
+++ b/src/openlcb/SimpleStack.cxx
@@ -78,6 +78,17 @@ std::unique_ptr<SimpleStackBase::PhysicalIf> SimpleCanStackBase::create_if(
     return std::unique_ptr<PhysicalIf>(new CanPhysicalIf(node_id, service()));
 }
 
+SimpleTcpStackBase::SimpleTcpStackBase(const openlcb::NodeID node_id)
+    : SimpleStackBase(std::bind(&SimpleTcpStackBase::create_if, this, node_id))
+{
+}
+
+std::unique_ptr<SimpleStackBase::PhysicalIf> SimpleTcpStackBase::create_if(
+    const openlcb::NodeID node_id)
+{
+    return std::unique_ptr<PhysicalIf>(new TcpPhysicalIf(node_id, service()));
+}
+
 SimpleCanStack::SimpleCanStack(const openlcb::NodeID node_id)
     : SimpleCanStackBase(node_id)
     , node_(iface(), node_id)
@@ -171,6 +182,10 @@ void SimpleTrainCanStack::start_node()
 void SimpleStackBase::start_after_delay()
 {
     start_iface(false);
+}
+
+void SimpleTcpStackBase::start_iface(bool restart)
+{
 }
 
 void SimpleCanStackBase::start_iface(bool restart)

--- a/src/openlcb/SimpleStack.cxx
+++ b/src/openlcb/SimpleStack.cxx
@@ -95,6 +95,12 @@ SimpleCanStack::SimpleCanStack(const openlcb::NodeID node_id)
 {
 }
 
+SimpleTcpStack::SimpleTcpStack(const openlcb::NodeID node_id)
+    : SimpleTcpStackBase(node_id)
+    , node_(iface(), node_id)
+{
+}
+
 void SimpleStackBase::start_stack(bool delay_start)
 {
 #if (!defined(ARDUINO)) || defined(ESP32)

--- a/src/openlcb/SimpleStack.cxxtest
+++ b/src/openlcb/SimpleStack.cxxtest
@@ -42,4 +42,20 @@ TEST_F(SimpleCanStackTest, create)
 {
 }
 
+class SimpleTcpStackTest : public AsyncCanTest
+{
+protected:
+    ~SimpleTcpStackTest()
+    {
+        twait();
+    }
+
+    SimpleTcpStack stack_ {TEST_NODE_ID};
+};
+
+TEST_F(SimpleTcpStackTest, create)
+{
+}
+
+
 } // namespace openlcb

--- a/src/openlcb/SimpleStack.hxx
+++ b/src/openlcb/SimpleStack.hxx
@@ -446,8 +446,13 @@ private:
         {
             return &datagramService_;
         }
+        /// This flow is the connection between the stack and the device
+        /// drivers. It also acts as a hub to multiple different clients or CAN
+        /// ports.
         CanHubFlow canHub0_;
+        /// Implementation of OpenLCB interface.
         IfCan ifCan_;
+        /// Datagram service (and clients) matching the interface.
         CanDatagramService datagramService_;
     };
 
@@ -466,7 +471,7 @@ public:
     /// link.
     HubFlow *tcp_hub()
     {
-        return &static_cast<TcpPhysicalIf *>(ifaceHolder_.get())->tcpHub0_;
+        return &static_cast<TcpPhysicalIf *>(ifaceHolder_.get())->tcpHub_;
     }
 
 protected:
@@ -478,8 +483,8 @@ private:
     {
     public:
         TcpPhysicalIf(const openlcb::NodeID node_id, Service *service)
-            : tcpHub0_(service)
-            , ifTcp_(node_id, &tcpHub0_, config_local_nodes_count())
+            : tcpHub_(service)
+            , ifTcp_(node_id, &tcpHub_, config_local_nodes_count())
             , datagramService_(&ifTcp_, config_num_datagram_registry_entries(),
                   config_num_datagram_clients())
         {
@@ -500,8 +505,12 @@ private:
         {
             return &datagramService_;
         }
-        HubFlow tcpHub0_;
+        /// This flow is the connection between the stack and the device
+        /// drivers.
+        HubFlow tcpHub_;
+        /// Implementation of OpenLCB interface.
         IfTcp ifTcp_;
+        /// Datagram service (and clients) matching the interface.
         TcpDatagramService datagramService_;
     };
 

--- a/src/openlcb/SimpleStack.hxx
+++ b/src/openlcb/SimpleStack.hxx
@@ -547,6 +547,36 @@ private:
     SNIPHandler snipHandler_ {iface(), &node_, &infoFlow_};
 };
 
+class SimpleTcpStack : public SimpleTcpStackBase
+{
+public:
+    SimpleTcpStack(const openlcb::NodeID node_id);
+
+    /// @returns the virtual node pointer of the main virtual node of the stack
+    /// (as defined by the NodeID argument of the constructor).
+    Node *node() override
+    {
+        return &node_;
+    }
+
+private:
+    static const auto PIP_RESPONSE = Defs::EVENT_EXCHANGE | Defs::DATAGRAM |
+        Defs::MEMORY_CONFIGURATION | Defs::ABBREVIATED_DEFAULT_CDI |
+        Defs::SIMPLE_NODE_INFORMATION | Defs::CDI;
+
+    void start_node() override
+    {
+        default_start_node();
+    }
+
+    /// The actual node.
+    DefaultNode node_;
+    /// Handles PIP requests.
+    ProtocolIdentificationHandler pipHandler_ {&node_, PIP_RESPONSE};
+    /// Handles SNIP requests.
+    SNIPHandler snipHandler_ {iface(), &node_, &infoFlow_};
+};
+
 /// CAN-based stack with TrainNode.
 class SimpleTrainCanStack : public SimpleCanStackBase
 {

--- a/src/openlcb/SimpleStack.hxx
+++ b/src/openlcb/SimpleStack.hxx
@@ -457,11 +457,17 @@ private:
     std::unique_ptr<PhysicalIf> create_if(const openlcb::NodeID node_id);
 };
 
-
 class SimpleTcpStackBase : public SimpleStackBase
 {
 public:
     SimpleTcpStackBase(const openlcb::NodeID node_id);
+
+    /// @return the device representing the connection to the TCP hardware
+    /// link.
+    HubFlow *tcp_hub()
+    {
+        return &static_cast<TcpPhysicalIf *>(ifaceHolder_.get())->tcpHub0_;
+    }
 
 protected:
     /// Helper function for start_stack et al.


### PR DESCRIPTION
This adds the TCP implementations into the SimpleStack class hierarchy:
- SimpleTcpStackBase that instantiates the TCP protocol interface
- SimpleTcpStack which has the DefaultNode.
In addition:
- Adds a create/destroy unit test for SimpleTcpStack
- Updates tcp_blink_client app to use SimpleTcpStack.