### PR TITLE
Adds a 'oneshot' feature to SocketClient

### DIFF
--- a/src/utils/SocketClient.cxxtest
+++ b/src/utils/SocketClient.cxxtest
@@ -265,6 +265,11 @@ public:
         return lastPort_;
     }
 
+    bool one_shot() override
+    {
+        return oneShot_;
+    }
+    
     SocketClientTest *parent_;
     int searchMode_{AUTO_MANUAL};
     bool enableLast_{true};
@@ -273,6 +278,7 @@ public:
     string mdnsServiceName_;
     string lastHostName_;
     int lastPort_{-1};
+    bool oneShot_{false};
 
     OSMutex lock_;
 };
@@ -417,4 +423,30 @@ TEST_F(SocketClientTest, test_fourth_sequence)
         usleep(40000);
         wait();
     }
+}
+
+TEST_F(SocketClientTest, one_shot)
+{
+    ::testing::InSequence seq;
+    auto p = std::make_unique<TestSocketClientParams>(this);
+    p->lastHostName_ = "127.0.0.2";
+    p->lastPort_ = LISTEN_PORT + 1;
+    p->mdnsServiceName_ = "_nonexist823467284._tcp";
+    p->oneShot_ = true;
+    p->searchMode_ = SocketClientParams::AUTO_MANUAL;
+    EXPECT_CALL(*this,
+        status_callback(SocketClientParams::CONNECT_RE, "127.0.0.2:12248"));
+    EXPECT_CALL(*this, status_callback(SocketClientParams::MDNS_SEARCH,
+                           "_nonexist823467284._tcp"));
+    EXPECT_CALL(*this, status_callback(SocketClientParams::MDNS_NOT_FOUND, _));
+    EXPECT_CALL(
+        *this, status_callback(SocketClientParams::CONNECT_FAILED_ONESHOT, _))
+        .WillOnce(::testing::InvokeWithoutArgs(&n_, &SyncNotifiable::notify));
+
+    sc_.reset(new SocketClient(node_->iface()->dispatcher()->service(),
+        &g_connect_executor, &g_connect_executor, std::move(p),
+        std::bind(&SocketClientTest::connect_callback, this, _1, _2)));
+
+    n_.wait_for_notification();
+    usleep(40000);
 }

--- a/src/utils/SocketClient.hxx
+++ b/src/utils/SocketClient.hxx
@@ -135,6 +135,8 @@ public:
         CONNECT_STATIC,
         /// Attempt complete. Start again.
         WAIT_RETRY,
+        /// Failed and do not start again (for one-shot mode).
+        FAILED_EXIT,
     };
 
     /// Updates the parameter structure for this socket client.
@@ -322,7 +324,14 @@ private:
                 strategyConfig_[ofs++] = Attempt::CONNECT_MDNS;
                 break;
         }
-        strategyConfig_[ofs++] = Attempt::WAIT_RETRY;
+        if (params_->one_shot())
+        {
+            strategyConfig_[ofs++] = Attempt::FAILED_EXIT;
+        }
+        else
+        {
+            strategyConfig_[ofs++] = Attempt::WAIT_RETRY;
+        }
         HASSERT(ofs <= strategyConfig_.size());
     }
 
@@ -361,6 +370,8 @@ private:
                 DIE("Unexpected action");
             case Attempt::WAIT_RETRY:
                 return wait_retry();
+            case Attempt::FAILED_EXIT:
+                return failed_oneshot();
             case Attempt::RECONNECT:
                 return try_schedule_connect(SocketClientParams::CONNECT_RE,
                     params_->last_host_name(), params_->last_port());
@@ -552,6 +563,13 @@ private:
             SocketClientParams::CONNECT_MDNS, std::move(host), port);
     }
 
+    /// Last state in the connection sequence, when everything failed, but the
+    /// caller wanted one shot only.
+    Action failed_oneshot()
+    {
+        params_->log_message(SocketClientParams::CONNECT_FAILED_ONESHOT);
+        return exit();
+    }
     /// Last state in the connection sequence, when everything failed: sleeps
     /// until the timeout specified in the params, then goes back to the
     /// start_connection.

--- a/src/utils/SocketClientParams.hxx
+++ b/src/utils/SocketClientParams.hxx
@@ -110,6 +110,11 @@ public:
     /// @return the last successfully used port number.
     virtual int last_port() = 0;
 
+    /// @return false for repeated connection attempts, true if we should stop
+    /// after the first failed connection attempt. If a one-stop mode fails,
+    /// the caller has to delete and re-create the socket client.
+    virtual bool one_shot() { return false; }
+    
     /// This function is called on an unspecified thread when a connection is
     /// successfully established.
     /// @param hostname is filled with a dotted decimal representation of the
@@ -137,6 +142,8 @@ public:
         CONNECT_MANUAL = 6,
         /// Connection dropped because target is localhost.
         CONNECT_FAILED_SELF = 7,
+        /// Attempt to search & connect failed, given up. No arg.
+        CONNECT_FAILED_ONESHOT = 8,
         CONNECTION_LOST
     };
 


### PR DESCRIPTION
Adds a 'oneshot' feature to SocketClient, which allows
invoking SocketClient with no retries in connection.
If the first detection & connection attempt fails, the flow
exits.

This is a re-submit of #292 where the review is, just fixing merge mistakes.