### PR TITLE
Safe stringprintf

### DIFF
--- a/src/freertos_drivers/common/CpuLoad.hxx
+++ b/src/freertos_drivers/common/CpuLoad.hxx
@@ -229,11 +229,11 @@ private:
         auto k = l->new_key();
         if (k < 300)
         {
-            l->set_key_description(k, StringPrintf("irq-%u", k));
+            l->set_key_description(k, StringPrintf("irq-%u", (unsigned)k));
         }
         else if (k & 1)
         {
-            l->set_key_description(k, StringPrintf("ex 0x%x", k & ~1));
+            l->set_key_description(k, StringPrintf("ex 0x%x", (unsigned)(k & ~1)));
         }
         else
         {

--- a/src/freertos_drivers/common/CpuLoad.hxx
+++ b/src/freertos_drivers/common/CpuLoad.hxx
@@ -233,7 +233,8 @@ private:
         }
         else if (k & 1)
         {
-            l->set_key_description(k, StringPrintf("ex 0x%x", (unsigned)(k & ~1)));
+            l->set_key_description(
+                k, StringPrintf("ex 0x%x", (unsigned)(k & ~1)));
         }
         else
         {

--- a/src/openlcb/DatagramCan.cxxtest
+++ b/src/openlcb/DatagramCan.cxxtest
@@ -172,7 +172,7 @@ TEST_F(AsyncRawDatagramTest, MultiFrameDatagramThenStartMiddle)
 
 ::std::ostream &operator<<(::std::ostream &o, const NodeHandle &h)
 {
-    o << StringPrintf("Handle(%012llx, %03x)", h.id, h.alias);
+    o << StringPrintf("Handle(%012" PRIx64 ", %03x)", h.id, h.alias);
     return o;
 }
 

--- a/src/openlcb/EventHandlerContainer.cxxtest
+++ b/src/openlcb/EventHandlerContainer.cxxtest
@@ -76,9 +76,10 @@ protected:
         tmp_event = event;
         unsigned actual_mask =
             EventRegistry::align_mask(&tmp_event, size);
-        string dbg = StringPrintf(
-            "event 0x%llx size %u actual event 0x%llx actual mask %u", event,
-            size, tmp_event, actual_mask);
+        string dbg =
+            StringPrintf("event 0x%" PRIx64 " size %u actual event 0x%" PRIx64
+                         " actual mask %u",
+                event, size, tmp_event, actual_mask);
         EXPECT_LE(tmp_event, event) << dbg;
         if (actual_mask < 64)
         {

--- a/src/utils/StringPrintf.hxx
+++ b/src/utils/StringPrintf.hxx
@@ -45,6 +45,6 @@
  * @param format is a c printf format string. 
  * @param ... are additional arguments to the format string
  * @return a string with the formatted data. */
-std::string StringPrintf(const char *format, ...);
+std::string StringPrintf(const char *format, ...) __attribute__ ((format (printf, 1, 2)));
 
 #endif // _UTILS_STIRNGPRINTF_HXX_

--- a/src/utils/StringPrintf.hxx
+++ b/src/utils/StringPrintf.hxx
@@ -45,6 +45,7 @@
  * @param format is a c printf format string. 
  * @param ... are additional arguments to the format string
  * @return a string with the formatted data. */
-std::string StringPrintf(const char *format, ...) __attribute__ ((format (printf, 1, 2)));
+std::string StringPrintf(const char *format, ...)
+    __attribute__((format(printf, 1, 2)));
 
 #endif // _UTILS_STIRNGPRINTF_HXX_


### PR DESCRIPTION
Adds the attribute to the stringprintf function declaration that makes gcc check the format arguments.
Fixes found violations.