### PR TITLE
Esp32WiFiManager Updates (SoftAP support)

### DIFF
--- a/arduino/OpenMRNLite.cpp
+++ b/arduino/OpenMRNLite.cpp
@@ -44,16 +44,20 @@ OpenMRN::OpenMRN(openlcb::NodeID node_id)
 #ifdef ESP32
 extern "C" {
 
+#ifndef OPENMRN_EXCLUDE_REBOOT_IMPL
 /// Reboots the ESP32 via the arduino-esp32 provided restart function.
 void reboot()
 {
     ESP.restart();
 }
+#endif // OPENMRN_EXCLUDE_REBOOT_IMPL
 
+#ifndef OPENMRN_EXCLUDE_FREE_HEAP_IMPL
 ssize_t os_get_free_heap()
 {
     return ESP.getFreeHeap();
 }
+#endif // OPENMRN_EXCLUDE_FREE_HEAP_IMPL
 
 }
 #endif // ESP32

--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -343,7 +343,8 @@ public:
     {
         for (auto *e : loopMembers_)
         {
-#if defined(ESP32)
+#if defined(ESP32) && CONFIG_TASK_WDT
+
             // Feed the watchdog so it doesn't reset the ESP32
             esp_task_wdt_reset();
 #endif // ESP32
@@ -364,9 +365,11 @@ public:
 #ifdef ESP32
         xTaskCreatePinnedToCore(&thread_entry, "OpenMRN", OPENMRN_STACK_SIZE,
             this, OPENMRN_TASK_PRIORITY, nullptr, 0);
+#if CONFIG_TASK_WDT
         // Remove IDLE0 task watchdog, because the openmrn task sometimes uses
         // 100% cpu and it is pinned to CPU 0.
         disableCore0WDT();
+#endif // CONFIG_TASK_WDT
 #else
         stack_->executor()->start_thread(
             "OpenMRN", OPENMRN_TASK_PRIORITY, OPENMRN_STACK_SIZE);

--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -365,11 +365,11 @@ public:
 #ifdef ESP32
         xTaskCreatePinnedToCore(&thread_entry, "OpenMRN", OPENMRN_STACK_SIZE,
             this, OPENMRN_TASK_PRIORITY, nullptr, 0);
-#if CONFIG_TASK_WDT
+#if CONFIG_TASK_WDT_CHECK_IDLE_TASK_CPU0
         // Remove IDLE0 task watchdog, because the openmrn task sometimes uses
         // 100% cpu and it is pinned to CPU 0.
         disableCore0WDT();
-#endif // CONFIG_TASK_WDT
+#endif // CONFIG_TASK_WDT_CHECK_IDLE_TASK_CPU0
 #else
         stack_->executor()->start_thread(
             "OpenMRN", OPENMRN_TASK_PRIORITY, OPENMRN_STACK_SIZE);

--- a/arduino/README.md
+++ b/arduino/README.md
@@ -34,41 +34,27 @@ For the hardware CAN support they will require two additional GPIO pins. WiFi
 does not require any additional GPIO pins.
 
 ## ESP32 WiFi support
-The ESP32 WiFi stack has issues at times but is generally stable. If you
-observe failures in connecting to WiFi add the following compiler option
-to turn on additional diagnostic output from the
-[WiFi](https://github.com/espressif/arduino-esp32/tree/master/libraries/WiFi)
-library:
-    `-DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG`
-This will give additional output on the Serial console which can help
-to resolve the connection issue. The following is an example of the output
-which may be observed:
-```
-    [D][WiFiGeneric.cpp:342] _eventCallback(): Event: 5 - STA_DISCONNECTED
-    [W][WiFiGeneric.cpp:357] _eventCallback(): Reason: 2 - AUTH_EXPIRE
-    [D][WiFiGeneric.cpp:342] _eventCallback(): Event: 0 - WIFI_READY
-    [D][WiFiGeneric.cpp:342] _eventCallback(): Event: 2 - STA_START
-    [D][WiFiGeneric.cpp:342] _eventCallback(): Event: 2 - STA_START
-    [D][WiFiGeneric.cpp:342] _eventCallback(): Event: 5 - STA_DISCONNECTED
-```
+The Esp32WiFiManager should be used to manage the ESP32's WiFi connection to
+the SSID, create a Soft AP (max of 4 clients connected to it) or to create both
+a Soft AP and connect to an SSID. See the ESP32IOBoard example for how to use
+the Esp32WiFiManager for how to connect to an SSID and have it automatically
+establish an uplink to a GridConnect based TCP/IP Hub. Additional configuration
+parameters can be configured via the CDI interface.
 
-If you observe this output, this generally means there was a timeout condition
-where the ESP32 did not receive a response from the access point. It generally
-means that the ESP32 is too far from the AP for the AP to hear what the ESP32
-is transmitting. Additional options to try if this does not resolve the
-connection issues:
-1. If the ESP32 board supports an external WiFi antenna use one, this will
-provide a higher signal strength which should allow a more successful
-connection.
-2. Clear the persistent WiFi connection details from NVS:
-```C
-        #include <nvs_flash.h>
-        nvs_flash_init();
-```
+## Using an SD card for configuration data
+When using an SD card for storage of the OpenMRN configuration data it is
+recommended to use an AutoSyncFileFlow to ensure the OpenMRN configuration
+data is persisted to the SD card. The default configuration of the SD virtual
+file system driver is to use a 512 byte per-file cache and only persist
+on-demand or when reading/writing outside this cached space. The
+AutoSyncFileFlow will ensure the configuration file is synchronized to the SD
+card on a regular basis. The SD VFS driver will check that the file has pending
+changes before synchronizing them to the SD card and when no changes are
+necessary no action is taken by the synchronization call.
 
-This should not be done very often (i.e. do not do it at every startup!), but
-is otherwise harmless. The same can also be achieved by using a flash erase
-tool `esptool.py erase_flash ...` and reflashing the ESP32.
+Note that the Arduino-esp32 SPIFFS library and the underlying SPIFFS VFS driver
+does use a cache but the AutoSyncFileFlow is not necessary due to the nature of
+the SPIFFS file system (monolithic blob containing all files concatenated).
 
 ## ESP32 Hardware CAN support
 The ESP32 has a built in CAN controller and needs an external CAN transceiver

--- a/arduino/libify.sh
+++ b/arduino/libify.sh
@@ -176,6 +176,7 @@ copy_file src/utils src/utils/*.{cxx,hxx,c,h}
 
 rm -f ${TARGET_LIB_DIR}/src/utils/ReflashBootloader.cxx \
     ${TARGET_LIB_DIR}/src/utils/AesCcmTestVectors.hxx \
+    ${TARGET_LIB_DIR}/src/utils/AesCcmTestVectorsEx.hxx \
     ${TARGET_LIB_DIR}/src/utils/async_datagram_test_helper.hxx \
     ${TARGET_LIB_DIR}/src/utils/async_if_test_helper.hxx \
     ${TARGET_LIB_DIR}/src/utils/async_traction_test_helper.hxx \

--- a/include/openmrn_features.h
+++ b/include/openmrn_features.h
@@ -73,6 +73,9 @@
 #if defined(__FreeRTOS__) || defined(ESP32)
 /// Use os_mutex_... implementation based on FreeRTOS mutex and semaphores.
 #define OPENMRN_FEATURE_MUTEX_FREERTOS 1
+
+/// Enables use of Notifiable::notify_from_isr and OSSem::post_from_isr.
+#define OPENMRN_FEATURE_RTOS_FROM_ISR 1
 #elif OPENMRN_FEATURE_SINGLE_THREADED
 /// Add a fake implementation for os_mutex_lock that crashes if there is a
 /// conflict.

--- a/include/openmrn_features.h
+++ b/include/openmrn_features.h
@@ -61,7 +61,7 @@
 #endif
 
 #if defined(OPENMRN_HAVE_SELECT) || defined(OPENMRN_HAVE_PSELECT) || defined(OPENMRN_FEATURE_DEVICE_SELECT)
-#define OPENMRN_FEATURE_EXECUTOR_SELECT
+#define OPENMRN_FEATURE_EXECUTOR_SELECT 1
 #endif
 
 #if (defined(ARDUINO) && !defined(ESP32)) || defined(ESP_NONOS) ||             \

--- a/src/console/Console.cxx
+++ b/src/console/Console.cxx
@@ -82,7 +82,7 @@ Console::Console(ExecutorBase *executor, int fd_in, int fd_out, int port)
  */
 void Console::open_session(int fd_in, int fd_out)
 {
-#ifdef HAVE_BSDSOCKET
+#if OPENMRN_FEATURE_BSD_SOCKET
     fcntl(fd_in, F_SETFL, fcntl(fd_in, F_GETFL, 0) | O_NONBLOCK);
 #endif
     new Session(this, fd_in, fd_out);
@@ -283,7 +283,7 @@ StateFlowBase::Action Console::Session::process_read()
     {
         struct stat stat;
         fstat(fdIn, &stat);
-#ifdef HAVE_BSDSOCKET
+#if OPENMRN_FEATURE_BSD_SOCKET
         if (S_ISSOCK(stat.st_mode))
         {
             /* Socket connection closed */
@@ -439,7 +439,7 @@ bool Console::Session::callback_result_process(CommandStatus status,
         {
             struct stat stat;
             fstat(fdIn, &stat);
-#ifdef HAVE_BSDSOCKET
+#if OPENMRN_FEATURE_BSD_SOCKET
             if (S_ISSOCK(stat.st_mode))
             {
                 fprintf(fp, "shutting down session\n");

--- a/src/console/Console.hxx
+++ b/src/console/Console.hxx
@@ -34,11 +34,12 @@
 #ifndef _CONSOLE_CONSOLE_HXX_
 #define _CONSOLE_CONSOLE_HXX_
 
+#include "openmrn_features.h"
 #include "utils/macros.h"
 #include "executor/Service.hxx"
 #include "executor/StateFlow.hxx"
 
-#ifdef HAVE_BSDSOCKET
+#if OPENMRN_FEATURE_BSD_SOCKET
 #define CONSOLE_NETWORKING
 #endif
 

--- a/src/executor/Notifiable.hxx
+++ b/src/executor/Notifiable.hxx
@@ -46,7 +46,7 @@ class Notifiable : public Destructable
 public:
     /// Generic callback.
     virtual void notify() = 0;
-#ifdef __FreeRTOS__
+#if OPENMRN_FEATURE_MUTEX_FREERTOS
     virtual void notify_from_isr()
     {
         DIE("Unexpected call to notify_from_isr.");
@@ -71,7 +71,7 @@ public:
         sem_.post();
     }
 
-#ifdef __FreeRTOS__
+#if OPENMRN_FEATURE_MUTEX_FREERTOS
     /// Implementation of notification receive from a FreeRTOS interrupt
     /// context.
     void notify_from_isr() OVERRIDE

--- a/src/executor/Notifiable.hxx
+++ b/src/executor/Notifiable.hxx
@@ -46,12 +46,12 @@ class Notifiable : public Destructable
 public:
     /// Generic callback.
     virtual void notify() = 0;
-#if OPENMRN_FEATURE_MUTEX_FREERTOS
+#if OPENMRN_FEATURE_RTOS_FROM_ISR
     virtual void notify_from_isr()
     {
         DIE("Unexpected call to notify_from_isr.");
     }
-#endif
+#endif // OPENMRN_FEATURE_RTOS_FROM_ISR
 };
 
 /// A Notifiable for synchronously waiting for a notification.
@@ -71,7 +71,7 @@ public:
         sem_.post();
     }
 
-#if OPENMRN_FEATURE_MUTEX_FREERTOS
+#if OPENMRN_FEATURE_RTOS_FROM_ISR
     /// Implementation of notification receive from a FreeRTOS interrupt
     /// context.
     void notify_from_isr() OVERRIDE
@@ -79,7 +79,7 @@ public:
         int woken = 0;
         sem_.post_from_isr(&woken);
     }
-#endif
+#endif // OPENMRN_FEATURE_RTOS_FROM_ISR
 
     /// Blocks the current thread until the notification is delivered.
     void wait_for_notification()

--- a/src/executor/SemaphoreNotifiableBlock.hxx
+++ b/src/executor/SemaphoreNotifiableBlock.hxx
@@ -78,13 +78,13 @@ public:
         sem_.post();
     }
 
-#if OPENMRN_FEATURE_MUTEX_FREERTOS
+#if OPENMRN_FEATURE_RTOS_FROM_ISR
     void notify_from_isr() OVERRIDE
     {
         int woken = 0;
         sem_.post_from_isr(&woken);
     }
-#endif
+#endif // OPENMRN_FEATURE_RTOS_FROM_ISR
 
 private:
     /// How many barriers did we allocate in total?

--- a/src/executor/SemaphoreNotifiableBlock.hxx
+++ b/src/executor/SemaphoreNotifiableBlock.hxx
@@ -78,7 +78,7 @@ public:
         sem_.post();
     }
 
-#ifdef __FreeRTOS__
+#if OPENMRN_FEATURE_MUTEX_FREERTOS
     void notify_from_isr() OVERRIDE
     {
         int woken = 0;

--- a/src/executor/StateFlow.hxx
+++ b/src/executor/StateFlow.hxx
@@ -724,7 +724,7 @@ protected:
     }
 
 
-#ifdef HAVE_BSDSOCKET
+#if OPENMRN_FEATURE_BSD_SOCKET
     /** Wait for a listen socket to become active and ready to accept an
      * incoming connection.
      * @param helper selectable helper for maintaining the select metadata
@@ -763,7 +763,7 @@ protected:
         service()->executor()->select(helper);
         return wait_and_call(c);
     }
-#endif
+#endif // OPENMRN_FEATURE_BSD_SOCKET
 
     /// Writes some data into a file descriptor, repeating the operation as
     /// necessary until all bytes are written.

--- a/src/freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx
+++ b/src/freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx
@@ -240,7 +240,7 @@ private:
             }
 
             /// ESP32 native CAN driver frame
-            can_message_t msg = {0};
+            can_message_t msg = {};
 
             msg.flags = CAN_MSG_FLAG_NONE;
             msg.identifier = can_frame->can_id;
@@ -306,7 +306,7 @@ private:
 #endif // CONFIG_TASK_WDT
 
             /// ESP32 native CAN driver frame
-            can_message_t msg = {0};
+            can_message_t msg = {};
             if (can_receive(&msg, pdMS_TO_TICKS(250)) != ESP_OK)
             {
                 // native CAN driver did not give us a frame.

--- a/src/freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx
+++ b/src/freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx
@@ -169,16 +169,20 @@ private:
         /// txBuf.
         Esp32HardwareCan *parent = reinterpret_cast<Esp32HardwareCan *>(can);
 
+#if CONFIG_TASK_WDT
         // Add this task to the WDT
         esp_task_wdt_add(parent->txTaskHandle_);
+#endif // CONFIG_TASK_WDT
 
         /// Tracks the last time that we displayed the CAN driver status.
         TickType_t next_status_display_tick_count = 0;
 
         while (true)
         {
+#if CONFIG_TASK_WDT
             // Feed the watchdog so it doesn't reset the ESP32
             esp_task_wdt_reset();
+#endif // CONFIG_TASK_WDT
 
             // periodic CAN driver monitoring and reporting, this takes care of
             // bus recovery when the CAN driver disables the bus due to error
@@ -289,13 +293,17 @@ private:
         /// Get handle to our parent Esp32HardwareCan object to access the rxBuf
         Esp32HardwareCan *parent = reinterpret_cast<Esp32HardwareCan *>(can);
 
+#if CONFIG_TASK_WDT
         // Add this task to the WDT
         esp_task_wdt_add(parent->rxTaskHandle_);
+#endif // CONFIG_TASK_WDT
 
         while (true)
         {
+#if CONFIG_TASK_WDT
             // Feed the watchdog so it doesn't reset the ESP32
             esp_task_wdt_reset();
+#endif // CONFIG_TASK_WDT
 
             /// ESP32 native CAN driver frame
             can_message_t msg = {0};

--- a/src/freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx
+++ b/src/freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx
@@ -240,7 +240,8 @@ private:
             }
 
             /// ESP32 native CAN driver frame
-            can_message_t msg = {};
+            can_message_t msg;
+            bzero(&msg, sizeof(can_message_t));
 
             msg.flags = CAN_MSG_FLAG_NONE;
             msg.identifier = can_frame->can_id;
@@ -306,7 +307,8 @@ private:
 #endif // CONFIG_TASK_WDT
 
             /// ESP32 native CAN driver frame
-            can_message_t msg = {};
+            can_message_t msg;
+            bzero(&msg, sizeof(can_message_t));
             if (can_receive(&msg, pdMS_TO_TICKS(250)) != ESP_OK)
             {
                 // native CAN driver did not give us a frame.

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
@@ -39,6 +39,7 @@
 #include <esp_log.h>
 #include <esp_wifi.h>
 #include <esp_wifi_internal.h>
+#include <lwip/dns.h>
 #include <mdns.h>
 #include <rom/crc.h>
 #include <tcpip_adapter.h>
@@ -52,6 +53,18 @@ using openlcb::TcpDefs;
 using openlcb::TcpManualAddress;
 using std::string;
 using std::unique_ptr;
+
+#ifndef ESP32_WIFIMGR_SOCKETPARAMS_LOG_LEVEL
+/// Allows setting the log level for mDNS related log messages from 
+/// @ref DefaultSocketClientParams.
+#define ESP32_WIFIMGR_SOCKETPARAMS_LOG_LEVEL INFO
+#endif
+
+#ifndef ESP32_WIFIMGR_MDNS_LOOKUP_LOG_LEVEL
+/// Allows setting the log level for mDNS results in the @ref mdns_lookup
+/// method.
+#define ESP32_WIFIMGR_MDNS_LOOKUP_LOG_LEVEL INFO
+#endif
 
 // Start of global namespace block.
 
@@ -92,7 +105,7 @@ static constexpr int WIFI_CONNECTED_BIT = BIT0;
 
 /// Bit designator for wifi_status_event_group which indicates we have an IPv4
 /// address assigned.
-static constexpr int DHCP_GOTIP_BIT = BIT1;
+static constexpr int WIFI_GOTIP_BIT = BIT1;
 
 /// Allow up to 36 checks to see if we have connected to the SSID and
 /// received an IPv4 address. This allows up to ~3 minutes for the entire
@@ -109,7 +122,7 @@ static constexpr uint8_t MAX_CONNECTION_CHECK_ATTEMPTS = 36;
 static esp_err_t wifi_event_handler(void *context, system_event_t *event)
 {
     auto wifi = static_cast<Esp32WiFiManager *>(context);
-    wifi->process_wifi_event(event->event_id);
+    wifi->process_wifi_event(event);
     return ESP_OK;
 }
 
@@ -180,14 +193,17 @@ public:
                 LOG(INFO, "[Uplink] Reconnecting to %s.", arg.c_str());
                 break;
             case MDNS_SEARCH:
-                LOG(INFO, "[Uplink] Starting mDNS searching for %s.",
+                LOG(ESP32_WIFIMGR_SOCKETPARAMS_LOG_LEVEL,
+                    "[Uplink] Starting mDNS searching for %s.",
                     arg.c_str());
                 break;
             case MDNS_NOT_FOUND:
-                LOG(INFO, "[Uplink] mDNS search failed.");
+                LOG(ESP32_WIFIMGR_SOCKETPARAMS_LOG_LEVEL,
+                    "[Uplink] mDNS search failed.");
                 break;
             case MDNS_FOUND:
-                LOG(INFO, "[Uplink] mDNS search succeeded.");
+                LOG(ESP32_WIFIMGR_SOCKETPARAMS_LOG_LEVEL,
+                    "[Uplink] mDNS search succeeded.");
                 break;
             case CONNECT_MDNS:
                 LOG(INFO, "[Uplink] mDNS connecting to %s.", arg.c_str());
@@ -196,9 +212,8 @@ public:
                 LOG(INFO, "[Uplink] Connecting to %s.", arg.c_str());
                 break;
             case CONNECT_FAILED_SELF:
-                LOG(INFO,
-                    "[Uplink] Rejecting attempt to connect to "
-                    "localhost.");
+                LOG(ESP32_WIFIMGR_SOCKETPARAMS_LOG_LEVEL,
+                    "[Uplink] Rejecting attempt to connect to localhost.");
                 break;
             case CONNECTION_LOST:
                 LOG(INFO, "[Uplink] Connection lost.");
@@ -224,13 +239,25 @@ private:
 // With this constructor being used the Esp32WiFiManager will manage the
 // WiFi connection, mDNS system and the hostname of the ESP32.
 Esp32WiFiManager::Esp32WiFiManager(const char *ssid, const char *password,
-    SimpleCanStack *stack, const WiFiConfiguration &cfg)
+    SimpleCanStack *stack, const WiFiConfiguration &cfg,
+    const char *hostname_prefix, wifi_mode_t wifi_mode,
+    tcpip_adapter_ip_info_t *station_static_ip, ip_addr_t primary_dns_server,
+    uint8_t soft_ap_channel, uint8_t soft_ap_max_stations,
+    wifi_auth_mode_t soft_ap_auth, tcpip_adapter_ip_info_t *softap_static_ip)
     : DefaultConfigUpdateListener()
+    , hostname_(hostname_prefix)
     , ssid_(ssid)
     , password_(password)
     , cfg_(cfg)
     , manageWiFi_(true)
     , stack_(stack)
+    , wifiMode_(wifi_mode)
+    , stationStaticIP_(station_static_ip)
+    , primaryDNSAddress_(primary_dns_server)
+    , softAPChannel_(soft_ap_channel)
+    , softAPMaxStations_(soft_ap_max_stations)
+    , softAPAuthMode_(soft_ap_auth)
+    , softAPStaticIP_(softap_static_ip)
 {
     // Extend the capacity of the hostname to make space for the node-id and
     // underscore.
@@ -255,6 +282,14 @@ Esp32WiFiManager::Esp32WiFiManager(const char *ssid, const char *password,
 
     // Release any extra capacity allocated for the hostname.
     hostname_.shrink_to_fit();
+
+    if (softAPMaxStations_ > 4)
+    {
+        LOG(WARNING,
+            "[SoftAP] Max stations %d is too high, reducing to 4.",
+            softAPMaxStations_);
+        softAPMaxStations_ = 4;
+    }
 }
 
 // With this constructor being used, it will be the responsibility of the
@@ -289,7 +324,7 @@ ConfigUpdateListener::UpdateAction Esp32WiFiManager::apply_configuration(
     // give up and request a reboot.
     if (lseek(fd, cfg_.offset(), SEEK_SET) != cfg_.offset())
     {
-        LOG(WARNING, "lseek failed to reset fd offset, REBOOT_NEEDED");
+        LOG_ERROR("lseek failed to reset fd offset, REBOOT_NEEDED");
         return ConfigUpdateListener::UpdateAction::REBOOT_NEEDED;
     }
 
@@ -297,7 +332,7 @@ ConfigUpdateListener::UpdateAction Esp32WiFiManager::apply_configuration(
     // give up and request a reboot.
     if (read(fd, crcbuf.get(), cfg_.size()) != cfg_.size())
     {
-        LOG(WARNING, "read failed to fully read the config, REBOOT_NEEDED");
+        LOG_ERROR("read failed to fully read the config, REBOOT_NEEDED");
         return ConfigUpdateListener::UpdateAction::REBOOT_NEEDED;
     }
 
@@ -372,93 +407,238 @@ void Esp32WiFiManager::factory_reset(int fd)
 }
 
 // Processes a WiFi system event
-void Esp32WiFiManager::process_wifi_event(int event_id)
+void Esp32WiFiManager::process_wifi_event(system_event_t *event)
 {
-    LOG(VERBOSE, "Esp32WiFiManager::process_wifi_event(%d)", event_id);
+    LOG(VERBOSE, "Esp32WiFiManager::process_wifi_event(%d)", event->event_id);
 
-    switch (event_id)
+    // We only are interested in this event if we are managing the
+    // WiFi and MDNS systems
+    if (event->event_id == SYSTEM_EVENT_STA_START && manageWiFi_)
     {
-        case SYSTEM_EVENT_STA_START:
-            // We only are interested in this event if we are managing the
-            // WiFi and MDNS systems
-            if (manageWiFi_)
-            {
-                // Set the generated hostname prior to connecting to the SSID
-                // so that it shows up with the generated hostname instead of
-                // the default "Espressif".
-                LOG(INFO, "[WiFi] Setting ESP32 hostname to \"%s\".",
-                    hostname_.c_str());
-                ESP_ERROR_CHECK(tcpip_adapter_set_hostname(
-                    TCPIP_ADAPTER_IF_STA, hostname_.c_str()));
+        // Set the generated hostname prior to connecting to the SSID
+        // so that it shows up with the generated hostname instead of
+        // the default "Espressif".
+        LOG(INFO, "[WiFi] Setting ESP32 hostname to \"%s\".",
+            hostname_.c_str());
+        ESP_ERROR_CHECK(tcpip_adapter_set_hostname(
+            TCPIP_ADAPTER_IF_STA, hostname_.c_str()));
+        uint8_t mac[6];
+        esp_wifi_get_mac(WIFI_IF_STA, mac);
+        LOG(INFO, "[WiFi] MAC Address: %s", mac_to_string(mac).c_str());
 
-                // Start the DHCP service before connecting to it hooks into
-                // the flow early and provisions the IP automatically.
-                LOG(INFO, "[WiFi] Starting DHCP services.");
-                ESP_ERROR_CHECK(
-                    tcpip_adapter_dhcpc_start(TCPIP_ADAPTER_IF_STA));
+        // Initialize the mDNS system.
+        LOG(INFO, "[mDNS] Initializing mDNS system");
+        ESP_ERROR_CHECK(mdns_init());
 
-                LOG(INFO,
-                    "[WiFi] Station started, attempting to connect "
-                    "to SSID: %s.",
-                    ssid_);
-                // Start the SSID connection process.
-                esp_wifi_connect();
-            }
-            break;
-        case SYSTEM_EVENT_STA_CONNECTED:
-            LOG(INFO, "[WiFi] Connected to SSID: %s", ssid_);
-            // Set the flag that indictes we are connected to the SSID.
-            xEventGroupSetBits(wifiStatusEventGroup_, WIFI_CONNECTED_BIT);
-            break;
-        case SYSTEM_EVENT_STA_GOT_IP:
-            // Retrieve the configured IP address from the TCP/IP stack.
-            tcpip_adapter_ip_info_t ip_info;
-            tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_STA, &ip_info);
+        // Set the mDNS hostname based on our generated hostname so it can be found
+        // by other nodes.
+        LOG(INFO, "[mDNS] Setting mDNS hostname to \"%s\"", hostname_.c_str());
+        ESP_ERROR_CHECK(mdns_hostname_set(hostname_.c_str()));
+
+        // Set the default mDNS instance name to the generated hostname.
+        ESP_ERROR_CHECK(mdns_instance_name_set(hostname_.c_str()));
+
+        if (stationStaticIP_)
+        {
+            // Stop the DHCP service before connecting, this allows us to
+            // specify a static IP address for the WiFi connection
+            LOG(INFO, "[DHCP] Stoping DHCP Client (if running).");
+            ESP_ERROR_CHECK(
+                tcpip_adapter_dhcpc_stop(TCPIP_ADAPTER_IF_STA));
+
             LOG(INFO,
-                "[WiFi] IP address is " IPSTR ", starting hub (if "
-                "enabled) and uplink.",
-                IP2STR(&ip_info.ip));
+                "[WiFi] Configuring Static IP address:\n"
+                "IP     : " IPSTR "\n"
+                "Gateway: " IPSTR "\n"
+                "Netmask: " IPSTR,
+                IP2STR(&stationStaticIP_->ip),
+                IP2STR(&stationStaticIP_->gw),
+                IP2STR(&stationStaticIP_->netmask));
+            ESP_ERROR_CHECK(
+                tcpip_adapter_set_ip_info(TCPIP_ADAPTER_IF_STA,
+                                          stationStaticIP_));
 
-            // Set the flag that indictes we have an IPv4 address.
-            xEventGroupSetBits(wifiStatusEventGroup_, DHCP_GOTIP_BIT);
-
-            // Wake up the wifi_manager_task so it can start connections
-            // creating connections, this will be a no-op for initial startup.
-            xTaskNotifyGive(wifiTaskHandle_);
-            break;
-        case SYSTEM_EVENT_STA_LOST_IP:
-            // clear the flag that indicates we are connected and have an
-            // IPv4 address.
-            xEventGroupClearBits(wifiStatusEventGroup_, DHCP_GOTIP_BIT);
-            // Wake up the wifi_manager_task so it can clean up connections.
-            xTaskNotifyGive(wifiTaskHandle_);
-            break;
-        case SYSTEM_EVENT_STA_DISCONNECTED:
-            // check if we have already connected, this event can be raised
-            // even before we have successfully connected during the SSID
-            // connect process.
-            if (xEventGroupGetBits(wifiStatusEventGroup_) & WIFI_CONNECTED_BIT)
+            // if we do not have a primary DNS address configure the default
+            if (ip_addr_isany(&primaryDNSAddress_))
             {
-                LOG(INFO, "[WiFi] Lost connection to SSID: %s", ssid_);
-                // clear the flag that indicates we are connected to the SSID.
-                xEventGroupClearBits(wifiStatusEventGroup_, WIFI_CONNECTED_BIT);
-                // clear the flag that indicates we have an IPv4 address.
-                xEventGroupClearBits(wifiStatusEventGroup_, DHCP_GOTIP_BIT);
-
-                // Wake up the wifi_manager_task so it can clean up
-                // connections.
-                xTaskNotifyGive(wifiTaskHandle_);
+                IP4_ADDR(&primaryDNSAddress_.u_addr.ip4, 8, 8, 8, 8);
             }
+            LOG(INFO, "[WiFi] Configuring primary DNS address to: " IPSTR,
+                IP2STR(&primaryDNSAddress_.u_addr.ip4));
+            // set the primary server (0)
+            dns_setserver(0, &primaryDNSAddress_);
+        }
+        else
+        {
+            // Start the DHCP service before connecting so it hooks into
+            // the flow early and provisions the IP automatically.
+            LOG(INFO, "[DHCP] Starting DHCP Client.");
+            ESP_ERROR_CHECK(
+                tcpip_adapter_dhcpc_start(TCPIP_ADAPTER_IF_STA));
+        }
 
-            // If we are managing the WiFi and MDNS systems we need to
-            // trigger the reconnection process at this point.
-            if (manageWiFi_)
+        LOG(INFO,
+            "[WiFi] Station started, attempting to connect to SSID: %s.",
+            ssid_);
+        // Start the SSID connection process.
+        esp_wifi_connect();
+    }
+    else if (event->event_id == SYSTEM_EVENT_STA_CONNECTED)
+    {
+        LOG(INFO, "[WiFi] Connected to SSID: %s", ssid_);
+        // Set the flag that indictes we are connected to the SSID.
+        xEventGroupSetBits(wifiStatusEventGroup_, WIFI_CONNECTED_BIT);
+    }
+    else if (event->event_id == SYSTEM_EVENT_STA_GOT_IP)
+    {
+        // Retrieve the configured IP address from the TCP/IP stack.
+        tcpip_adapter_ip_info_t ip_info;
+        tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_STA, &ip_info);
+        LOG(INFO,
+            "[WiFi] IP address is " IPSTR ", starting hub (if enabled) and "
+            "uplink.",
+            IP2STR(&ip_info.ip));
+
+        // Set the flag that indictes we have an IPv4 address.
+        xEventGroupSetBits(wifiStatusEventGroup_, WIFI_GOTIP_BIT);
+
+        // Wake up the wifi_manager_task so it can start connections
+        // creating connections, this will be a no-op for initial startup.
+        xTaskNotifyGive(wifiTaskHandle_);
+    }
+    else if (event->event_id == SYSTEM_EVENT_STA_LOST_IP)
+    {
+        // Clear the flag that indicates we are connected and have an
+        // IPv4 address.
+        xEventGroupClearBits(wifiStatusEventGroup_, WIFI_GOTIP_BIT);
+        // Wake up the wifi_manager_task so it can clean up connections.
+        xTaskNotifyGive(wifiTaskHandle_);
+    }
+    else if (event->event_id == SYSTEM_EVENT_STA_DISCONNECTED)
+    {
+        // flag to indicate that we should print the reconnecting log message.
+        bool was_previously_connected = false;
+
+        // Check if we have already connected, this event can be raised
+        // even before we have successfully connected during the SSID
+        // connect process.
+        if (xEventGroupGetBits(wifiStatusEventGroup_) & WIFI_CONNECTED_BIT)
+        {
+            // track that we were connected previously.
+            was_previously_connected = true;
+
+            LOG(INFO, "[WiFi] Lost connection to SSID: %s", ssid_);
+            // Clear the flag that indicates we are connected to the SSID.
+            xEventGroupClearBits(wifiStatusEventGroup_, WIFI_CONNECTED_BIT);
+            // Clear the flag that indicates we have an IPv4 address.
+            xEventGroupClearBits(wifiStatusEventGroup_, WIFI_GOTIP_BIT);
+
+            // Wake up the wifi_manager_task so it can clean up
+            // connections.
+            xTaskNotifyGive(wifiTaskHandle_);
+        }
+
+        // If we are managing the WiFi and MDNS systems we need to
+        // trigger the reconnection process at this point.
+        if (manageWiFi_)
+        {
+            if (was_previously_connected)
             {
                 LOG(INFO, "[WiFi] Attempting to reconnect to SSID: %s.",
                     ssid_);
-                esp_wifi_connect();
             }
-            break;
+            else
+            {
+                LOG(INFO,
+                    "[WiFi] Connection failed, reconnecting to SSID: %s.",
+                    ssid_);
+            }
+            esp_wifi_connect();
+        }
+    }
+    else if (event->event_id == SYSTEM_EVENT_AP_START && manageWiFi_)
+    {
+        // Set the generated hostname prior to connecting to the SSID
+        // so that it shows up with the generated hostname instead of
+        // the default "Espressif".
+        LOG(INFO, "[SoftAP] Setting ESP32 hostname to \"%s\".",
+            hostname_.c_str());
+        ESP_ERROR_CHECK(tcpip_adapter_set_hostname(
+            TCPIP_ADAPTER_IF_AP, hostname_.c_str()));
+
+        uint8_t mac[6];
+        esp_wifi_get_mac(WIFI_IF_AP, mac);
+        LOG(INFO, "[SoftAP] MAC Address: %s", mac_to_string(mac).c_str());
+
+        if (softAPStaticIP_ && wifiMode_ != WIFI_MODE_STA)
+        {
+            // Stop the DHCP server so we can reconfigure it.
+            LOG(INFO, "[SoftAP] Stoping DHCP Server (if running).");
+            ESP_ERROR_CHECK(tcpip_adapter_dhcps_stop(TCPIP_ADAPTER_IF_AP));
+
+            LOG(INFO,
+                "[SoftAP] Configuring Static IP address:\n"
+                "IP     : " IPSTR "\n"
+                "Gateway: " IPSTR "\n"
+                "Netmask: " IPSTR,
+                IP2STR(&softAPStaticIP_->ip),
+                IP2STR(&softAPStaticIP_->gw),
+                IP2STR(&softAPStaticIP_->netmask));
+            ESP_ERROR_CHECK(
+                tcpip_adapter_set_ip_info(TCPIP_ADAPTER_IF_AP,
+                                          softAPStaticIP_));
+
+            // Convert the Soft AP Static IP to a uint32 for manipulation
+            uint32_t apIP = ntohl(ip4_addr_get_u32(&softAPStaticIP_->ip));
+
+            // Default configuration is for DHCP addresses to follow
+            // immediately after the static ip address of the Soft AP.
+            ip4_addr_t first_ip, last_ip;
+            ip4_addr_set_u32(&first_ip, htonl(apIP + 1));
+            ip4_addr_set_u32(&last_ip, htonl(apIP + softAPMaxStations_));
+
+            dhcps_lease_t dhcp_lease {
+                true,                   // enable dhcp lease functionality
+                first_ip,               // first ip to assign
+                last_ip,                // last ip to assign
+            };
+
+            LOG(INFO,
+                "[SoftAP] Configuring DHCP Server for IPs: " IPSTR " - " IPSTR,
+                IP2STR(&dhcp_lease.start_ip), IP2STR(&dhcp_lease.end_ip));
+            ESP_ERROR_CHECK(
+                tcpip_adapter_dhcps_option(TCPIP_ADAPTER_OP_SET,
+                                           TCPIP_ADAPTER_REQUESTED_IP_ADDRESS,
+                                           (void *)&dhcp_lease,
+                                           sizeof(dhcps_lease_t)));
+
+            // Start the DHCP server so it can provide IP addresses to stations
+            // when they connect.
+            LOG(INFO, "[SoftAP] Starting DHCP Server.");
+            ESP_ERROR_CHECK(
+                tcpip_adapter_dhcps_start(TCPIP_ADAPTER_IF_AP));
+        }
+    }
+    else if (event->event_id == SYSTEM_EVENT_AP_STACONNECTED)
+    {
+        LOG(INFO, "[SoftAP aid:%d] %s connected.",
+            event->event_info.sta_connected.aid,
+            mac_to_string(event->event_info.sta_connected.mac).c_str());
+    }
+    else if (event->event_id == SYSTEM_EVENT_AP_STADISCONNECTED)
+    {
+        LOG(INFO, "[SoftAP aid:%d] %s disconnected.",
+            event->event_info.sta_disconnected.aid,
+            mac_to_string(event->event_info.sta_connected.mac).c_str());
+    }
+
+    {
+        OSMutexLock l(&eventCallbacksLock_);
+        // Pass the event received from ESP-IDF to any registered callbacks.
+        for(auto callback : eventCallbacks_)
+        {
+            callback(event);
+        }
     }
 }
 
@@ -478,12 +658,9 @@ void Esp32WiFiManager::enable_verbose_logging()
 // potential corruption of entries in NVS.
 // 6) Configure the WiFi system for SSID/PW.
 // 7) Set the hostname based on the generated hostname.
-// 8) Connect to WiFi and wait for DHCP IP assignment.
-// 9) Verify that we connected and received a DHCP IP address, if not log a
-// FATAL message and give up.
-// 10) Initialize the mDNS system.
-// 11) Set the mDNS hostname based on the generated hostname.
-// 12) Set the default mDNS instance name based on the generated hostname.
+// 8) Connect to WiFi and wait for IP assignment.
+// 9) Verify that we connected and received a IP address, if not log a FATAL
+// message and give up.
 void Esp32WiFiManager::start_wifi_system()
 {
     // Create the event group used for tracking connected/disconnected status.
@@ -507,7 +684,25 @@ void Esp32WiFiManager::start_wifi_system()
     // Start the WiFi adapter.
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     LOG(INFO, "[WiFi] Initializing WiFi stack");
+
+    // Disable NVS storage for the WiFi driver
     cfg.nvs_enable = false;
+
+    // override the defaults coming from arduino-esp32, the ones below improve
+    // throughput and stability of TCP/IP, for more info on these values, see:
+    // https://github.com/espressif/arduino-esp32/issues/2899 and
+    // https://github.com/espressif/arduino-esp32/pull/2912
+    //
+    // Note: these numbers are slightly higher to allow compatibility with the
+    // WROVER chip and WROOM-32 chip. The increase results in ~2kb less heap
+    // at runtime.
+    //
+    // These do not require recompilation of arduino-esp32 code as these are
+    // used in the WIFI_INIT_CONFIG_DEFAULT macro, they simply need to be redefined.
+    cfg.static_rx_buf_num = 16;
+    cfg.dynamic_rx_buf_num = 32;
+    cfg.rx_ba_win = 16;
+
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
 
     if (esp32VerboseLogging_)
@@ -515,8 +710,8 @@ void Esp32WiFiManager::start_wifi_system()
         enable_esp_wifi_logging();
     }
 
-    // Set the WiFi mode to STATION.
-    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    // Set the WiFi mode.
+    ESP_ERROR_CHECK(esp_wifi_set_mode(wifiMode_));
 
     // This disables storage of SSID details in NVS which has been shown to be
     // problematic at times for the ESP32, it is safer to always pass fresh
@@ -524,92 +719,121 @@ void Esp32WiFiManager::start_wifi_system()
     // use a cached set from NVS.
     esp_wifi_set_storage(WIFI_STORAGE_RAM);
 
-    // Configure the SSID details for the station based on the SSID and
-    // password provided to the Esp32WiFiManager constructor.
-    wifi_config_t conf;
-    memset(&conf, 0, sizeof(wifi_config_t));
-    strcpy(reinterpret_cast<char *>(conf.sta.ssid), ssid_);
-    if (password_)
+    // If we want to host a SoftAP configure it now.
+    if (wifiMode_ == WIFI_MODE_APSTA || wifiMode_ == WIFI_MODE_AP)
     {
-        strcpy(reinterpret_cast<char *>(conf.sta.password), password_);
-    }
-
-    LOG(INFO, "[WiFi] Configuring WiFi stack");
-    ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &conf));
-
-    // Attempt to connect to the SSID, this will block until the ESP32 starts
-    // the connection process, note it may not have an IP address immediately
-    // thus the need to check the connection result a few times before giving
-    // up with a FATAL error.
-    LOG(INFO, "[WiFi] Starting WiFi stack");
-    ESP_ERROR_CHECK(esp_wifi_start());
-
-    uint8_t attempt = 0;
-    EventBits_t bits = 0;
-    uint32_t bitMask = WIFI_CONNECTED_BIT;
-    while (++attempt <= MAX_CONNECTION_CHECK_ATTEMPTS)
-    {
-        // If we have connected to the SSID we then are waiting for DHCP.
-        if (bits & WIFI_CONNECTED_BIT)
+        wifi_config_t conf;
+        memset(&conf, 0, sizeof(wifi_config_t));
+        conf.ap.authmode = softAPAuthMode_;
+        conf.ap.beacon_interval = 100;
+        conf.ap.channel = softAPChannel_;
+        conf.ap.max_connection = softAPMaxStations_;
+        if (wifiMode_ == WIFI_MODE_AP)
         {
-            LOG(INFO, "[DHCP] [%d/%d] Waiting for IP address assignment.",
-                attempt, MAX_CONNECTION_CHECK_ATTEMPTS);
+            // Configure the SSID for the Soft AP based on the SSID passed to
+            // the Esp32WiFiManager constructor.
+            strcpy(reinterpret_cast<char *>(conf.ap.ssid), ssid_);
         }
         else
         {
-            // Waiting for SSID connection
-            LOG(INFO, "[WiFi] [%d/%d] Waiting for SSID connection.", attempt,
-                MAX_CONNECTION_CHECK_ATTEMPTS);
+            // Configure the SSID for the Soft AP based on the generated
+            // hostname when operating in WIFI_MODE_APSTA mode.
+            strcpy(reinterpret_cast<char *>(conf.ap.ssid), hostname_.c_str());
         }
-        bits = xEventGroupWaitBits(wifiStatusEventGroup_,
-            bitMask, // bits we are interested in
-            pdFALSE, // clear on exit
-            pdTRUE,  // wait for all bits
-            WIFI_CONNECT_CHECK_INTERVAL);
-        // Check if have connected to the SSID
-        if (bits & WIFI_CONNECTED_BIT)
+        
+        if (password_ && softAPAuthMode_ != WIFI_AUTH_OPEN)
         {
-            // Since we have connected to the SSID we now need to track that we
-            // get an IP via DHCP.
-            bitMask |= DHCP_GOTIP_BIT;
+            strcpy(reinterpret_cast<char *>(conf.ap.password), password_);
         }
-        // Check if we have received an IP via DHCP.
-        if (bits & DHCP_GOTIP_BIT)
+
+        LOG(INFO, "[WiFi] Configuring SoftAP (SSID: %s)", conf.ap.ssid);
+        ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_AP, &conf));
+    }
+
+    // If we need to connect to an SSID, configure it now.
+    if (wifiMode_ == WIFI_MODE_APSTA || wifiMode_ == WIFI_MODE_STA)
+    {
+        // Configure the SSID details for the station based on the SSID and
+        // password provided to the Esp32WiFiManager constructor.
+        wifi_config_t conf;
+        memset(&conf, 0, sizeof(wifi_config_t));
+        strcpy(reinterpret_cast<char *>(conf.sta.ssid), ssid_);
+        if (password_)
         {
-            break;
+            strcpy(reinterpret_cast<char *>(conf.sta.password), password_);
+        }
+
+        LOG(INFO, "[WiFi] Configuring Station (SSID: %s)", conf.sta.ssid);
+        ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &conf));
+    }
+
+    // Start the WiFi stack. This will start the SoftAP and/or connect to the
+    // SSID based on the configuration set above.
+    LOG(INFO, "[WiFi] Starting WiFi stack");
+    ESP_ERROR_CHECK(esp_wifi_start());
+
+    // If we are using the STATION interface, this will block until the ESP32
+    // starts the connection process, note it may not have an IP address
+    // immediately thus the need to check the connection result a few times
+    // before giving up with a FATAL error.
+    if (wifiMode_ == WIFI_MODE_APSTA || wifiMode_ == WIFI_MODE_STA)
+    {
+        uint8_t attempt = 0;
+        EventBits_t bits = 0;
+        uint32_t bitMask = WIFI_CONNECTED_BIT;
+        while (++attempt <= MAX_CONNECTION_CHECK_ATTEMPTS)
+        {
+            // If we have connected to the SSID we then are waiting for IP
+            // address.
+            if (bits & WIFI_CONNECTED_BIT)
+            {
+                LOG(INFO, "[IPv4] [%d/%d] Waiting for IP address assignment.",
+                    attempt, MAX_CONNECTION_CHECK_ATTEMPTS);
+            }
+            else
+            {
+                // Waiting for SSID connection
+                LOG(INFO, "[WiFi] [%d/%d] Waiting for SSID connection.",
+                    attempt, MAX_CONNECTION_CHECK_ATTEMPTS);
+            }
+            bits = xEventGroupWaitBits(wifiStatusEventGroup_,
+                bitMask, // bits we are interested in
+                pdFALSE, // clear on exit
+                pdTRUE,  // wait for all bits
+                WIFI_CONNECT_CHECK_INTERVAL);
+            // Check if have connected to the SSID
+            if (bits & WIFI_CONNECTED_BIT)
+            {
+                // Since we have connected to the SSID we now need to track
+                // that we get an IP.
+                bitMask |= WIFI_GOTIP_BIT;
+            }
+            // Check if we have received an IP.
+            if (bits & WIFI_GOTIP_BIT)
+            {
+                break;
+            }
+        }
+
+        // Check if we successfully connected or not. If not, force a reboot.
+        if ((bits & WIFI_CONNECTED_BIT) != WIFI_CONNECTED_BIT)
+        {
+            LOG(FATAL, "[WiFi] Failed to connect to SSID: %s.", ssid_);
+        }
+
+        // Check if we successfully connected or not. If not, force a reboot.
+        if ((bits & WIFI_GOTIP_BIT) != WIFI_GOTIP_BIT)
+        {
+            LOG(FATAL, "[IPv4] Timeout waiting for an IP.");
         }
     }
-
-    // Check if we successfully connected or not. If not, force a reboot.
-    if ((bits & WIFI_CONNECTED_BIT) != WIFI_CONNECTED_BIT)
-    {
-        LOG(FATAL, "[WiFi] Failed to connect to SSID: %s.", ssid_);
-    }
-
-    // Check if we successfully connected or not. If not, force a reboot.
-    if ((bits & DHCP_GOTIP_BIT) != DHCP_GOTIP_BIT)
-    {
-        LOG(FATAL, "[DHCP] Timeout waiting for an IP.");
-    }
-
-    // Initialize the mDNS system.
-    LOG(INFO, "[mDNS] Initializing mDNS system");
-    ESP_ERROR_CHECK(mdns_init());
-
-    // Set the mDNS hostname based on our generated hostname so it can be found
-    // by other nodes.
-    LOG(INFO, "[mDNS] Setting mDNS hostname to \"%s\"", hostname_.c_str());
-    ESP_ERROR_CHECK(mdns_hostname_set(hostname_.c_str()));
-
-    // Set the default mDNS instance name to the generated hostname.
-    ESP_ERROR_CHECK(mdns_instance_name_set(hostname_.c_str()));
 }
 
 // Starts a background task for the Esp32WiFiManager.
 void Esp32WiFiManager::start_wifi_task()
 {
-    LOG(INFO, "[WiFiMgr] Starting WiFi Manager task");
-    os_thread_create(&wifiTaskHandle_, "OpenMRN-WiFiMgr", WIFI_TASK_PRIORITY,
+    LOG(INFO, "[WiFi] Starting WiFi Manager task");
+    os_thread_create(&wifiTaskHandle_, "Esp32WiFiMgr", WIFI_TASK_PRIORITY,
         WIFI_TASK_STACK_SIZE, wifi_manager_task, this);
 }
 
@@ -625,7 +849,7 @@ void *Esp32WiFiManager::wifi_manager_task(void *param)
     while (true)
     {
         EventBits_t bits = xEventGroupGetBits(wifi->wifiStatusEventGroup_);
-        if (bits & DHCP_GOTIP_BIT)
+        if (bits & WIFI_GOTIP_BIT)
         {
             // If we do not have not an uplink connection force a config reload
             // to start the connection process.
@@ -838,7 +1062,7 @@ int mdns_lookup(
     unique_ptr<struct addrinfo> ai(new struct addrinfo);
     if (ai.get() == nullptr)
     {
-        LOG(WARNING, "[mDNS] Allocation failed for addrinfo.");
+        LOG_ERROR("[mDNS] Allocation failed for addrinfo.");
         return EAI_MEMORY;
     }
     memset(ai.get(), 0, sizeof(struct addrinfo));
@@ -846,7 +1070,7 @@ int mdns_lookup(
     unique_ptr<struct sockaddr> sa(new struct sockaddr);
     if (sa.get() == nullptr)
     {
-        LOG(WARNING, "[mDNS] Allocation failed for sockaddr.");
+        LOG_ERROR("[mDNS] Allocation failed for sockaddr.");
         return EAI_MEMORY;
     }
     memset(sa.get(), 0, sizeof(struct sockaddr));
@@ -865,20 +1089,23 @@ int mdns_lookup(
     split_mdns_service_name(&service_name, &protocol_name);
 
     mdns_result_t *results = NULL;
-    esp_err_t err = mdns_query_ptr(service_name.c_str(), protocol_name.c_str(),
-        MDNS_QUERY_TIMEOUT, MDNS_MAX_RESULTS, &results);
-    LOG(VERBOSE, "[mDNS] mdns_query_ptr: %s.", esp_err_to_name(err));
-    if (err)
+    if (ESP_ERROR_CHECK_WITHOUT_ABORT(
+            mdns_query_ptr(service_name.c_str(),
+                           protocol_name.c_str(),
+                           MDNS_QUERY_TIMEOUT,
+                           MDNS_MAX_RESULTS,
+                           &results)))
     {
         // failed to find any matches
-        LOG(WARNING, "[mDNS] mDNS query failed: %s.", esp_err_to_name(err));
         return EAI_FAIL;
     }
 
     if (!results)
     {
         // failed to find any matches
-        LOG(WARNING, "[mDNS] No matches found for service: %s.", service);
+        LOG(ESP32_WIFIMGR_MDNS_LOOKUP_LOG_LEVEL,
+            "[mDNS] No matches found for service: %s.",
+            service);
         return EAI_AGAIN;
     }
 
@@ -895,7 +1122,7 @@ int mdns_lookup(
             // if this result has an IPv4 address process it
             if (ipaddr->addr.type == IPADDR_TYPE_V4)
             {
-                LOG(INFO,
+                LOG(ESP32_WIFIMGR_MDNS_LOOKUP_LOG_LEVEL,
                     "[mDNS] Found %s as providing service: %s on port %d.",
                     res->hostname, service, res->port);
                 inet_addr_from_ip4addr(
@@ -913,7 +1140,9 @@ int mdns_lookup(
 
     if (!match_found)
     {
-        LOG(WARNING, "[mDNS] No matches found for service: %s.", service);
+        LOG(ESP32_WIFIMGR_MDNS_LOOKUP_LOG_LEVEL,
+            "[mDNS] No matches found for service: %s.",
+            service);
         return EAI_AGAIN;
     }
 

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
@@ -47,6 +47,8 @@
 #include "utils/macros.h"
 
 #include <freertos/event_groups.h>
+#include <esp_event.h>
+#include <esp_wifi_types.h>
 
 namespace openmrn_arduino
 {
@@ -85,11 +87,42 @@ public:
     /// @param cfg is the WiFiConfiguration instance used for this node. This
     /// will be monitored for changes and the WiFi behavior altered
     /// accordingly.
+    /// @param hostname_prefix is the hostname prefix to use for this node.
+    /// The @ref NodeID will be appended to this value. The maximum length for
+    /// final hostname is 32 bytes.
+    /// @param wifi_mode is the WiFi operating mode. When set to WIFI_MODE_STA
+    /// the Esp32WiFiManager will attempt to connect to the provided WiFi SSID.
+    /// When the wifi_mode is WIFI_MODE_AP the Esp32WiFiManager will create an
+    /// AP with the provided SSID and PASSWORD. When the wifi_mode is
+    /// WIFI_MODE_APSTA the Esp32WiFiManager will connect to the provided WiFi
+    /// AP and create an AP with the SSID of "<hostname>" and the provided
+    /// password. Note, the password for the AP will not be used if
+    /// soft_ap_auth is set to WIFI_AUTH_OPEN (default).
+    /// @param station_static_ip is the static IP configuration to use for the
+    /// Station WiFi connection. If not specified DHCP will be used instead.
+    /// @param primary_dns_server is the primary DNS server to use when a
+    /// static IP address is being used. If left as the default (ip_addr_any)
+    /// the Esp32WiFiManager will use 8.8.8.8 if using a static IP address.
+    /// @param soft_ap_channel is the WiFi channel to use for the SoftAP.
+    /// @param soft_ap_max_clients is the maximum number of stations that can
+    /// connect to the SoftAP. This is limited to 1-4.
+    /// @param soft_ap_auth is the authentication mode for the AP when
+    /// wifi_mode is set to WIFI_MODE_AP or WIFI_MODE_APSTA.
+    /// @param softap_static_ip is the static IP configuration for the SoftAP,
+    /// when not specified the SoftAP will have an IP address of 192.168.4.1.
     ///
     /// Note: Both ssid and password must remain in memory for the duration of
     /// node uptime.
     Esp32WiFiManager(const char *ssid, const char *password,
-        openlcb::SimpleCanStack *stack, const WiFiConfiguration &cfg);
+        openlcb::SimpleCanStack *stack, const WiFiConfiguration &cfg,
+        const char *hostname_prefix = "esp32_",
+        wifi_mode_t wifi_mode = WIFI_MODE_STA,
+        tcpip_adapter_ip_info_t *station_static_ip = nullptr,
+        ip_addr_t primary_dns_server = ip_addr_any,
+        uint8_t soft_ap_channel = 1,
+        uint8_t soft_ap_max_stations = 4,
+        wifi_auth_mode_t soft_ap_auth = WIFI_AUTH_OPEN,
+        tcpip_adapter_ip_info_t *softap_static_ip=nullptr);
 
     /// Constructor.
     ///
@@ -126,16 +159,30 @@ public:
     /// @param fd is the file descriptor used for the configuration settings.
     void factory_reset(int fd) override;
 
-    /// Processes an Esp32 WiFi event based on the event_id raised by the
+    /// Processes an ESP-IDF WiFi event based on the event raised by the
     /// ESP-IDF event loop processor. This should be used when the
-    /// Esp32WiFiManager is not managing the WiFi or MDNS systems so that it
-    /// can react to WiFi events to cleanup or recreate the hub or uplink
-    /// connections as required.
+    /// Esp32WiFiManager is not managing the WiFi or MDNS systems so that
+    /// it can react to WiFi events to cleanup or recreate the hub or uplink
+    /// connections as required. When Esp32WiFiManager is managing the WiFi
+    /// connection this method will be called automatically from the
+    /// esp_event_loop. Note that ESP-IDF only supports one callback being
+    /// registered. 
     ///
-    /// @param event_id is the system_event_t.event_id value.
-    void process_wifi_event(int event_id);
+    /// @param event is the system_event_t raised by ESP-IDF.
+    void process_wifi_event(system_event_t *event);
 
-    /// If called, setsthe ESP32 wifi stack to log verbose information to the
+    /// Adds a callback to receive WiFi events as they are received/processed
+    /// by the Esp32WiFiManager.
+    ///
+    /// @param callback is the callback to invoke when events are received,
+    /// the only parameter is the system_event_t that was received.
+    void add_event_callback(std::function<void(system_event_t *)> callback)
+    {
+        OSMutexLock l(&eventCallbacksLock_);
+        eventCallbacks_.emplace_back(std::move(callback));
+    }
+
+    /// If called, sets the ESP32 wifi stack to log verbose information to the
     /// ESP32 serial port.
     void enable_verbose_logging();
 
@@ -189,8 +236,9 @@ private:
     /// periodic health checks of the connected hubs or clients.
     os_thread_t wifiTaskHandle_;
 
-    /// Dynamically generated hostname for this node, esp32_{node-id}.
-    std::string hostname_{"esp32_"};
+    /// Dynamically generated hostname for this node, esp32_{node-id}. This is
+    /// also used for the SoftAP SSID name (if enabled).
+    std::string hostname_{""};
 
     /// User provided SSID to connect to.
     const char *ssid_;
@@ -205,8 +253,32 @@ private:
     /// some environments this may be managed externally.
     const bool manageWiFi_;
 
-    /// OpenMRN stack for the Arduino system
+    /// OpenMRN stack for the Arduino system.
     openlcb::SimpleCanStack *stack_;
+
+    /// WiFi operating mode.
+    wifi_mode_t wifiMode_{WIFI_MODE_STA};
+
+    /// Static IP Address configuration for the Station connection.
+    tcpip_adapter_ip_info_t *stationStaticIP_{nullptr};
+
+    /// Primary DNS Address to use when configured for Static IP.
+    ip_addr_t primaryDNSAddress_{ip_addr_any};
+
+    /// Channel to use for the SoftAP interface.
+    uint8_t softAPChannel_{1};
+
+    /// Maximum number of station connections to the SoftAP, supported
+    /// values: 1-4.
+    uint8_t softAPMaxStations_{4};
+
+    /// Authentication mode to use for the SoftAP. If not set to WIFI_AUTH_OPEN
+    /// @ref password_ will be used.
+    wifi_auth_mode_t softAPAuthMode_{WIFI_AUTH_OPEN};
+
+    /// Static IP Address configuration for the SoftAP.
+    /// Default static IP provided by ESP-IDF is 192.168.4.1.
+    tcpip_adapter_ip_info_t *softAPStaticIP_{nullptr};
 
     /// Cached copy of the file descriptor passed into apply_configuration.
     /// This is internally used by the wifi_manager_task to processed deferred
@@ -231,6 +303,12 @@ private:
 
     /// @ref SocketClient for this node's uplink.
     std::unique_ptr<SocketClient> uplink_;
+
+    /// Collection of registered WiFi event callback handlers.
+    std::vector<std::function<void(system_event_t *)>> eventCallbacks_;
+
+    /// Protects eventCallbacks_ vector.
+    OSMutex eventCallbacksLock_;
 
     /// Internal event group used to track the IP assignment events.
     EventGroupHandle_t wifiStatusEventGroup_;

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
@@ -104,25 +104,29 @@ public:
     /// static IP address is being used. If left as the default (ip_addr_any)
     /// the Esp32WiFiManager will use 8.8.8.8 if using a static IP address.
     /// @param soft_ap_channel is the WiFi channel to use for the SoftAP.
-    /// @param soft_ap_max_clients is the maximum number of stations that can
-    /// connect to the SoftAP. This is limited to 1-4.
     /// @param soft_ap_auth is the authentication mode for the AP when
     /// wifi_mode is set to WIFI_MODE_AP or WIFI_MODE_APSTA.
+    /// @param soft_ap_password will be used as the password for the SoftAP,
+    /// if null and soft_ap_auth is not WIFI_AUTH_OPEN password will be used.
+    /// If provided, this must stay alive forever.
     /// @param softap_static_ip is the static IP configuration for the SoftAP,
     /// when not specified the SoftAP will have an IP address of 192.168.4.1.
     ///
     /// Note: Both ssid and password must remain in memory for the duration of
     /// node uptime.
-    Esp32WiFiManager(const char *ssid, const char *password,
-        openlcb::SimpleCanStack *stack, const WiFiConfiguration &cfg,
-        const char *hostname_prefix = "esp32_",
-        wifi_mode_t wifi_mode = WIFI_MODE_STA,
-        tcpip_adapter_ip_info_t *station_static_ip = nullptr,
-        ip_addr_t primary_dns_server = ip_addr_any,
-        uint8_t soft_ap_channel = 1,
-        uint8_t soft_ap_max_stations = 4,
-        wifi_auth_mode_t soft_ap_auth = WIFI_AUTH_OPEN,
-        tcpip_adapter_ip_info_t *softap_static_ip=nullptr);
+    Esp32WiFiManager(const char *ssid
+                   , const char *password
+                   , openlcb::SimpleCanStack *stack
+                   , const WiFiConfiguration &cfg
+                   , const char *hostname_prefix = "esp32_"
+                   , wifi_mode_t wifi_mode = WIFI_MODE_STA
+                   , tcpip_adapter_ip_info_t *station_static_ip = nullptr
+                   , ip_addr_t primary_dns_server = ip_addr_any
+                   , uint8_t soft_ap_channel = 1
+                   , wifi_auth_mode_t soft_ap_auth = WIFI_AUTH_OPEN
+                   , const char *soft_ap_password = nullptr
+                   , tcpip_adapter_ip_info_t *softap_static_ip = nullptr
+    );
 
     /// Constructor.
     ///
@@ -238,7 +242,7 @@ private:
 
     /// Dynamically generated hostname for this node, esp32_{node-id}. This is
     /// also used for the SoftAP SSID name (if enabled).
-    std::string hostname_{""};
+    std::string hostname_;
 
     /// User provided SSID to connect to.
     const char *ssid_;
@@ -268,13 +272,13 @@ private:
     /// Channel to use for the SoftAP interface.
     uint8_t softAPChannel_{1};
 
-    /// Maximum number of station connections to the SoftAP, supported
-    /// values: 1-4.
-    uint8_t softAPMaxStations_{4};
-
     /// Authentication mode to use for the SoftAP. If not set to WIFI_AUTH_OPEN
-    /// @ref password_ will be used.
+    /// @ref softAPPassword_ will be used.
     wifi_auth_mode_t softAPAuthMode_{WIFI_AUTH_OPEN};
+
+    /// User provided password for the SoftAP when active, defaults to
+    /// @ref password when null and softAPAuthMode_ is not WIFI_AUTH_OPEN.
+    const char *softAPPassword_;
 
     /// Static IP Address configuration for the SoftAP.
     /// Default static IP provided by ESP-IDF is 192.168.4.1.
@@ -299,7 +303,7 @@ private:
     std::unique_ptr<GcTcpHub> hub_;
 
     /// mDNS service name being advertised by the hub, if enabled.
-    std::string hubServiceName_{""};
+    std::string hubServiceName_;
 
     /// @ref SocketClient for this node's uplink.
     std::unique_ptr<SocketClient> uplink_;

--- a/src/os/OS.hxx
+++ b/src/os/OS.hxx
@@ -262,7 +262,7 @@ public:
     }
 
 
-#if OPENMRN_FEATURE_MUTEX_FREERTOS
+#if OPENMRN_FEATURE_RTOS_FROM_ISR
     /** Post (increment) a semaphore from ISR context.
      * @param woken is the task woken up
      */
@@ -270,7 +270,7 @@ public:
     {
         os_sem_post_from_isr(&handle, woken);
     }
-#endif
+#endif // OPENMRN_FEATURE_RTOS_FROM_ISR
 
 
     /** Wait on (decrement) a semaphore.

--- a/src/os/OS.hxx
+++ b/src/os/OS.hxx
@@ -262,7 +262,7 @@ public:
     }
 
 
-#if defined (__FreeRTOS__)
+#if OPENMRN_FEATURE_MUTEX_FREERTOS
     /** Post (increment) a semaphore from ISR context.
      * @param woken is the task woken up
      */
@@ -280,7 +280,7 @@ public:
         os_sem_wait(&handle);
     }
 
-#if !(defined(ESP_NONOS) || defined(ARDUINO))
+#if OPENMRN_FEATURE_SEM_TIMEDWAIT
     /** Wait on (decrement) a semaphore with timeout condition.
      * @param timeout timeout in nanoseconds, else OPENMRN_OS_WAIT_FOREVER to wait forever
      * @return 0 upon success, else -1 with errno set to indicate error

--- a/src/os/OSSelectWakeup.cxx
+++ b/src/os/OSSelectWakeup.cxx
@@ -10,7 +10,7 @@ void empty_signal_handler(int)
 #include <sys/stat.h>
 #include <fcntl.h>
 
-#include "../vfs/esp_vfs.h"
+#include <esp_vfs.h>
 
 /// Protects the initialization of vfs_id.
 static pthread_once_t vfs_init_once = PTHREAD_ONCE_INIT;

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -605,7 +605,7 @@ OS_INLINE int os_sem_post(os_sem_t *sem)
 #endif
 }
 
-#if OPENMRN_FEATURE_MUTEX_FREERTOS
+#if OPENMRN_FEATURE_RTOS_FROM_ISR
 /** Post a semaphore from the ISR context.
  * @param sem address of semaphore to increment
  * @param woken is the task woken up
@@ -618,7 +618,7 @@ OS_INLINE int os_sem_post_from_isr(os_sem_t *sem, int *woken)
     *woken |= local_woken;
     return 0;
 }
-#endif
+#endif // OPENMRN_FEATURE_RTOS_FROM_ISR
 
 /** Wait on a semaphore.
  * @param sem address of semaphore to decrement

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -719,7 +719,7 @@ OS_INLINE int os_sem_timedwait(os_sem_t *sem, long long timeout)
 #endif
 }
 
-#endif // #ifdef OPENMRN_FEATURE_SEM_TIMEDWAIT
+#endif // OPENMRN_FEATURE_SEM_TIMEDWAIT
 
 
 #if !defined (OPENMRN_FEATURE_MUTEX_FREERTOS)

--- a/src/utils/AutoSyncFileFlow.hxx
+++ b/src/utils/AutoSyncFileFlow.hxx
@@ -58,7 +58,7 @@ public:
                    , name_(StringPrintf("AutoSyncFileFlow(%d)", fd_))
     {
       HASSERT(fd_ >= 0);
-      HASSERT(syncInterval_ > 0);
+      HASSERT(interval_ > 0);
       start_flow(STATE(sleep_and_call_sync));
     }
 

--- a/src/utils/GridConnectHub.cxx
+++ b/src/utils/GridConnectHub.cxx
@@ -41,7 +41,7 @@
 #include "utils/Buffer.hxx"
 #include "utils/BufferPort.hxx"
 #include "utils/HubDevice.hxx"
-#ifdef OPENMRN_FEATURE_EXECUTOR_SELECT
+#if OPENMRN_FEATURE_EXECUTOR_SELECT
 #include "utils/HubDeviceSelect.hxx"
 #endif
 #include "utils/Hub.hxx"

--- a/src/utils/GridConnectHub.cxx
+++ b/src/utils/GridConnectHub.cxx
@@ -33,6 +33,8 @@
 
 //#define LOGLEVEL VERBOSE
 
+#include "openmrn_features.h"
+
 #include "utils/GridConnectHub.hxx"
 
 #include "executor/StateFlow.hxx"

--- a/src/utils/Queue.hxx
+++ b/src/utils/Queue.hxx
@@ -726,7 +726,7 @@ public:
         QProtected<T>::insert_locked(item);
         post_from_isr();
     }
-#endif
+#endif // OPENMRN_FEATURE_RTOS_FROM_ISR
 
     /** Get an item from the front of the queue.
      * @return item retrieved from queue
@@ -834,7 +834,7 @@ public:
         QListProtected<items>::insert_locked(item, index);
         this->post_from_isr(&woken);
     }
-#endif
+#endif // OPENMRN_FEATURE_RTOS_FROM_ISR
 
     /** Translate the Result type */
     typedef typename QListProtected<items>::Result Result;

--- a/src/utils/Queue.hxx
+++ b/src/utils/Queue.hxx
@@ -717,7 +717,7 @@ public:
         post();
     }
 
-#ifdef __FreeRTOS__
+#if OPENMRN_FEATURE_RTOS_FROM_ISR
     /** Add an item to the back of the queue, callable from interrupt context.
      * @param item item to add to queue
      */
@@ -823,7 +823,7 @@ public:
         post();
     }
 
-#ifdef __FreeRTOS__
+#if OPENMRN_FEATURE_RTOS_FROM_ISR
     /** Add an item to the back of the queue.
      * @param item item to add to queue
      * @param index in the list to operate on

--- a/src/utils/logging.cxx
+++ b/src/utils/logging.cxx
@@ -35,6 +35,8 @@
 
 #if defined(__linux__) || defined(__MACH__)
 char logbuffer[4096];
+#elif defined(ESP32)
+char logbuffer[2048];
 #else
 /// Temporary buffer to sprintf() the log lines into.
 char logbuffer[256];

--- a/src/utils/logging.cxx
+++ b/src/utils/logging.cxx
@@ -36,7 +36,7 @@
 #if defined(__linux__) || defined(__MACH__)
 char logbuffer[4096];
 #elif defined(ESP32)
-char logbuffer[2048];
+char logbuffer[1024];
 #else
 /// Temporary buffer to sprintf() the log lines into.
 char logbuffer[256];

--- a/src/utils/logging.h
+++ b/src/utils/logging.h
@@ -124,7 +124,7 @@ extern os_mutex_t g_log_mutex;
 #if defined(__linux__) || defined(__MACH__)
 extern char logbuffer[4096];
 #elif defined(ESP32)
-extern char logbuffer[2048];
+extern char logbuffer[1024];
 #else
 /// Temporary buffer to sprintf() the log lines into.
 extern char logbuffer[256];

--- a/src/utils/logging.h
+++ b/src/utils/logging.h
@@ -123,6 +123,8 @@ extern os_mutex_t g_log_mutex;
 
 #if defined(__linux__) || defined(__MACH__)
 extern char logbuffer[4096];
+#elif defined(ESP32)
+extern char logbuffer[2048];
 #else
 /// Temporary buffer to sprintf() the log lines into.
 extern char logbuffer[256];

--- a/src/utils/macros.h
+++ b/src/utils/macros.h
@@ -199,11 +199,6 @@ extern const char* g_death_file;
 #include <esp8266-compat.h>
 #endif
 
-#if defined (__linux__) || defined (__MACH__) || defined (GCC_ARMCM3)
-#define HAVE_BSDSOCKET
-#endif
-
-
 /// Retrieve a parent pointer from a member class variable. UNSAFE.
 /// Usage:
 /// class Parent {


### PR DESCRIPTION
1) Adding SoftAP support using the provided ssid/password when running in AP only mode. When operating in AP+STA the SoftAP will use the hostname for it's SSID.
2) Use the full system_event_t object in process_wifi_event.
3) Add support for callers to ask the wifi mgr for event callbacks.
4) Added defines for silencing most of the Esp32SocketParams::log_message output.
5) Changed to using ESP_ERROR_CHECK_WITHOUT_ABORT to mdns_lookup rather than checking/logging the error in this method.
6) Added define to silence mdns_lookup output for search result output.
7) Shorten task name to "Esp32WiFiMgr".
8) Move mdns system init to STA start event handler.
9) Performance/stability improvements to the LwIP stack based on values coming in arduino-esp32 1.0.3.
10) #ifdef -> #if for feature flags
11) Add check for WDT being enabled before using APIs
12) Expose Notifiable::notify_from_isr based on OPENMRN_FEATURE_MUTEX_FREERTOS (underlying impl uses this flag)
13) Increase of LOG(...) buffer size to 2kb for ESP32
14) Replace a couple lingering references to HAVE_BSDSOCKET with OPENMRN_FEATURE_BSD_SOCKET.