### PR TITLE
handle zero byte internal config file

### DIFF
--- a/src/openlcb/SimpleStack.cxx
+++ b/src/openlcb/SimpleStack.cxx
@@ -258,6 +258,13 @@ int SimpleStackBase::create_config_file_if_needed(const InternalConfigData &cfg,
     {
         extend = true;
     }
+    // Handle the case where the file exists but is zero bytes. This was
+    // observed on the esp32 with SD storage which does not automatically
+    // flush to disk on write.
+    if (statbuf.st_size == 0)
+    {
+        reset = true;
+    }
     if (!reset && cfg.version().read(fd) != expected_version)
     {
         reset = true;

--- a/src/openlcb/SimpleStack.cxx
+++ b/src/openlcb/SimpleStack.cxx
@@ -258,19 +258,29 @@ int SimpleStackBase::create_config_file_if_needed(const InternalConfigData &cfg,
     {
         extend = true;
     }
-    // Handle the case where the file exists but is zero bytes. This was
-    // observed on the esp32 with SD storage which does not automatically
-    // flush to disk on write.
-    if (statbuf.st_size == 0)
+    // Handle the case where the file exists but is too short for the verison
+    // check. This was observed on the esp32 with SD storage which does not
+    // automatically flush to disk on write.
+    if (statbuf.st_size < cfg.version().end_offset())
     {
+        LOG(VERBOSE, "%s is too short (%ld vs %d), forcing reset.",
+            CONFIG_FILENAME, statbuf.st_size, cfg.version().end_offset());
         reset = true;
     }
     if (!reset && cfg.version().read(fd) != expected_version)
     {
-        reset = true;
+        uint16_t current_version = cfg.version().read(fd);
+        if (current_version != expected_version)
+        {
+            LOG(VERBOSE, "config version mismatch (%d vs %d), forcing reset.",
+                current_version, expected_version);
+            reset = true;
+        }
     }
     if (!reset && !extend)
+    {
         return fd;
+    }
 
     // Clears the file, preserving the node name and desription if any.
     if (extend && !reset)


### PR DESCRIPTION
fix for #306, when the file exists but is zero bytes we can't read from it to check the version so it should treated as a reset instead.