### PR TITLE
SPIFFS unmount bugfix

### DIFF
--- a/src/freertos_drivers/spiffs/SPIFFS.cxx
+++ b/src/freertos_drivers/spiffs/SPIFFS.cxx
@@ -135,13 +135,25 @@ SPIFFS::SPIFFS(size_t physical_address, size_t size_on_disk,
 //
 SPIFFS::~SPIFFS()
 {
-    if (name)
-    {
-        SPIFFS_unmount(fs_);
-    }
+    // Performing unmount in the destructor of the base class is not
+    // possible, because the virtual functions for reading and writing the
+    // flash cannot be called anymore.
+    HASSERT(SPIFFS_mounted(fs_) == 0);
     delete[] fdSpace_;
     delete[] workBuffer_;
     delete fs_;
+}
+
+//
+// SPIFFS::unmount
+//
+void SPIFFS::unmount()
+{
+    if (name)
+    {
+        SPIFFS_unmount(fs_);
+        name = nullptr;
+    }
 }
 
 ///

--- a/src/freertos_drivers/spiffs/SPIFFS.hxx
+++ b/src/freertos_drivers/spiffs/SPIFFS.hxx
@@ -148,12 +148,23 @@ protected:
     /// Destructor.
     ~SPIFFS()
     {
+        // Performing unmount in the destructor of the base class is not
+        // possible, because the virtual functions for reading and writing the
+        // flash cannot be called anymore.
+        HASSERT(SPIFFS_mounted(&fs_) == 0);
+        delete[] fdSpace_;
+        delete[] workBuffer_;
+    }
+
+    /// FLushes caches and unmounts the filesystem. The destructor of the
+    /// derived class MUST call this function.
+    void unmount()
+    {
         if (name)
         {
             SPIFFS_unmount(&fs_);
+            name = nullptr;
         }
-        delete[] fdSpace_;
-        delete[] workBuffer_;
     }
 
     /// SPIFFS callback to read flash.

--- a/src/freertos_drivers/spiffs/SPIFFS.hxx
+++ b/src/freertos_drivers/spiffs/SPIFFS.hxx
@@ -134,7 +134,7 @@ protected:
     /// Destructor.
     ~SPIFFS();
 
-    /// FLushes caches and unmounts the filesystem. The destructor of the
+    /// Flushes caches and unmounts the filesystem. The destructor of the
     /// derived class MUST call this function.
     void unmount();
 

--- a/src/freertos_drivers/spiffs/cc32x0sf/CC32x0SFSPIFFS.hxx
+++ b/src/freertos_drivers/spiffs/cc32x0sf/CC32x0SFSPIFFS.hxx
@@ -56,6 +56,7 @@ public:
     /// Destructor.
     ~CC32x0SFSPIFFS()
     {
+        unmount();
     }
 
 private:

--- a/src/freertos_drivers/spiffs/stm32f0_f3/Stm32SPIFFS.hxx
+++ b/src/freertos_drivers/spiffs/stm32f0_f3/Stm32SPIFFS.hxx
@@ -58,6 +58,7 @@ public:
     /// Destructor.
     ~Stm32SPIFFS()
     {
+        unmount();
     }
 
 private:

--- a/src/freertos_drivers/spiffs/stm32f7/Stm32SPIFFS.hxx
+++ b/src/freertos_drivers/spiffs/stm32f7/Stm32SPIFFS.hxx
@@ -58,6 +58,7 @@ public:
     /// Destructor.
     ~Stm32SPIFFS()
     {
+        unmount();
     }
 
 private:


### PR DESCRIPTION
Makes sure unmount is called in the derived class destructor, because we cannot
perform reads and writes by the time we get to the base class destructor.