### PR TITLE
Enable add_from_isr and wakeup_from_isr via OPENMRN_FEATURE_RTOS_FROM_ISR feature macro.

### DIFF
--- a/src/executor/Executor.hxx
+++ b/src/executor/Executor.hxx
@@ -87,7 +87,7 @@ public:
      * the execution is completed. @param fn is the closure to run. */
     void sync_run(std::function<void()> fn);
 
-#ifdef __FreeRTOS__
+#if OPENMRN_FEATURE_RTOS_FROM_ISR
     /** Send a message to this Executor's queue. Callable from interrupt
      * context.
      * @param action Executable instance to insert into the input queue
@@ -95,7 +95,7 @@ public:
      */
     virtual void add_from_isr(Executable *action,
                               unsigned priority = UINT_MAX) = 0;
-#endif
+#endif // OPENMRN_FEATURE_RTOS_FROM_ISR
 
     /** Adds a file descriptor to be watched to the select loop.
      * @param job Selectable structure that describes the descriptor to watch.
@@ -314,7 +314,7 @@ public:
 #endif
     }
 
-#ifdef __FreeRTOS__
+#if OPENMRN_FEATURE_RTOS_FROM_ISR
     /** Send a message to this Executor's queue. Callable from interrupt
      * context.
      * @param msg Executable instance to insert into the input queue
@@ -326,7 +326,7 @@ public:
             msg, priority >= NUM_PRIO ? NUM_PRIO - 1 : priority);
         selectHelper_.wakeup_from_isr();
     }
-#endif
+#endif // OPENMRN_FEATURE_RTOS_FROM_ISR
 
     /** If the executor was created with NO_THREAD, then this function needs to
      * be called to run the executor loop. It will exit when the execut gets

--- a/src/executor/Executor.hxx
+++ b/src/executor/Executor.hxx
@@ -332,8 +332,8 @@ public:
 #else
         queue_.insert_locked(
             msg, priority >= NUM_PRIO ? NUM_PRIO - 1 : priority);
-        selectHelper_.wakeup_from_isr();
 #endif // ESP32
+        selectHelper_.wakeup_from_isr();
     }
 #endif // OPENMRN_FEATURE_RTOS_FROM_ISR
 

--- a/src/executor/Executor.hxx
+++ b/src/executor/Executor.hxx
@@ -322,9 +322,18 @@ public:
      */
     void add_from_isr(Executable *msg, unsigned priority = UINT_MAX) override
     {
+#ifdef ESP32
+        // On the ESP32 we need to call insert instead of insert_locked to
+        // ensure that all code paths lock the queue for consistency since
+        // this code path is not guaranteed to be protected by a critical
+        // section.
+        queue_.insert(
+            msg, priority >= NUM_PRIO ? NUM_PRIO - 1 : priority);
+#else
         queue_.insert_locked(
             msg, priority >= NUM_PRIO ? NUM_PRIO - 1 : priority);
         selectHelper_.wakeup_from_isr();
+#endif // ESP32
     }
 #endif // OPENMRN_FEATURE_RTOS_FROM_ISR
 

--- a/src/executor/StateFlow.cxx
+++ b/src/executor/StateFlow.cxx
@@ -99,24 +99,24 @@ void StateFlowBase::notify()
     service()->executor()->add(this);
 }
 
-#ifdef __FreeRTOS__
+#if OPENMRN_FEATURE_RTOS_FROM_ISR
 void StateFlowBase::notify_from_isr()
 {
     service()->executor()->add_from_isr(this, 0);
 }
-#endif
+#endif // OPENMRN_FEATURE_RTOS_FROM_ISR
 
 void StateFlowWithQueue::notify()
 {
     service()->executor()->add(this, currentPriority_);
 }
 
-#ifdef __FreeRTOS__
+#if OPENMRN_FEATURE_RTOS_FROM_ISR
 void StateFlowWithQueue::notify_from_isr()
 {
     service()->executor()->add_from_isr(this, currentPriority_);
 }
-#endif
+#endif // OPENMRN_FEATURE_RTOS_FROM_ISR
 
 /** Terminates the current StateFlow activity.  This is a sink state, and there
  * has to be an external call to do anything useful after this state has been

--- a/src/executor/StateFlow.hxx
+++ b/src/executor/StateFlow.hxx
@@ -179,11 +179,11 @@ public:
      * priority. */
     void notify() override;
 
-#ifdef __FreeRTOS__
+#if OPENMRN_FEATURE_RTOS_FROM_ISR
     /** Wakeup call arrived. Schedules *this on the executor. Does not know the
      * priority. */
     virtual void notify_from_isr() OVERRIDE;
-#endif
+#endif // OPENMRN_FEATURE_RTOS_FROM_ISR
 
     /** Return a pointer to the service I am bound to.
      * @return pointer to service
@@ -965,10 +965,10 @@ public:
     /// Wakeup call arrived. Schedules *this on the executor.
     void notify() override;
 
-#ifdef __FreeRTOS__
+#if OPENMRN_FEATURE_RTOS_FROM_ISR
     /** Wakeup call arrived. Schedules *this on the executor. */
     void notify_from_isr() OVERRIDE;
-#endif
+#endif // OPENMRN_FEATURE_RTOS_FROM_ISR
 
     /// @returns true if the flow is waiting for work.
     bool is_waiting()

--- a/src/os/OSSelectWakeup.cxx
+++ b/src/os/OSSelectWakeup.cxx
@@ -23,6 +23,7 @@ extern "C"
 {
     void *sys_thread_sem_get();
     void sys_sem_signal(void *);
+    void sys_sem_signal_isr(void *);
 }
 
 static int esp_wakeup_open(const char * path, int flags, int mode) {
@@ -100,6 +101,46 @@ void OSSelectWakeup::esp_wakeup()
         // sys_thread_sem_get() will get the semaphore that belongs to the
         // calling thread, not the target thread to wake up.
         sys_sem_signal(lwipSem_);
+    }
+#endif
+}
+
+void OSSelectWakeup::esp_wakeup_from_isr()
+{
+    if (woken_)
+    {
+        return;
+    }
+    AtomicHolder h(this);
+    if (woken_)
+    {
+        return;
+    }
+    woken_ = true;
+    BaseType_t woken = PDFALSE;
+#if 0
+    esp_vfs_select_triggered_isr((SemaphoreHandle_t *)espSem_, &woken);
+    if (woken == pdTRUE)
+    {
+        portYIELD_FROM_ISR();
+    }
+#else
+    if (espSem_)
+    {
+        esp_vfs_select_triggered_isr((SemaphoreHandle_t *)espSem_, &woken);
+        if (woken == pdTRUE)
+        {
+            portYIELD_FROM_ISR();
+        }
+    }
+    else
+    {
+        // Works around a bug in the implementation of
+        // esp_vfs_select_triggered, which internally calls
+        // sys_sem_signal(sys_thread_sem_get()); This is buggy because
+        // sys_thread_sem_get() will get the semaphore that belongs to the
+        // calling thread, not the target thread to wake up.
+        sys_sem_signal_isr(lwipSem_);
     }
 #endif
 }

--- a/src/utils/Atomic.hxx
+++ b/src/utils/Atomic.hxx
@@ -95,12 +95,34 @@ public:
     /// Locks the specific critical section.
     void lock()
     {
-        portENTER_CRITICAL(&mux);
+        // This should really use portENTER_CRITICAL_SAFE() but that is not
+        // available prior to ESP-IDF 3.3 which is not available in the
+        // arduino-esp32 environment generally. The below code is the
+        // implementation of that macro.
+        if (xPortInIsrContext())
+        {
+            portENTER_CRITICAL_ISR(&mux);
+        }
+        else
+        {
+            portENTER_CRITICAL(&mux);
+        }
     }
     /// Unlocks the specific critical section.
     void unlock()
     {
-        portEXIT_CRITICAL(&mux);
+        // This should really use portEXIT_CRITICAL_SAFE() but that is not
+        // available prior to ESP-IDF 3.3 which is not available in the
+        // arduino-esp32 environment generally. The below code is the
+        // implementation of that macro.
+        if (xPortInIsrContext())
+        {
+            portEXIT_CRITICAL_ISR(&mux);
+        }
+        else
+        {
+            portEXIT_CRITICAL(&mux);
+        }
     }
 
 private:


### PR DESCRIPTION
The ESP32 ::select() wakeup from an ISR required the addition of OSSelectWakeup::esp_wakeup_from_isr() which uses ISR versions of those in OSSelectWakeup::esp_wakeup(). Note the LOG statement has been dropped as it is not safe from inside an ISR.

I wasn't sure if pthread_kill is safe to call from inside the ISR context so left it commented in wakeup_from_isr(). @balazsracz can you confirm on if this is safe or not?