### PR TITLE
Adding shutdown() method to AutoSyncFileFlow

### DIFF
--- a/src/utils/AutoSyncFileFlow.hxx
+++ b/src/utils/AutoSyncFileFlow.hxx
@@ -62,6 +62,13 @@ public:
       start_flow(STATE(sleep_and_call_sync));
     }
 
+    /// Discontinues the automatic calls to fsync.
+    void shutdown()
+    {
+        timer_.cancel();
+        reset_flow(STATE(exit));
+    }
+
 private:
     const int fd_;
     const uint64_t interval_;

--- a/src/utils/AutoSyncFileFlow.hxx
+++ b/src/utils/AutoSyncFileFlow.hxx
@@ -62,11 +62,18 @@ public:
       start_flow(STATE(sleep_and_call_sync));
     }
 
-    /// Discontinues the automatic calls to fsync.
-    void shutdown()
+    /// Requests the discontinuation of automatic calls to fsync.
+    ///
+    /// @param n is the @ref Notifiable to call when this flow exits.
+    void shutdown(Notifiable *n)
     {
-        timer_.cancel();
-        reset_flow(STATE(exit));
+        shutdown_ = true;
+        std::swap(shutdownDone_, n);
+        if (n)
+        {
+            n->notify();
+        }
+        timer_.ensure_triggered();
     }
 
 private:
@@ -74,16 +81,23 @@ private:
     const uint64_t interval_;
     const std::string name_;
     StateFlowTimer timer_{this};
+    bool shutdown_{false};
+    Notifiable *shutdownDone_{nullptr};
 
     Action sleep_and_call_sync()
     {
-      return sleep_and_call(&timer_, interval_, STATE(sync));
+        return sleep_and_call(&timer_, interval_, STATE(sync));
     }
 
     Action sync()
     {
-      ERRNOCHECK(name_.c_str(), fsync(fd_));
-      return call_immediately(STATE(sleep_and_call_sync));
+        if (shutdown_)
+        {
+            AutoNotify n(shutdownDone_);
+            return exit();
+        }
+        ERRNOCHECK(name_.c_str(), fsync(fd_));
+        return call_immediately(STATE(sleep_and_call_sync));
     }
 };
 


### PR DESCRIPTION
Adding ability to shutdown the AutoSyncFileFlow so the underlying file/filesystem can be modified without the fsync call(s) being invoked.

The intent of this method is to discontinue automatic fsync calls prior to the unmounting of the VFS on the esp32 and prevent the ERRNOCHECK() call from calling abort() when fsync returns ERRNO=9 (bad file descriptor) since the underlying VFS has disappeared.