### PR TITLE
Adding OPENMRN_FEATURE_REBOOT macro for reboot().

### DIFF
--- a/include/openmrn_features.h
+++ b/include/openmrn_features.h
@@ -144,6 +144,11 @@
 
 #endif
 
+#if !defined(__MACH__)
+/// Compiles support for calling reboot() in ConfigUpdateFlow.hxx and
+/// MemoryConfig.cxx.
+#define OPENMRN_FEATURE_REBOOT 1
+#endif
 
 
 #endif // _INCLUDE_OPENMRN_FEATURES_

--- a/src/openlcb/ConfigUpdateFlow.hxx
+++ b/src/openlcb/ConfigUpdateFlow.hxx
@@ -37,17 +37,18 @@
 #ifndef _OPENLCB_CONFIGUPDATEFLOW_HXX_
 #define _OPENLCB_CONFIGUPDATEFLOW_HXX_
 
+#include "openmrn_features.h"
 #include "utils/ConfigUpdateListener.hxx"
 #include "utils/ConfigUpdateService.hxx"
 #include "openlcb/NodeInitializeFlow.hxx"
 #include "executor/StateFlow.hxx"
 
-#if !defined (__MACH__)
+#if OPENMRN_FEATURE_REBOOT
 extern "C" {
 /// Called when the node needs to be rebooted.
 extern void reboot();
 }
-#endif
+#endif // OPENMRN_FEATURE_REBOOT
 
 namespace openlcb
 {
@@ -168,7 +169,7 @@ private:
         /// TODO(balazs.racz) apply the changes reported.
         if (needsReboot_)
         {
-#ifdef __FreeRTOS__
+#if OPENMRN_FEATURE_REBOOT
             reboot();
 #endif
         }

--- a/src/openlcb/MemoryConfig.cxx
+++ b/src/openlcb/MemoryConfig.cxx
@@ -38,6 +38,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include "openmrn_features.h"
 #include "utils/logging.h"
 #ifdef __FreeRTOS__
 #include "can_ioctl.h"
@@ -52,13 +53,13 @@ void enter_bootloader()
 {
 }
 
-#if !defined (__MACH__)
+#if OPENMRN_FEATURE_REBOOT
 /// Implement this function (usually in HwInit.cxx) to reboot the MCU.
 void reboot() __attribute__ ((weak));
 void reboot()
 {
 }
-#endif
+#endif // OPENMRN_FEATURE_REBOOT
 }
 
 namespace openlcb

--- a/src/openlcb/MemoryConfig.hxx
+++ b/src/openlcb/MemoryConfig.hxx
@@ -35,6 +35,7 @@
 #ifndef _OPENLCB_MEMORYCONFIG_HXX_
 #define _OPENLCB_MEMORYCONFIG_HXX_
 
+#include "openmrn_features.h"
 #include "openlcb/DatagramDefs.hxx"
 #include "openlcb/DatagramHandlerDefault.hxx"
 #include "openlcb/MemoryConfig.hxx"
@@ -46,7 +47,7 @@ class Notifiable;
 extern "C" {
 extern void enter_bootloader();
 /** @todo need to find an alternative for reboot() for MacOS */
-#if !defined (__MACH__)
+#if OPENMRN_FEATURE_REBOOT
 extern void reboot();
 #endif
 }

--- a/src/openlcb/MemoryConfig.hxx
+++ b/src/openlcb/MemoryConfig.hxx
@@ -699,7 +699,7 @@ private:
             }
             case MemoryConfigDefs::COMMAND_RESET:
             {
-#if !defined (__MACH__)
+#if OPENMRN_FEATURE_REBOOT
                 reboot();
 #endif
                 return respond_reject(Defs::ERROR_UNIMPLEMENTED_SUBCMD);


### PR DESCRIPTION
This was being not called from ConfigUpdateFlow except when ```__FreeRTOS__``` was defined even though the weak function was defined everywhere except on Mac OS.