### PR TITLE
Updating constants.hxx to fix issue on esp32

### DIFF
--- a/src/utils/constants.hxx
+++ b/src/utils/constants.hxx
@@ -94,7 +94,7 @@
 #else  // native C
 
 #define DECLARE_CONST(name)                                                    \
-    EXTERNC extern void _sym_##name(void);                                     \
+    EXTERNC extern int _sym_##name;                                            \
     EXTERNCEND typedef unsigned char                                           \
     _do_not_add_declare_and_default_const_to_the_same_file_for_##name;         \
     static inline ptrdiff_t config_##name(void)                                \


### PR DESCRIPTION
Using the datatype as "void" and _sym_XXX as a function causes the xtensa GCC compiler to generate code which is unable to successfully evaluate config_XXX() == CONSTANT_TRUE as boolean true even when config_XXX() returns CONSTANT_TRUE when printed. By switching the datatype to int and treating it as a variable instead, the compiler generates the expected equality test.

The previous PR for this used constant values of 4 and 8 which also worked but simply changing the declaration of the symbol is a smaller change.