### PR TITLE
Quote handling added (Robert Heller <heller@deepsoft.com>)

### DIFF
--- a/src/console/Console.cxx
+++ b/src/console/Console.cxx
@@ -307,7 +307,8 @@ StateFlowBase::Action Console::Session::process_read()
                 {
                     case '\r':
                     case '\n':
-                    if (quote != '\0') { // dangling quote check
+                    if (quote != '\0') 
+                    { // dangling quote check
                         /* Open quotes at EOL? -- syntax error! */
                         fprintf(fp, "syntax error: unclosed %c\n",quote);
                         i = pos; // force EOL
@@ -324,21 +325,26 @@ StateFlowBase::Action Console::Session::process_read()
                         // is not implemented, although both types of
                         // quotes (double and single) are handled,
                         // allowing one to quote the other.
-                        if (quote == line[i]) {/* End of quoted */
+                        if (quote == line[i]) 
+                        {/* End of quoted */
                             line[i] = '\0'; // EOS (clobber the quote)
                             quote = '\0';   // reset flag
                             // Handling a following space.
-                            if (i+1 < pos && line[i+1] <= ' ') {
+                            if ((i + 1) < pos && line[i+1] <= ' ') 
+                            {
                                 line[++i] = '\0';
                             }
                             break;
-                        } else if (quote == '\0') { /* Start of quoted */
+                        } else if (quote == '\0') 
+                        { /* Start of quoted */
                             quote = line[i]; // Save  the quote mark
-                            if (i+1 < pos) { 
+                            if ((i + 1) < pos) 
+                            { 
                                 // skip over the quote and start an arg.
                                 args[argc] = &line[i+1];
                                 argc = (argc == MAX_ARGS) ? MAX_ARGS : argc + 1;
-                            } else {
+                            } else 
+                            {
                                 /* Loose quote mark at EOL? -- syntax error! */
                                 fprintf(fp, "syntax error: unclosed %c\n",quote);
                                 i = pos; // force EOL

--- a/src/console/Console.cxx
+++ b/src/console/Console.cxx
@@ -330,20 +330,22 @@ StateFlowBase::Action Console::Session::process_read()
                             line[i] = '\0'; // EOS (clobber the quote)
                             quote = '\0';   // reset flag
                             // Handling a following space.
-                            if ((i + 1) < pos && line[i+1] <= ' ') 
+                            if ((i + 1) < pos && line[i + 1] <= ' ') 
                             {
                                 line[++i] = '\0';
                             }
                             break;
-                        } else if (quote == '\0') 
+                        } 
+                        else if (quote == '\0') 
                         { /* Start of quoted */
                             quote = line[i]; // Save  the quote mark
                             if ((i + 1) < pos) 
                             { 
                                 // skip over the quote and start an arg.
-                                args[argc] = &line[i+1];
+                                args[argc] = &line[i + 1];
                                 argc = (argc == MAX_ARGS) ? MAX_ARGS : argc + 1;
-                            } else 
+                            }
+                            else 
                             {
                                 /* Loose quote mark at EOL? -- syntax error! */
                                 fprintf(fp, "syntax error: unclosed %c\n",quote);

--- a/src/console/Console.cxx
+++ b/src/console/Console.cxx
@@ -294,23 +294,58 @@ StateFlowBase::Action Console::Session::process_read()
 
     while(count--)
     {
+        bool unclosed = false; // dangling quote mark flag
         if (line[pos++] == '\n')
         {
             /* parse the line input into individual arguments */
             unsigned argc = 0;
             char last = '\0';
-
+            char quote = '\0'; // Quote mark we are in (\0 means no quotes).
             for (size_t i = 0; i < pos; ++i)
             {
                 switch (line[i])
                 {
                     case '\r':
                     case '\n':
+                    if (quote != '\0') { // dangling quote check
+                        /* Open quotes at EOL? -- syntax error! */
+                        fprintf(fp, "syntax error: unclosed %c\n",quote);
+                        i = pos; // force EOL
+                        unclosed = true; // set error flag
+                    }
                     case ' ':
-                        line[i] = '\0';
+                        // Space is only meaningful when not in quotes
+                        if (quote == '\0') line[i] = '\0';
                         break;
+                    case '\'':
                     case '"':
-                        /** @todo quoted arguments not yet supported */
+                        /// Quote handling added (Robert Heller <heller@deepsoft.com>)
+                        // This is a relativly simple handling.  Escaping
+                        // is not implemented, although both types of
+                        // quotes (double and single) are handled,
+                        // allowing one to quote the other.
+                        if (quote == line[i]) {/* End of quoted */
+                            line[i] = '\0'; // EOS (clobber the quote)
+                            quote = '\0';   // reset flag
+                            // Handling a following space.
+                            if (i+1 < pos && line[i+1] <= ' ') {
+                                line[++i] = '\0';
+                            }
+                            break;
+                        } else if (quote == '\0') { /* Start of quoted */
+                            quote = line[i]; // Save  the quote mark
+                            if (i+1 < pos) { 
+                                // skip over the quote and start an arg.
+                                args[argc] = &line[i+1];
+                                argc = (argc == MAX_ARGS) ? MAX_ARGS : argc + 1;
+                            } else {
+                                /* Loose quote mark at EOL? -- syntax error! */
+                                fprintf(fp, "syntax error: unclosed %c\n",quote);
+                                i = pos; // force EOL
+                                unclosed = true; // set error flag
+                            }
+                            break;
+                        }
                     default:
                         if (last == '\0')
                         {
@@ -340,6 +375,7 @@ StateFlowBase::Action Console::Session::process_read()
                     break;
                 default:
                 {
+                    if (unclosed) break;
                     CommandStatus status = callback(argc, args);
                     if (status == COMMAND_NEXT)
                     {

--- a/src/console/Console.cxxtest
+++ b/src/console/Console.cxxtest
@@ -270,3 +270,37 @@ TEST(ConsoleTest, testAddCommandFlow)
 }
 
 
+static Console::CommandStatus echo_command(FILE *fp, int argc, const char *argv[], void *context)
+{
+    if (argc == 0) {
+        fprintf(fp, "the echo command\n");
+    } else if (argc == 2) {
+        fprintf(fp, "%s\n", argv[2]);
+    } else {
+        return Console::COMMAND_ERROR;
+    }
+
+    return Console::COMMAND_OK;
+}
+
+TEST(ConsoleTest, testQuotedParameters)
+{
+    g_console.add_command("echo", echo_command, nullptr);
+    
+    int s = ConnectSocket("localhost", 12345);
+    
+    EXPECT_EQ(::read(s, buf, 1024), 2);
+    EXPECT_TRUE(!strncmp(buf, "> ", 2));
+    
+    EXPECT_EQ(::write(s, "echo \"It couldn't\"\n",19), 19);
+    usleep(1000);
+    EXPECT_EQ(::read(s, buf, 1024), 14);
+    EXPECT_TRUE(!strncmp(buf, "It couldn't\n> ", 14));
+    
+    EXPECT_EQ(::write(s, "echo '\"Oh no, no, no\", said the man'\n", 37), 37);
+    usleep(1000);
+    EXPECT_EQ(::read(s, buf, 1024), 32);
+    EXPECT_TRUE(!strncmp(buf, "\"Oh no, no, no\", said the man\n> ", 32));
+    
+    close(s);
+}


### PR DESCRIPTION
This is a relativly simple handling.  Escaping is not implemented,
although both types of quotes (double and single) are handled,
 allowing one to quote the other.