### PR TITLE
SHA256 helper for the CC32xx hardware and for linux using OpenSSL.

### DIFF
--- a/bin/sha-test-vectors.awk
+++ b/bin/sha-test-vectors.awk
@@ -1,0 +1,20 @@
+#!/usr/bin/gawk -f
+
+# This file is used to preprocess the SHA test vectors file.
+# Usage: $0 < SHA256LongMsg.rsp
+
+BEGIN {
+  idx = 0;
+}
+
+/Msg =/ {
+  printf("if (index == %d)\n{\n    Payload = hex2str(\"%s\");\n", idx, $3);
+  idx = idx + 1;
+}
+
+/MD =/ {
+  printf("    Hash = hex2str(\"%s\");\n}\n", $3);
+}
+
+// {}
+

--- a/src/freertos_drivers/ti/CC32xxAesTest.hxx
+++ b/src/freertos_drivers/ti/CC32xxAesTest.hxx
@@ -26,7 +26,7 @@
  *
  * \file CC32xxAesTest.hxx
  *
- * Test runner for the CC32xx AES-CCM tests.
+ * Test runner for the CC32xx AES-CCM and SHA tests.
  *
  * @author Balazs Racz
  * @date 29 July 2019
@@ -39,6 +39,7 @@
 
 #include "freertos_drivers/ti/CC32xxHelper.hxx"
 #include "freertos_drivers/ti/CC32xxAes.hxx"
+#include "freertos_drivers/ti/CC32xxSha.hxx"
 #include "fs.h"
 
 namespace aes_test {
@@ -93,6 +94,12 @@ void get_example(int index, string &Key, string &Nonce, string &Adata,
 #include "utils/AesCcmTestVectorsEx.hxx"
 }
 
+void get_sha_example(int index, string &Key, string &Hash,
+    string &Payload)
+{
+#include "utils/ShaTestVectors.hxx"
+}
+
 bool have_failure = false;
 
 void printcomp(const string& exp, const string& act, const char* name) {
@@ -142,6 +149,15 @@ bool run_all_tests()
         printcomp(tag, o_tag, "tag");
         printcomp(cipher, o_cipher, "cipher");
     }
+
+    for (int i = 0; i <= 67; i++) {
+        string digest;
+        get_sha_example(i, key, digest, plain);
+        LOG(INFO, "SHA256 Example %d datalen=%d", i, (int)plain.size());
+        string o_digest = SHAHelper::sha256(plain.data(), plain.size());
+        printcomp(digest, o_digest, "hash");
+    }
+    
     return !have_failure;
 }
 

--- a/src/freertos_drivers/ti/CC32xxAesTest.hxx
+++ b/src/freertos_drivers/ti/CC32xxAesTest.hxx
@@ -37,8 +37,8 @@
 
 #define LOGLEVEL INFO
 
-#include "freertos_drivers/ti/CC32xxHelper.hxx"
 #include "freertos_drivers/ti/CC32xxAes.hxx"
+#include "freertos_drivers/ti/CC32xxHelper.hxx"
 #include "freertos_drivers/ti/CC32xxSha.hxx"
 #include "fs.h"
 
@@ -94,8 +94,7 @@ void get_example(int index, string &Key, string &Nonce, string &Adata,
 #include "utils/AesCcmTestVectorsEx.hxx"
 }
 
-void get_sha_example(int index, string &Key, string &Hash,
-    string &Payload)
+void get_sha_example(int index, string &Key, string &Hash, string &Payload)
 {
 #include "utils/ShaTestVectors.hxx"
 }
@@ -150,14 +149,15 @@ bool run_all_tests()
         printcomp(cipher, o_cipher, "cipher");
     }
 
-    for (int i = 0; i <= 67; i++) {
+    for (int i = 0; i <= 67; i++)
+    {
         string digest;
         get_sha_example(i, key, digest, plain);
         LOG(INFO, "SHA256 Example %d datalen=%d", i, (int)plain.size());
         string o_digest = SHAHelper::sha256(plain.data(), plain.size());
         printcomp(digest, o_digest, "hash");
     }
-    
+
     return !have_failure;
 }
 

--- a/src/freertos_drivers/ti/CC32xxSha.hxx
+++ b/src/freertos_drivers/ti/CC32xxSha.hxx
@@ -1,0 +1,77 @@
+/** \copyright
+ * Copyright (c) 2019, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file CC32xxSha.hxx
+ *
+ * Helper function to perform SHA calculation with hardware hash engine on the
+ * CC32xx.
+ *
+ * @author Balazs Racz
+ * @date 3 Nov 2019
+ */
+
+#ifndef _CC32xxSHA_HXX_
+#define _CC32xxSHA_HXX_
+
+#define USE_CC3220_ROM_DRV_API
+
+#include "driverlib/prcm.h"
+#include "driverlib/rom.h"
+#include "driverlib/rom_map.h"
+#include "driverlib/shamd5.h"
+#include "inc/hw_dthe.h"
+#include "inc/hw_memmap.h"
+#include "inc/hw_types.h"
+
+#include <string>
+
+#include "utils/SyncStream.hxx"
+
+class SHAHelper
+{
+public:
+    /// Computes a SHA-256 hash of the given input data.
+    /// @param data is the pointer to the input.
+    /// @param len the size in bytes of the input. Must be a multiple of 64
+    /// bytes.
+    /// @return a 256-bit (32 byte) string containing the SHA256 hash.
+    static std::string sha256(const void *data, size_t len)
+    {
+        MAP_SHAMD5ConfigSet(SHAMD5_BASE, SHAMD5_ALGO_SHA256, 1, 1, 0, 0);
+        std::string ret(32, 0);
+        // Note: this should really be SHAMD5DataProcess, but that has an
+        // assert on len%64 == 0 for no reason. The below function does the
+        // same thing but without the extra assert.
+        ROM_SHAMD5DataProcess(SHAMD5_BASE, (uint8_t *)data, len, (uint8_t*)&ret[0]);
+        return ret;
+    }
+
+private:
+    /// This class cannot be instantiated.
+    SHAHelper();
+};
+
+#endif // _CC32xxSHA_HXX_

--- a/src/freertos_drivers/ti/CC32xxSha.hxx
+++ b/src/freertos_drivers/ti/CC32xxSha.hxx
@@ -65,7 +65,8 @@ public:
         // Note: this should really be SHAMD5DataProcess, but that has an
         // assert on len%64 == 0 for no reason. The below function does the
         // same thing but without the extra assert.
-        ROM_SHAMD5DataProcess(SHAMD5_BASE, (uint8_t *)data, len, (uint8_t*)&ret[0]);
+        ROM_SHAMD5DataProcess(
+            SHAMD5_BASE, (uint8_t *)data, len, (uint8_t *)&ret[0]);
         return ret;
     }
 

--- a/src/utils/OpenSSLAesCcm.cxxtest
+++ b/src/utils/OpenSSLAesCcm.cxxtest
@@ -29,13 +29,12 @@ void get_example(int index, string& Key, string& Nonce, string& Adata, string& P
 #include "utils/AesCcmTestVectors.hxx"
 }
 
-void get_sha_example(int index, string &Key, string &Hash,
-    string &Payload)
-{
+void get_sha_example(int index, string &Key, string &Hash, string &Payload) {
 #include "utils/ShaTestVectors.hxx"
 }
 
-TEST(OpenSSLCCMTest, EncryptionTest) {
+TEST(OpenSSLCCMTest, EncryptionTest)
+{
     string key;
     string nonce;
     string auth_data;

--- a/src/utils/OpenSSLAesCcm.cxxtest
+++ b/src/utils/OpenSSLAesCcm.cxxtest
@@ -29,6 +29,11 @@ void get_example(int index, string& Key, string& Nonce, string& Adata, string& P
 #include "utils/AesCcmTestVectors.hxx"
 }
 
+void get_sha_example(int index, string &Key, string &Hash,
+    string &Payload)
+{
+#include "utils/ShaTestVectors.hxx"
+}
 
 TEST(OpenSSLCCMTest, EncryptionTest) {
     string key;
@@ -50,5 +55,17 @@ TEST(OpenSSLCCMTest, EncryptionTest) {
         CCMEncrypt(key, nonce, auth_data, plain, &o_cipher, &o_tag);
         EXPECT_EQ(tag, o_tag);
         EXPECT_EQ(cipher, o_cipher);
+    }
+}
+
+TEST(OpenSSLSHATest, HashTest)
+{
+    for (int i = 0; i <= 67; i++)
+    {
+        string digest, key, plain;
+        get_sha_example(i, key, digest, plain);
+        LOG(INFO, "SHA256 Example %d datalen=%d", i, (int)plain.size());
+        string o_digest = MD::SHA256(plain.data(), plain.size());
+        EXPECT_EQ(digest, o_digest);
     }
 }

--- a/src/utils/OpenSSLAesCcm.hxx
+++ b/src/utils/OpenSSLAesCcm.hxx
@@ -119,4 +119,30 @@ void CCMEncrypt(const std::string &aes_key, const std::string &iv,
     EVP_CIPHER_CTX_free(ctx);
 }
 
+/// Helper class to do hashing algorithms via OpenSSL library.
+class MD
+{
+public:
+    /// Computes a SHA256 hash of a given data payload.
+    /// @param data pointer to the beginning of the data to be hashed.
+    /// @param len the number of bytes to be hashed
+    /// @return SHA256 hash (32 bytes long).
+    static std::string SHA256(const void *data, size_t len)
+    {
+        EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+        std::string ret(32, 0);
+        EVP_DigestInit_ex(mdctx, EVP_sha256(), NULL);
+        EVP_DigestUpdate(mdctx, data, len);
+        unsigned int md_len;
+        EVP_DigestFinal_ex(mdctx, (uint8_t *)&ret[0], &md_len);
+        HASSERT(md_len == 32);
+        EVP_MD_CTX_free(mdctx);
+        return ret;
+    }
+
+private:
+    /// This class cannot be instantiated.
+    MD();
+};
+
 #endif // _UTILS_OPENSSLAESCCM_HXX_

--- a/src/utils/ShaTestVectors.hxx
+++ b/src/utils/ShaTestVectors.hxx
@@ -1,0 +1,340 @@
+if (index == 0)
+{
+    Payload = "";
+    Hash = hex2str("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+}
+if (index == 1)
+{
+    Payload = hex2str("d3");
+    Hash = hex2str("28969cdfa74a12c82f3bad960b0b000aca2ac329deea5c2328ebc6f2ba9802c1");
+}
+if (index == 2)
+{
+    Payload = hex2str("11af");
+    Hash = hex2str("5ca7133fa735326081558ac312c620eeca9970d1e70a4b95533d956f072d1f98");
+}
+if (index == 3)
+{
+    Payload = hex2str("b4190e");
+    Hash = hex2str("dff2e73091f6c05e528896c4c831b9448653dc2ff043528f6769437bc7b975c2");
+}
+if (index == 4)
+{
+    Payload = hex2str("74ba2521");
+    Hash = hex2str("b16aa56be3880d18cd41e68384cf1ec8c17680c45a02b1575dc1518923ae8b0e");
+}
+if (index == 5)
+{
+    Payload = hex2str("c299209682");
+    Hash = hex2str("f0887fe961c9cd3beab957e8222494abb969b1ce4c6557976df8b0f6d20e9166");
+}
+if (index == 6)
+{
+    Payload = hex2str("e1dc724d5621");
+    Hash = hex2str("eca0a060b489636225b4fa64d267dabbe44273067ac679f20820bddc6b6a90ac");
+}
+if (index == 7)
+{
+    Payload = hex2str("06e076f5a442d5");
+    Hash = hex2str("3fd877e27450e6bbd5d74bb82f9870c64c66e109418baa8e6bbcff355e287926");
+}
+if (index == 8)
+{
+    Payload = hex2str("5738c929c4f4ccb6");
+    Hash = hex2str("963bb88f27f512777aab6c8b1a02c70ec0ad651d428f870036e1917120fb48bf");
+}
+if (index == 9)
+{
+    Payload = hex2str("3334c58075d3f4139e");
+    Hash = hex2str("078da3d77ed43bd3037a433fd0341855023793f9afd08b4b08ea1e5597ceef20");
+}
+if (index == 10)
+{
+    Payload = hex2str("74cb9381d89f5aa73368");
+    Hash = hex2str("73d6fad1caaa75b43b21733561fd3958bdc555194a037c2addec19dc2d7a52bd");
+}
+if (index == 11)
+{
+    Payload = hex2str("76ed24a0f40a41221ebfcf");
+    Hash = hex2str("044cef802901932e46dc46b2545e6c99c0fc323a0ed99b081bda4216857f38ac");
+}
+if (index == 12)
+{
+    Payload = hex2str("9baf69cba317f422fe26a9a0");
+    Hash = hex2str("fe56287cd657e4afc50dba7a3a54c2a6324b886becdcd1fae473b769e551a09b");
+}
+if (index == 13)
+{
+    Payload = hex2str("68511cdb2dbbf3530d7fb61cbc");
+    Hash = hex2str("af53430466715e99a602fc9f5945719b04dd24267e6a98471f7a7869bd3b4313");
+}
+if (index == 14)
+{
+    Payload = hex2str("af397a8b8dd73ab702ce8e53aa9f");
+    Hash = hex2str("d189498a3463b18e846b8ab1b41583b0b7efc789dad8a7fb885bbf8fb5b45c5c");
+}
+if (index == 15)
+{
+    Payload = hex2str("294af4802e5e925eb1c6cc9c724f09");
+    Hash = hex2str("dcbaf335360de853b9cddfdafb90fa75567d0d3d58af8db9d764113aef570125");
+}
+if (index == 16)
+{
+    Payload = hex2str("0a27847cdc98bd6f62220b046edd762b");
+    Hash = hex2str("80c25ec1600587e7f28b18b1b18e3cdc89928e39cab3bc25e4d4a4c139bcedc4");
+}
+if (index == 17)
+{
+    Payload = hex2str("1b503fb9a73b16ada3fcf1042623ae7610");
+    Hash = hex2str("d5c30315f72ed05fe519a1bf75ab5fd0ffec5ac1acb0daf66b6b769598594509");
+}
+if (index == 18)
+{
+    Payload = hex2str("59eb45bbbeb054b0b97334d53580ce03f699");
+    Hash = hex2str("32c38c54189f2357e96bd77eb00c2b9c341ebebacc2945f97804f59a93238288");
+}
+if (index == 19)
+{
+    Payload = hex2str("58e5a3259cb0b6d12c83f723379e35fd298b60");
+    Hash = hex2str("9b5b37816de8fcdf3ec10b745428708df8f391c550ea6746b2cafe019c2b6ace");
+}
+if (index == 20)
+{
+    Payload = hex2str("c1ef39cee58e78f6fcdc12e058b7f902acd1a93b");
+    Hash = hex2str("6dd52b0d8b48cc8146cebd0216fbf5f6ef7eeafc0ff2ff9d1422d6345555a142");
+}
+if (index == 21)
+{
+    Payload = hex2str("9cab7d7dcaec98cb3ac6c64dd5d4470d0b103a810c");
+    Hash = hex2str("44d34809fc60d1fcafa7f37b794d1d3a765dd0d23194ebbe340f013f0c39b613");
+}
+if (index == 22)
+{
+    Payload = hex2str("ea157c02ebaf1b22de221b53f2353936d2359d1e1c97");
+    Hash = hex2str("9df5c16a3f580406f07d96149303d8c408869b32053b726cf3defd241e484957");
+}
+if (index == 23)
+{
+    Payload = hex2str("da999bc1f9c7acff32828a73e672d0a492f6ee895c6867");
+    Hash = hex2str("672b54e43f41ee77584bdf8bf854d97b6252c918f7ea2d26bc4097ea53a88f10");
+}
+if (index == 24)
+{
+    Payload = hex2str("47991301156d1d977c0338efbcad41004133aefbca6bcf7e");
+    Hash = hex2str("feeb4b2b59fec8fdb1e55194a493d8c871757b5723675e93d3ac034b380b7fc9");
+}
+if (index == 25)
+{
+    Payload = hex2str("2e7ea84da4bc4d7cfb463e3f2c8647057afff3fbececa1d200");
+    Hash = hex2str("76e3acbc718836f2df8ad2d0d2d76f0cfa5fea0986be918f10bcee730df441b9");
+}
+if (index == 26)
+{
+    Payload = hex2str("47c770eb4549b6eff6381d62e9beb464cd98d341cc1c09981a7a");
+    Hash = hex2str("6733809c73e53666c735b3bd3daf87ebc77c72756150a616a194108d71231272");
+}
+if (index == 27)
+{
+    Payload = hex2str("ac4c26d8b43b8579d8f61c9807026e83e9b586e1159bd43b851937");
+    Hash = hex2str("0e6e3c143c3a5f7f38505ed6adc9b48c18edf6dedf11635f6e8f9ac73c39fe9e");
+}
+if (index == 28)
+{
+    Payload = hex2str("0777fc1e1ca47304c2e265692838109e26aab9e5c4ae4e8600df4b1f");
+    Hash = hex2str("ffb4fc03e054f8ecbc31470fc023bedcd4a406b9dd56c71da1b660dcc4842c65");
+}
+if (index == 29)
+{
+    Payload = hex2str("1a57251c431d4e6c2e06d65246a296915071a531425ecf255989422a66");
+    Hash = hex2str("c644612cd326b38b1c6813b1daded34448805aef317c35f548dfb4a0d74b8106");
+}
+if (index == 30)
+{
+    Payload = hex2str("9b245fdad9baeb890d9c0d0eff816efb4ca138610bc7d78cb1a801ed3273");
+    Hash = hex2str("c0e29eeeb0d3a7707947e623cdc7d1899adc70dd7861205ea5e5813954fb7957");
+}
+if (index == 31)
+{
+    Payload = hex2str("95a765809caf30ada90ad6d61c2b4b30250df0a7ce23b7753c9187f4319ce2");
+    Hash = hex2str("a4139b74b102cf1e2fce229a6cd84c87501f50afa4c80feacf7d8cf5ed94f042");
+}
+if (index == 32)
+{
+    Payload = hex2str("09fc1accc230a205e4a208e64a8f204291f581a12756392da4b8c0cf5ef02b95");
+    Hash = hex2str("4f44c1c7fbebb6f9601829f3897bfd650c56fa07844be76489076356ac1886a4");
+}
+if (index == 33)
+{
+    Payload = hex2str("0546f7b8682b5b95fd32385faf25854cb3f7b40cc8fa229fbd52b16934aab388a7");
+    Hash = hex2str("b31ad3cd02b10db282b3576c059b746fb24ca6f09fef69402dc90ece7421cbb7");
+}
+if (index == 34)
+{
+    Payload = hex2str("b12db4a1025529b3b7b1e45c6dbc7baa8897a0576e66f64bf3f8236113a6276ee77d");
+    Hash = hex2str("1c38bf6bbfd32292d67d1d651fd9d5b623b6ec1e854406223f51d0df46968712");
+}
+if (index == 35)
+{
+    Payload = hex2str("e68cb6d8c1866c0a71e7313f83dc11a5809cf5cfbeed1a587ce9c2c92e022abc1644bb");
+    Hash = hex2str("c2684c0dbb85c232b6da4fb5147dd0624429ec7e657991edd95eda37a587269e");
+}
+if (index == 36)
+{
+    Payload = hex2str("4e3d8ac36d61d9e51480831155b253b37969fe7ef49db3b39926f3a00b69a36774366000");
+    Hash = hex2str("bf9d5e5b5393053f055b380baed7e792ae85ad37c0ada5fd4519542ccc461cf3");
+}
+if (index == 37)
+{
+    Payload = hex2str("03b264be51e4b941864f9b70b4c958f5355aac294b4b87cb037f11f85f07eb57b3f0b89550");
+    Hash = hex2str("d1f8bd684001ac5a4b67bbf79f87de524d2da99ac014dec3e4187728f4557471");
+}
+if (index == 38)
+{
+    Payload = hex2str("d0fefd96787c65ffa7f910d6d0ada63d64d5c4679960e7f06aeb8c70dfef954f8e39efdb629b");
+    Hash = hex2str("49ba38db85c2796f85ffd57dd5ec337007414528ae33935b102d16a6b91ba6c1");
+}
+if (index == 39)
+{
+    Payload = hex2str("b7c79d7e5f1eeccdfedf0e7bf43e730d447e607d8d1489823d09e11201a0b1258039e7bd4875b1");
+    Hash = hex2str("725e6f8d888ebaf908b7692259ab8839c3248edd22ca115bb13e025808654700");
+}
+if (index == 40)
+{
+    Payload = hex2str("64cd363ecce05fdfda2486d011a3db95b5206a19d3054046819dd0d36783955d7e5bf8ba18bf738a");
+    Hash = hex2str("32caef024f84e97c30b4a7b9d04b678b3d8a6eb2259dff5b7f7c011f090845f8");
+}
+if (index == 41)
+{
+    Payload = hex2str("6ac6c63d618eaf00d91c5e2807e83c093912b8e202f78e139703498a79c6067f54497c6127a23910a6");
+    Hash = hex2str("4bb33e7c6916e08a9b3ed6bcef790aaaee0dcf2e7a01afb056182dea2dad7d63");
+}
+if (index == 42)
+{
+    Payload = hex2str("d26826db9baeaa892691b68900b96163208e806a1da077429e454fa011840951a031327e605ab82ecce2");
+    Hash = hex2str("3ac7ac6bed82fdc8cd15b746f0ee7489158192c238f371c1883c9fe90b3e2831");
+}
+if (index == 43)
+{
+    Payload = hex2str("3f7a059b65d6cb0249204aac10b9f1a4ac9e5868adebbe935a9eb5b9019e1c938bfc4e5c5378997a3947f2");
+    Hash = hex2str("bfce809534eefe871273964d32f091fe756c71a7f512ef5f2300bcd57f699e74");
+}
+if (index == 44)
+{
+    Payload = hex2str("60ffcb23d6b88e485b920af81d1083f6291d06ac8ca3a965b85914bc2add40544a027fca936bbde8f359051c");
+    Hash = hex2str("1d26f3e04f89b4eaa9dbed9231bb051eef2e8311ad26fe53d0bf0b821eaf7567");
+}
+if (index == 45)
+{
+    Payload = hex2str("9ecd07b684bb9e0e6692e320cec4510ca79fcdb3a2212c26d90df65db33e692d073cc174840db797504e482eef");
+    Hash = hex2str("0ffeb644a49e787ccc6970fe29705a4f4c2bfcfe7d19741c158333ff6982cc9c");
+}
+if (index == 46)
+{
+    Payload = hex2str("9d64de7161895884e7fa3d6e9eb996e7ebe511b01fe19cd4a6b3322e80aaf52bf6447ed1854e71001f4d54f8931d");
+    Hash = hex2str("d048ee1524014adf9a56e60a388277de194c694cc787fc5a1b554ea9f07abfdf");
+}
+if (index == 47)
+{
+    Payload = hex2str("c4ad3c5e78d917ecb0cbbcd1c481fc2aaf232f7e289779f40e504cc309662ee96fecbd20647ef00e46199fbc482f46");
+    Hash = hex2str("50dbf40066f8d270484ee2ef6632282dfa300a85a8530eceeb0e04275e1c1efd");
+}
+if (index == 48)
+{
+    Payload = hex2str("4eef5107459bddf8f24fc7656fd4896da8711db50400c0164847f692b886ce8d7f4d67395090b3534efd7b0d298da34b");
+    Hash = hex2str("7c5d14ed83dab875ac25ce7feed6ef837d58e79dc601fb3c1fca48d4464e8b83");
+}
+if (index == 49)
+{
+    Payload = hex2str("047d2758e7c2c9623f9bdb93b6597c5e84a0cd34e610014bcb25b49ed05c7e356e98c7a672c3dddcaeb84317ef614d342f");
+    Hash = hex2str("7d53eccd03da37bf58c1962a8f0f708a5c5c447f6a7e9e26137c169d5bdd82e4");
+}
+if (index == 50)
+{
+    Payload = hex2str("3d83df37172c81afd0de115139fbf4390c22e098c5af4c5ab4852406510bc0e6cf741769f44430c5270fdae0cb849d71cbab");
+    Hash = hex2str("99dc772e91ea02d9e421d552d61901016b9fd4ad2df4a8212c1ec5ba13893ab2");
+}
+if (index == 51)
+{
+    Payload = hex2str("33fd9bc17e2b271fa04c6b93c0bdeae98654a7682d31d9b4dab7e6f32cd58f2f148a68fbe7a88c5ab1d88edccddeb30ab21e5e");
+    Hash = hex2str("cefdae1a3d75e792e8698d5e71f177cc761314e9ad5df9602c6e60ae65c4c267");
+}
+if (index == 52)
+{
+    Payload = hex2str("77a879cfa11d7fcac7a8282cc38a43dcf37643cc909837213bd6fd95d956b219a1406cbe73c52cd56c600e55b75bc37ea69641bc");
+    Hash = hex2str("c99d64fa4dadd4bc8a389531c68b4590c6df0b9099c4d583bc00889fb7b98008");
+}
+if (index == 53)
+{
+    Payload = hex2str("45a3e6b86527f20b4537f5af96cfc5ad8777a2dde6cf7511886c5590ece24fc61b226739d207dabfe32ba6efd9ff4cd5db1bd5ead3");
+    Hash = hex2str("4d12a849047c6acd4b2eee6be35fa9051b02d21d50d419543008c1d82c427072");
+}
+if (index == 54)
+{
+    Payload = hex2str("25362a4b9d74bde6128c4fdc672305900947bc3ada9d9d316ebcf1667ad4363189937251f149c72e064a48608d940b7574b17fefc0df");
+    Hash = hex2str("f8e4ccab6c979229f6066cc0cb0cfa81bb21447c16c68773be7e558e9f9d798d");
+}
+if (index == 55)
+{
+    Payload = hex2str("3ebfb06db8c38d5ba037f1363e118550aad94606e26835a01af05078533cc25f2f39573c04b632f62f68c294ab31f2a3e2a1a0d8c2be51");
+    Hash = hex2str("6595a2ef537a69ba8583dfbf7f5bec0ab1f93ce4c8ee1916eff44a93af5749c4");
+}
+if (index == 56)
+{
+    Payload = hex2str("2d52447d1244d2ebc28650e7b05654bad35b3a68eedc7f8515306b496d75f3e73385dd1b002625024b81a02f2fd6dffb6e6d561cb7d0bd7a");
+    Hash = hex2str("cfb88d6faf2de3a69d36195acec2e255e2af2b7d933997f348e09f6ce5758360");
+}
+if (index == 57)
+{
+    Payload = hex2str("4cace422e4a015a75492b3b3bbfbdf3758eaff4fe504b46a26c90dacc119fa9050f603d2b58b398cad6d6d9fa922a154d9e0bc4389968274b0");
+    Hash = hex2str("4d54b2d284a6794581224e08f675541c8feab6eefa3ac1cfe5da4e03e62f72e4");
+}
+if (index == 58)
+{
+    Payload = hex2str("8620b86fbcaace4ff3c2921b8466ddd7bacae07eefef693cf17762dcabb89a84010fc9a0fb76ce1c26593ad637a61253f224d1b14a05addccabe");
+    Hash = hex2str("dba490256c9720c54c612a5bd1ef573cd51dc12b3e7bd8c6db2eabe0aacb846b");
+}
+if (index == 59)
+{
+    Payload = hex2str("d1be3f13febafefc14414d9fb7f693db16dc1ae270c5b647d80da8583587c1ad8cb8cb01824324411ca5ace3ca22e179a4ff4986f3f21190f3d7f3");
+    Hash = hex2str("02804978eba6e1de65afdbc6a6091ed6b1ecee51e8bff40646a251de6678b7ef");
+}
+if (index == 60)
+{
+    Payload = hex2str("f499cc3f6e3cf7c312ffdfba61b1260c37129c1afb391047193367b7b2edeb579253e51d62ba6d911e7b818ccae1553f6146ea780f78e2219f629309");
+    Hash = hex2str("0b66c8b4fefebc8dc7da0bbedc1114f228aa63c37d5c30e91ab500f3eadfcec5");
+}
+if (index == 61)
+{
+    Payload = hex2str("6dd6efd6f6caa63b729aa8186e308bc1bda06307c05a2c0ae5a3684e6e460811748690dc2b58775967cfcc645fd82064b1279fdca771803db9dca0ff53");
+    Hash = hex2str("c464a7bf6d180de4f744bb2fe5dc27a3f681334ffd54a9814650e60260a478e3");
+}
+if (index == 62)
+{
+    Payload = hex2str("6511a2242ddb273178e19a82c57c85cb05a6887ff2014cf1a31cb9ba5df1695aadb25c22b3c5ed51c10d047d256b8e3442842ae4e6c525f8d7a5a944af2a");
+    Hash = hex2str("d6859c0b5a0b66376a24f56b2ab104286ed0078634ba19112ace0d6d60a9c1ae");
+}
+if (index == 63)
+{
+    Payload = hex2str("e2f76e97606a872e317439f1a03fcd92e632e5bd4e7cbc4e97f1afc19a16fde92d77cbe546416b51640cddb92af996534dfd81edb17c4424cf1ac4d75aceeb");
+    Hash = hex2str("18041bd4665083001fba8c5411d2d748e8abbfdcdfd9218cb02b68a78e7d4c23");
+}
+if (index == 64)
+{
+    Payload = hex2str("5a86b737eaea8ee976a0a24da63e7ed7eefad18a101c1211e2b3650c5187c2a8a650547208251f6d4237e661c7bf4c77f335390394c37fa1a9f9be836ac28509");
+    Hash = hex2str("42e61e174fbb3897d6dd6cef3dd2802fe67b331953b06114a65c772859dfc1aa");
+}
+if (index == 65)
+{
+    Payload = hex2str("451101250ec6f26652249d59dc974b7361d571a8101cdfd36aba3b5854d3ae086b5fdd4597721b66e3c0dc5d8c606d9657d0e323283a5217d1f53f2f284f57b85c8a61ac8924711f895c5ed90ef17745ed2d728abd22a5f7a13479a462d71b56c19a74a40b655c58edfe0a188ad2cf46cbf30524f65d423c837dd1ff2bf462ac4198007345bb44dbb7b1c861298cdf61982a833afc728fae1eda2f87aa2c9480858bec");
+    Hash = hex2str("3c593aa539fdcdae516cdf2f15000f6634185c88f505b39775fb9ab137a10aa2");
+}
+if (index == 66)
+{
+    Payload = hex2str("6b918fb1a5ad1f9c5e5dbdf10a93a9c8f6bca89f37e79c9fe12a57227941b173ac79d8d440cde8c64c4ebc84a4c803d198a296f3de060900cc427f58ca6ec373084f95dd6c7c427ecfbf781f68be572a88dbcbb188581ab200bfb99a3a816407e7dd6dd21003554d4f7a99c93ebfce5c302ff0e11f26f83fe669acefb0c1bbb8b1e909bd14aa48ba3445c88b0e1190eef765ad898ab8ca2fe507015f1578f10dce3c11a55fb9434ee6e9ad6cc0fdc4684447a9b3b156b908646360f24fec2d8fa69e2c93db78708fcd2eef743dcb9353819b8d667c48ed54cd436fb1476598c4a1d7028e6f2ff50751db36ab6bc32435152a00abd3d58d9a8770d9a3e52d5a3628ae3c9e0325");
+    Hash = hex2str("46500b6ae1ab40bde097ef168b0f3199049b55545a1588792d39d594f493dca7");
+}
+if (index == 67)
+{
+    Payload = hex2str("82829690aa3733c62b90d3297886952fc1dc473d67bb7d6bb299e088c65fc95ed3ca0f368d111d9fdcc9476cd4065efce7c481be598537f3f53bbbb6ff67973a69837454499e31398b463288e3aafb8b0600fdba1a25af806b83e1425f384e9eac7570f0c823981ba2cd3d868fba94648759623991e30f997c3bfb33d019150f0467a914f1eb79cd8727106dbf7d5310d0975943a6067cc79029b09239511417d922c7c7ac3dfdd8a41c52455b3c5e164b8289e141d820910f17a9668129743d936f7312e1604bc35f73ab164a3fddfe5fe19b1a4a9f237f61cb8eb792e95d099a1455fb789d8d1622f6c5e976cef951737e36f7a9a4ad19ee0d068e53d9f60457d9148d5a3ce85a546b45c5c631d995f11f037e472fe4e81fa7b9f2ac4068b5308858cd6d8586165c9bd6b322afa755408da9b90a87f3735a5f50eb8568daa58ee7cbc59abf8fd2a44e1eba72928816c890d1b0dbf6004208ff7381c697755adac0137cca342b1693");
+    Hash = hex2str("5f4e16a72d6c9857da0ba009ccacd4f26d7f6bf6c1b78a2ed35e68fcb15b8e40");
+}


### PR DESCRIPTION
Adds a helper library for computing SHA256 on the CC32xx hardware.
Adds linux based OpenSSL helper function for SHA256.
Adds test vectors of SHA256.
Updates test suite runners to also run the SHA256 tests as well (both on linux and C32xx).