### PR TITLE
Fix constants override feature for ARM processors.

### DIFF
--- a/src/utils/constants.hxx
+++ b/src/utils/constants.hxx
@@ -94,9 +94,9 @@
 #else  // native C
 
 #define DECLARE_CONST(name)                                                    \
-    EXTERNC extern int _sym_##name;                                            \
+    EXTERNC extern char _sym_##name;                                           \
     EXTERNCEND typedef unsigned char                                           \
-    _do_not_add_declare_and_default_const_to_the_same_file_for_##name;         \
+        _do_not_add_declare_and_default_const_to_the_same_file_for_##name;     \
     static inline ptrdiff_t config_##name(void)                                \
     {                                                                          \
         return (ptrdiff_t)(&_sym_##name);                                      \


### PR DESCRIPTION
Fixes bug in #320 
GCC apparently optimized away some comparisons because it believed that an int typed variable must be aligned.