### PR TITLE
Adds support for inverted banks in CC3220SF SPIFFS.

### DIFF
--- a/src/freertos_drivers/spiffs/cc32x0sf/CC32x0SFSPIFFS.cxx
+++ b/src/freertos_drivers/spiffs/cc32x0sf/CC32x0SFSPIFFS.cxx
@@ -61,13 +61,14 @@ constexpr unsigned minpri = 0x40;
 #define DI() 
 #define EI() 
 
+static unsigned addr_mirror = (HWREG(FLASH_CONF) & FCMME) ? 0x80000 : 0;
 
 #if 1
-#define FPG ROM_FlashProgram
-#define FER ROM_FlashErase
+#define FPG(data, addr, size) ROM_FlashProgram(data, (addr) ^ addr_mirror, size)
+#define FER(addr) ROM_FlashErase((addr) ^ addr_mirror)
 #else
-#define FPG FlashProgram
-#define FER FlashErase
+#define FPG(data, addr, size) FlashProgram(data, (addr) ^ addr_mirror, size)
+#define FER(addr) FlashErase((addr) ^ addr_mirror)
 #endif
 
 //

--- a/src/freertos_drivers/spiffs/cc32x0sf/CC32x0SFSPIFFS.cxx
+++ b/src/freertos_drivers/spiffs/cc32x0sf/CC32x0SFSPIFFS.cxx
@@ -41,13 +41,28 @@
 #include "inc/hw_types.h"
 #include "driverlib/flash.h"
 #include "driverlib/rom.h"
+#include "driverlib/cpu.h"
 
+unsigned ppri;
+constexpr unsigned minpri = 0x40;
+
+//static unsigned lock = 0;
+
+#define FLASH_CONF              0x400FDFC8
+#define FCMME   0x40000000
 //#define DI() asm("cpsid i\n") 
 //#define EI() asm("cpsie i\n")
-#define DI()
-#define EI()
+//#define DI() portENTER_CRITICAL()
+//#define EI() portEXIT_CRITICAL()
+//#define DI() ppri = CPUbasepriGet(); CPUbasepriSet(minpri); HWREG(FLASH_CONF) |=  0x20110000;
+//#define EI() CPUbasepriSet(ppri);
+//#define DI() (void)ppri; (void)::lock; HASSERT(::lock == 0); ::lock = 1;
+//#define EI() ::lock = 0;
+#define DI() 
+#define EI() 
 
-#if 0
+
+#if 1
 #define FPG ROM_FlashProgram
 #define FER ROM_FlashErase
 #else

--- a/src/freertos_drivers/spiffs/cc32x0sf/CC32x0SFSPIFFS.cxx
+++ b/src/freertos_drivers/spiffs/cc32x0sf/CC32x0SFSPIFFS.cxx
@@ -47,19 +47,18 @@
 #include "driverlib/cpu.h"
 
 /// Flash configuration register.
-#define FLASH_CONF              0x400FDFC8
+#define FLASH_CONF 0x400FDFC8
 /// This bit in the FLASH_CONF register means that the banks are reversed by
 /// their address mapping.
-#define FCMME   0x40000000
+#define FCMME 0x40000000
 /// This value defines up to one bit that needs to be XOR-ed to the flash
 /// address before calling the flash APIs to cover for reversed flash banks.
 static const unsigned addr_mirror = (HWREG(FLASH_CONF) & FCMME) ? 0x80000 : 0;
 
-
 // Different options for what to set for flash write locking.
 
 // Global disable interrupts.
-//#define DI() asm("cpsid i\n") 
+//#define DI() asm("cpsid i\n")
 //#define EI() asm("cpsie i\n")
 
 // Critical section (interrupts better than MIN_SYSCALL_PRIORITY are still
@@ -74,8 +73,8 @@ static const unsigned addr_mirror = (HWREG(FLASH_CONF) & FCMME) ? 0x80000 : 0;
 //#define EI() CPUbasepriSet(ppri);
 
 // No write locking.
-#define DI() 
-#define EI() 
+#define DI()
+#define EI()
 
 // This ifdef decides whether we use the ROM or the flash based implementations
 // for Flash write and erase. It also supports correcting for the reversed bank
@@ -180,7 +179,7 @@ int32_t CC32x0SFSPIFFS::flash_write(uint32_t addr, uint32_t size, uint8_t *src)
         }
 
         DI();
-        HASSERT(FPG((unsigned long*)src, addr, size) == 0);
+        HASSERT(FPG((unsigned long *)src, addr, size) == 0);
         EI();
     }
 

--- a/src/freertos_drivers/spiffs/cc32x0sf/CC32x0SFSPIFFS.cxx
+++ b/src/freertos_drivers/spiffs/cc32x0sf/CC32x0SFSPIFFS.cxx
@@ -47,6 +47,14 @@
 #define DI()
 #define EI()
 
+#if 0
+#define FPG ROM_FlashProgram
+#define FER ROM_FlashErase
+#else
+#define FPG FlashProgram
+#define FER FlashErase
+#endif
+
 //
 // CC32x0SFSPIFFS::flash_read()
 //
@@ -84,7 +92,7 @@ int32_t CC32x0SFSPIFFS::flash_write(uint32_t addr, uint32_t size, uint8_t *src)
         memcpy(ww.data + (addr % 4), src, size);
         ww.data_word &= *((uint32_t*)(addr & (~0x3)));
         DI();
-        HASSERT(ROM_FlashProgram(&ww.data_word, addr & (~0x3), 4) == 0);
+        HASSERT(FPG(&ww.data_word, addr & (~0x3), 4) == 0);
         EI();
         LOG(INFO, "Write done1");
         return 0;
@@ -100,7 +108,7 @@ int32_t CC32x0SFSPIFFS::flash_write(uint32_t addr, uint32_t size, uint8_t *src)
         memcpy(&ww.data_word, src + size - misaligned, misaligned);
         ww.data_word &= *((uint32_t*)((addr + size) & (~0x3)));
         DI();
-        HASSERT(ROM_FlashProgram(&ww.data_word, (addr + size) & (~0x3), 4) == 0);
+        HASSERT(FPG(&ww.data_word, (addr + size) & (~0x3), 4) == 0);
         EI();
 
         size -= misaligned;
@@ -116,7 +124,7 @@ int32_t CC32x0SFSPIFFS::flash_write(uint32_t addr, uint32_t size, uint8_t *src)
         memcpy(ww.data + misaligned, src, 4 - misaligned);
         ww.data_word &= *((uint32_t*)(addr & (~0x3)));
         DI();
-        HASSERT(ROM_FlashProgram(&ww.data_word, addr & (~0x3), 4) == 0);
+        HASSERT(FPG(&ww.data_word, addr & (~0x3), 4) == 0);
         EI();
         addr += 4 - misaligned;
         size -= 4 - misaligned;
@@ -139,7 +147,7 @@ int32_t CC32x0SFSPIFFS::flash_write(uint32_t addr, uint32_t size, uint8_t *src)
         }
 
         DI();
-        HASSERT(ROM_FlashProgram((unsigned long*)src, addr, size) == 0);
+        HASSERT(FPG((unsigned long*)src, addr, size) == 0);
         EI();
     }
 
@@ -161,7 +169,7 @@ int32_t CC32x0SFSPIFFS::flash_erase(uint32_t addr, uint32_t size)
     while (size)
     {
         DI();
-        HASSERT(ROM_FlashErase(addr) == 0);
+        HASSERT(FER(addr) == 0);
         EI();
         addr += ERASE_PAGE_SIZE;
         size -= ERASE_PAGE_SIZE;

--- a/src/freertos_drivers/spiffs/cc32x0sf/CC32x0SFSPIFFS.cxx
+++ b/src/freertos_drivers/spiffs/cc32x0sf/CC32x0SFSPIFFS.cxx
@@ -58,19 +58,22 @@ static const unsigned addr_mirror = (HWREG(FLASH_CONF) & FCMME) ? 0x80000 : 0;
 // Different options for what to set for flash write locking.
 
 // Global disable interrupts.
-//#define DI() asm("cpsid i\n")
-//#define EI() asm("cpsie i\n")
+//
+// #define DI() asm("cpsid i\n")
+// #define EI() asm("cpsie i\n")
 
 // Critical section (interrupts better than MIN_SYSCALL_PRIORITY are still
 // running).
-//#define DI() portENTER_CRITICAL()
-//#define EI() portEXIT_CRITICAL()
+//
+// #define DI() portENTER_CRITICAL()
+// #define EI() portEXIT_CRITICAL()
 
 // Disable interrupts with a custom priority limit (must not be zero).
-//unsigned ppri;
-//constexpr unsigned minpri = 0x40;
-//#define DI() ppri = CPUbasepriGet(); CPUbasepriSet(minpri); HWREG(FLASH_CONF) |=  0x20110000;
-//#define EI() CPUbasepriSet(ppri);
+//
+// unsigned ppri;
+// constexpr unsigned minpri = 0x40;
+// #define DI() ppri = CPUbasepriGet(); CPUbasepriSet(minpri); HWREG(FLASH_CONF) |=  0x20110000;
+// #define EI() CPUbasepriSet(ppri);
 
 // No write locking.
 #define DI()

--- a/src/freertos_drivers/spiffs/cc32x0sf/CC32x0SFSPIFFS.cxx
+++ b/src/freertos_drivers/spiffs/cc32x0sf/CC32x0SFSPIFFS.cxx
@@ -55,7 +55,9 @@
 /// address before calling the flash APIs to cover for reversed flash banks.
 static const unsigned addr_mirror = (HWREG(FLASH_CONF) & FCMME) ? 0x80000 : 0;
 
-// Different options for what to set for flash write locking.
+// Different options for what to set for flash write locking. These are only
+// needed to debug when the operating system is misbehaving during flash
+// writes.
 
 // Global disable interrupts.
 //


### PR DESCRIPTION
Adds support for Flash Mirrored Mode to the 3220SF SPIFFS driver. In mirrored mode the upper and lower banks are reversed in address space of the MCU; however, when talking to the flash controller, the original addresses need to be used.
This PR adds code to automatically decide which of the flash mode we are using, assuming that by the time of the static initializers are run the flash controller is reconfigured.

Adds some debug options and workarounds:
- can enable INFO logging of flash operations
- adds custom locking around flash operations, with a few options on what could be used as a lock (e.g. global interrupt disable).
- Adds selectable ROM or Flash based addresses for the actual flash write/erase API calls.