### PR TITLE
Lower default priority for OpenMRN tasks on ESP32

### DIFF
--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -57,11 +57,13 @@ namespace openmrn_arduino {
 /// Default stack size to use for all OpenMRN tasks on the ESP32 platform.
 constexpr uint32_t OPENMRN_STACK_SIZE = 4096L;
 
-/// Default thread priority for any OpenMRN owned tasks on the ESP32
-/// platform. ESP32 hardware CAN RX and TX tasks run at lower priority
-/// (-1 and -2 respectively) of this default priority to ensure timely
-/// consumption of CAN frames from the hardware driver.
-constexpr UBaseType_t OPENMRN_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO;
+/// Default thread priority for any OpenMRN owned tasks on the ESP32 platform.
+/// ESP32 hardware CAN RX and TX tasks run at lower priority (-1 and -2 
+/// respectively) of this default priority to ensure timely consumption of CAN
+/// frames from the hardware driver.
+/// Note: This defaults to one priority level lower than the TCP/IP task uses
+/// on the ESP32.
+constexpr UBaseType_t OPENMRN_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO - 1;
 
 } // namespace openmrn_arduino
 

--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -61,8 +61,8 @@ constexpr uint32_t OPENMRN_STACK_SIZE = 4096L;
 /// ESP32 hardware CAN RX and TX tasks run at lower priority (-1 and -2 
 /// respectively) of this default priority to ensure timely consumption of CAN
 /// frames from the hardware driver.
-/// Note: This defaults to one priority level lower than the TCP/IP task uses
-/// on the ESP32.
+/// Note: This is set to one priority level lower than the TCP/IP task uses on
+/// the ESP32.
 constexpr UBaseType_t OPENMRN_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO - 1;
 
 } // namespace openmrn_arduino

--- a/src/freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx
+++ b/src/freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx
@@ -153,11 +153,11 @@ private:
 
     /// Priority to use for the rx_task. This needs to be higher than the
     /// tx_task and lower than @ref OPENMRN_TASK_PRIORITY.
-    static constexpr UBaseType_t RX_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO - 1;
+    static constexpr UBaseType_t RX_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO - 2;
 
     /// Priority to use for the tx_task. This should be lower than
     /// @ref RX_TASK_PRIORITY and @ref OPENMRN_TASK_PRIORITY.
-    static constexpr UBaseType_t TX_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO - 2;
+    static constexpr UBaseType_t TX_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO - 3;
 
     /// Background task that takes care of the conversion of the @ref can_frame
     /// provided by the @ref txBuf into an ESP32 can_message_t which can be


### PR DESCRIPTION
Lower the default priority of OpenMRN tasks on the ESP32 by one, this is to ensure that none of the OpenMRN tasks block the TCP/IP task from timely execution. Further refinements/documentation of task priorities will be done in a subsequent PR.