### PR TITLE
Fix bug in Buffet bucket initialization

### DIFF
--- a/src/utils/Buffer.cxx
+++ b/src/utils/Buffer.cxx
@@ -40,7 +40,7 @@ Pool* init_main_buffer_pool()
     if (!mainBufferPool)
     {
         mainBufferPool = new DynamicPool(
-            Bucket::init(16, 32, 48, LARGEST_BUFFERPOOL_BUCKET, 0));
+            Bucket::init(32, 48, LARGEST_BUFFERPOOL_BUCKET, 0));
     }
     return mainBufferPool;
 }

--- a/src/utils/Buffer.cxx
+++ b/src/utils/Buffer.cxx
@@ -39,8 +39,8 @@ Pool* init_main_buffer_pool()
 {
     if (!mainBufferPool)
     {
-        mainBufferPool = new DynamicPool(
-            Bucket::init(32, 48, LARGEST_BUFFERPOOL_BUCKET, 0));
+        mainBufferPool =
+            new DynamicPool(Bucket::init(32, 48, LARGEST_BUFFERPOOL_BUCKET, 0));
     }
     return mainBufferPool;
 }

--- a/src/utils/Buffer.hxx
+++ b/src/utils/Buffer.hxx
@@ -142,7 +142,7 @@ protected:
 
     /** number of references in use */
     uint16_t count_;
-    
+
     /** Constructor.  Initializes count to 1 and done_ to NULL.
      * @param size size of buffer data
      * @param pool pool this buffer belong to
@@ -406,7 +406,7 @@ public:
 
         new (now) Bucket(s);
         now++;
-            
+
         for (int i = 1; i < count; ++i)
         {
             new (now) Bucket(va_arg(aq, int));

--- a/src/utils/Buffer.hxx
+++ b/src/utils/Buffer.hxx
@@ -130,11 +130,6 @@ protected:
         return pool_;
     }
 
-    /** size of data in bytes */
-    uint16_t size_;
-
-    /** number of references in use */
-    uint16_t count_;
     /** Reference to the pool from whence this buffer came */
     Pool *pool_;
 
@@ -142,16 +137,22 @@ protected:
     /// everywhere. May be nullptr.
     BarrierNotifiable *done_;
 
+    /** size of data in bytes */
+    uint16_t size_;
+
+    /** number of references in use */
+    uint16_t count_;
+    
     /** Constructor.  Initializes count to 1 and done_ to NULL.
      * @param size size of buffer data
      * @param pool pool this buffer belong to
      */
     BufferBase(size_t size, Pool *pool)
         : QMember()
-        , size_(size)
-        , count_(1)
         , pool_(pool)
         , done_(NULL)
+        , size_(size)
+        , count_(1)
     {
     }
 
@@ -403,7 +404,10 @@ public:
         Bucket *bucket = (Bucket *)malloc(sizeof(Bucket) * count);
         Bucket *now = bucket;
 
-        for (int i = 0; i < count; ++i)
+        new (now) Bucket(s);
+        now++;
+            
+        for (int i = 1; i < count; ++i)
         {
             new (now) Bucket(va_arg(aq, int));
             now++;


### PR DESCRIPTION
Fix bug in Buffet bucket initialization: the first size value was never actually translated into a valid bucket.

After fixing, removes the first bucket from the mainBufferPool because we never used it
in production due to the bug and the utility is questionable given the sizes of the
smallest messages (buffer<struct can_frame>) are already beyond 16 bytes.

nit: rearranges member order in the BufferBase structure to avoid alignment padding in 64-bit systems.