### PR TITLE
Fix race conditions found by thread sanitizer in an example unittest

### DIFF
--- a/src/executor/Executor.hxx
+++ b/src/executor/Executor.hxx
@@ -232,9 +232,9 @@ private:
 
     /** Set to 1 when the executor thread has exited and it is safe to delete
      * *this. */
-    std::atomic_uint_fast8_t done_;
+    std::atomic_uint_least8_t done_;
     /// 1 if the executor is already running
-    std::atomic_uint_fast8_t started_;
+    std::atomic_uint_least8_t started_;
     /// How many executables we schedule blindly before calling a select() in
     /// order to find more data to read/write in the FDs being waited upon.
     unsigned selectPrescaler_ : 5;

--- a/src/executor/Executor.hxx
+++ b/src/executor/Executor.hxx
@@ -37,6 +37,7 @@
 #define _EXECUTOR_EXECUTOR_HXX_
 
 #include <functional>
+#include <atomic>
 
 #include "executor/Executable.hxx"
 #include "executor/Notifiable.hxx"
@@ -231,9 +232,9 @@ private:
 
     /** Set to 1 when the executor thread has exited and it is safe to delete
      * *this. */
-    unsigned done_ : 1;
+    std::atomic_uint_fast8_t done_;
     /// 1 if the executor is already running
-    unsigned started_ : 1;
+    std::atomic_uint_fast8_t started_;
     /// How many executables we schedule blindly before calling a select() in
     /// order to find more data to read/write in the FDs being waited upon.
     unsigned selectPrescaler_ : 5;

--- a/src/executor/Timer.cxx
+++ b/src/executor/Timer.cxx
@@ -68,9 +68,8 @@ ActiveTimers::~ActiveTimers()
 
 void ActiveTimers::notify()
 {
-    if (!isPending_)
+    if (isPending_.exchange(1) == 0)
     {
-        isPending_ = 1;
         executor_->add(this);
     }
 }

--- a/src/executor/Timer.hxx
+++ b/src/executor/Timer.hxx
@@ -120,7 +120,7 @@ private:
     /// List of timers that are scheduled.
     QMember activeTimers_;
     /// 1 if we in the executor's queue.
-    unsigned isPending_ : 1;
+    std::atomic_uint_fast8_t isPending_;
 
     friend class TimerTest;
 

--- a/src/executor/Timer.hxx
+++ b/src/executor/Timer.hxx
@@ -120,7 +120,7 @@ private:
     /// List of timers that are scheduled.
     QMember activeTimers_;
     /// 1 if we in the executor's queue.
-    std::atomic_uint_fast8_t isPending_;
+    std::atomic_uint_least8_t isPending_;
 
     friend class TimerTest;
 

--- a/src/freertos_drivers/common/libatomic.c
+++ b/src/freertos_drivers/common/libatomic.c
@@ -38,12 +38,12 @@
 // On Cortex-M0 the only way to do atomic operation is to disable interrupts.
 
 /// Disables interrupts and saves the interrupt enable flag in a register.
-#define ACQ_LOCK()                                                      \
+#define ACQ_LOCK()                                                             \
     int _pastlock;                                                             \
     __asm volatile(" mrs %0, PRIMASK \n cpsid i\n" : "=r"(_pastlock));
 
 /// Restores the interrupte enable flag from a register.
-#define REL_LOCK() __asm volatile(" msr PRIMASK, %0\n ": : "r"(_pastlock));
+#define REL_LOCK() __asm volatile(" msr PRIMASK, %0\n " : : "r"(_pastlock));
 
 uint16_t __atomic_fetch_sub_2(uint16_t *ptr, uint16_t val, int memorder)
 {

--- a/src/freertos_drivers/common/libatomic.c
+++ b/src/freertos_drivers/common/libatomic.c
@@ -1,0 +1,64 @@
+/** \copyright
+ * Copyright (c) 2019, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file libatomic.c
+ *
+ * A partial implementation of libatomic for Cortex-M0 for the necessary
+ * operations in OpenMRN.
+ *
+ * @author Balazs Racz
+ * @date 30 Dec 2019
+ */
+
+#include <stdint.h>
+
+// On Cortex-M0 the only way to do atomic operation is to disable interrupts.
+
+/// Disables interrupts and saves the interrupt enable flag in a register.
+#define ACQ_LOCK()                                                      \
+    int _pastlock;                                                             \
+    __asm volatile(" mrs %0, PRIMASK \n cpsid i\n" : "=r"(_pastlock));
+
+/// Restores the interrupte enable flag from a register.
+#define REL_LOCK() __asm volatile(" msr PRIMASK, %0\n ": : "r"(_pastlock));
+
+uint16_t __atomic_fetch_sub_2(uint16_t *ptr, uint16_t val, int memorder)
+{
+    ACQ_LOCK();
+    uint16_t ret = *ptr;
+    *ptr -= val;
+    REL_LOCK();
+    return ret;
+}
+
+uint8_t __atomic_exchange_1(uint8_t *ptr, uint8_t val, int memorder)
+{
+    ACQ_LOCK();
+    uint8_t ret = *ptr;
+    *ptr = val;
+    REL_LOCK();
+    return ret;
+}

--- a/src/freertos_drivers/sources
+++ b/src/freertos_drivers/sources
@@ -77,5 +77,7 @@ ifeq ($(TARGET),freertos.armv6m)
 SUBDIRS += drivers_lpc11cxx stm32cubef071xb_2xb stm32cubef091xc
 # Avoids exception handling from operator new.
 CXXSRCS += c++_operators.cxx
+# Implementations for the __atomic_* "builtins" for GCC.
+CSRCS += libatomic.c
 endif
 

--- a/src/openlcb/IfCan.cxxtest
+++ b/src/openlcb/IfCan.cxxtest
@@ -145,6 +145,8 @@ TEST_F(AsyncNodeTest, NodeIdLookupLocal)
     auto b = invoke_flow(&lflow, node_, NodeHandle(0, 0x22A));
     EXPECT_EQ(0, b->data()->resultCode);
     EXPECT_EQ(0x02010d000003U, b->data()->handle.id);
+
+    wait();
 }
 
 TEST_F(AsyncNodeTest, NodeIdLookupRemoteMissing)
@@ -154,6 +156,8 @@ TEST_F(AsyncNodeTest, NodeIdLookupRemoteMissing)
     auto b = invoke_flow(&lflow, node_, NodeHandle(0, 0x882));
     EXPECT_EQ(0x2030, b->data()->resultCode);
     EXPECT_EQ(0u, b->data()->handle.id);
+
+    wait();
 }
 
 TEST_F(AsyncNodeTest, NodeIdLookupRemoteFound)
@@ -164,6 +168,8 @@ TEST_F(AsyncNodeTest, NodeIdLookupRemoteFound)
     auto b = invoke_flow(&lflow, node_, NodeHandle(0, 0x882));
     EXPECT_EQ(0, b->data()->resultCode);
     EXPECT_EQ(0x010203040506u, b->data()->handle.id);
+
+    wait();
 }
 
 TEST_F(AsyncNodeTest, NodeIdLookupRemoteFake)
@@ -174,6 +180,8 @@ TEST_F(AsyncNodeTest, NodeIdLookupRemoteFake)
     auto b = invoke_flow(&lflow, node_, NodeHandle(0, 0x882));
     EXPECT_EQ(0x2030, b->data()->resultCode);
     EXPECT_EQ(0u, b->data()->handle.id);
+
+    wait();
 }
 
 class AsyncMessageCanTests : public AsyncIfTest
@@ -723,6 +731,7 @@ TEST_F(AsyncNodeTest, SendAddressedMessageToNodeCacheMissTimeout)
     ifCan_->addressed_message_write_flow()->send(b);
     // Then a verify node id global.
     expect_packet(":X1949022AN050101FFFFDD;");
+    wait();
     // Then given up.
     wait_for_notification();
 }
@@ -742,6 +751,7 @@ TEST_F(AsyncNodeTest, SendAddressedMessageToNodeCacheMissAMDTimeout)
     ifCan_->addressed_message_write_flow()->send(b);
     wait();
     expect_packet(":X1949022AN050101FFFFDD;");
+    wait();
     usleep(30000);
     wait();
     send_packet_and_expect_response(

--- a/src/utils/Buffer.hxx
+++ b/src/utils/Buffer.hxx
@@ -143,7 +143,7 @@ protected:
     uint16_t size_;
 
     /** number of references in use */
-    std::atomic_uint_fast16_t count_;
+    std::atomic_uint_least16_t count_;
 
     /** Constructor.  Initializes count to 1 and done_ to NULL.
      * @param size size of buffer data

--- a/src/utils/LinkedObject.hxx
+++ b/src/utils/LinkedObject.hxx
@@ -64,7 +64,7 @@ public:
     }
 
 private:
-    std::atomic_uint_fast8_t isInitialized_;
+    std::atomic_uint_least8_t isInitialized_;
     uninitialized<Atomic> atomic_;
 };
 

--- a/src/utils/LinkedObject.hxx
+++ b/src/utils/LinkedObject.hxx
@@ -36,7 +36,37 @@
 #ifndef _UTILS_LINKEDOBJECT_HXX_
 #define _UTILS_LINKEDOBJECT_HXX_
 
+#include <atomic>
+
 #include "utils/Atomic.hxx"
+#include "utils/Uninitialized.hxx"
+
+/// This object encapsulates an Atomic, which never gets destroyed. It is
+/// intended to be used only as static object, because we depend on zero
+/// initialization at construction time.
+class CreateOnlyAtomic
+{
+public:
+    CreateOnlyAtomic()
+    {
+        // Ensures the object gets created at static initialization time while
+        // the program is still single threaded.
+        get();
+    }
+
+    Atomic *get()
+    {
+        if (isInitialized_.exchange(1) == 0)
+        {
+            atomic_.emplace();
+        }
+        return &atomic_.value();
+    }
+
+private:
+    std::atomic_uint_fast8_t isInitialized_;
+    uninitialized<Atomic> atomic_;
+};
 
 /// This static object is factored into a separate namespace because current
 /// GDB crashes when trying to print an object with a static Atomic member
@@ -44,7 +74,7 @@
 template <class T> class LinkedObjectHeadMutex
 {
 public:
-    static Atomic headMu_;
+    static CreateOnlyAtomic headMu_;
 };
 
 /// Using this class as a base class will cause the given class to have all its
@@ -62,7 +92,7 @@ public:
 
     /// Locks the list for modification (at any entry!).
     static Atomic* head_mu() {
-        return &LinkedObjectHeadMutex<T>::headMu_;
+        return LinkedObjectHeadMutex<T>::headMu_.get();
     }
 
 protected:
@@ -107,6 +137,6 @@ protected:
 
 // static
 template <class T> T *LinkedObject<T>::head_{nullptr};
-template <class T> Atomic LinkedObjectHeadMutex<T>::headMu_;
+template <class T> CreateOnlyAtomic LinkedObjectHeadMutex<T>::headMu_;
 
 #endif // _UTILS_LINKEDOBJECT_HXX_

--- a/src/utils/Queue.hxx
+++ b/src/utils/Queue.hxx
@@ -122,9 +122,9 @@ public:
      */
     void insert(QMember *item, unsigned index = 0)
     {
+        AtomicHolder h(this);
         HASSERT(item->next == nullptr);
         HASSERT(item != tail);
-        AtomicHolder h(this);
         if (head == NULL)
         {
             head = tail = item;

--- a/src/utils/async_if_test_helper.hxx
+++ b/src/utils/async_if_test_helper.hxx
@@ -365,7 +365,9 @@ protected:
         wait();
         if (pendingAliasAllocation_)
         {
-            ifCan_->alias_allocator()->TEST_finish_pending_allocation();
+            run_x([this]() {
+                ifCan_->alias_allocator()->TEST_finish_pending_allocation();
+            });
             wait();
         }
     }

--- a/src/utils/test_main.hxx
+++ b/src/utils/test_main.hxx
@@ -255,6 +255,12 @@ public:
     {
     }
 
+    /// Restores the original value.
+    void restore()
+    {
+        holder_.reset();
+    }
+
 private:
     /// Virtual base class for the destructible holders.
     class HolderBase


### PR DESCRIPTION
This PR fixes a number of multi-threading issues, some of which are test-only, while other are serious bugs impacting any application that runs in more than one thread/executor:

- Adds the ability to run the 'cov' target using ThreadSanitizer mode and disabling the coverage reporting. (Coverage reporting creates a lot of false positives for thread sanitizer.)
- Fixes a reported data race in the shutdown() method of the Executor by using atomic integer. This is typically invoked in tests only.
- Fixes a reported data race in the ActivetTimers::notify() method by using atomic integer and cmpxchg.
- Fixes a major bug in the reference counting of buffers by using atomic integers and cmpxchg.
- Fixes a global destructor ordering bug that probably caused the segfaults upon program exit under linux. The issue was that the LinkedObject utility class uses a statically allocated mutex, which, upon static destruction, was deleted. Depending on the destruction order, there were still stateflows that were trying to access this mutex.
- Fixes incorrect ordering of lock and test in Q::insert. This was a race condition but probably harmless.
- Fixes a test destructor bug that accessed the timer object in the wrong thread.
- Fixes a bunch of race conditions relating to the ordering of entering expectations in a unit test.
