### PR TITLE
Adds always logging option.

### DIFF
--- a/etc/linux.x86.mk
+++ b/etc/linux.x86.mk
@@ -31,10 +31,13 @@ ARCHOPTIMIZATION = -g -fdata-sections -ffunction-sections -fPIC
 
 CSHAREDFLAGS = -c $(ARCHOPTIMIZATION) -Wall -Werror -Wno-unknown-pragmas -MD -MP -fno-stack-protector -D_GNU_SOURCE
 
-CFLAGS = $(CSHAREDFLAGS) -std=gnu99
+CFLAGS = $(CSHAREDFLAGS) -std=gnu99 \
+          $(CFLAGSENV) $(CFLAGSEXTRA) \
+
 
 CXXFLAGS = $(CSHAREDFLAGS) -std=c++0x -D__STDC_FORMAT_MACROS \
-           -D__STDC_LIMIT_MACROS #-D__LINEAR_MAP__
+           -D__STDC_LIMIT_MACROS $(CXXFLAGSENV) \
+          $(CXXFLAGSENV) $(CXXFLAGSEXTRA) \
 
 LDFLAGS = $(ARCHOPTIMIZATION) -pg -Wl,-Map="$(@:%=%.map)" -Wl,--undefined=ignore_fn
 

--- a/etc/linux.x86.mk
+++ b/etc/linux.x86.mk
@@ -32,12 +32,12 @@ ARCHOPTIMIZATION = -g -fdata-sections -ffunction-sections -fPIC
 CSHAREDFLAGS = -c $(ARCHOPTIMIZATION) -Wall -Werror -Wno-unknown-pragmas -MD -MP -fno-stack-protector -D_GNU_SOURCE
 
 CFLAGS = $(CSHAREDFLAGS) -std=gnu99 \
-          $(CFLAGSENV) $(CFLAGSEXTRA) \
+         $(CFLAGSENV) $(CFLAGSEXTRA) \
 
 
 CXXFLAGS = $(CSHAREDFLAGS) -std=c++0x -D__STDC_FORMAT_MACROS \
            -D__STDC_LIMIT_MACROS $(CXXFLAGSENV) \
-          $(CXXFLAGSENV) $(CXXFLAGSEXTRA) \
+           $(CXXFLAGSENV) $(CXXFLAGSEXTRA) \
 
 LDFLAGS = $(ARCHOPTIMIZATION) -pg -Wl,-Map="$(@:%=%.map)" -Wl,--undefined=ignore_fn
 

--- a/src/utils/FdUtils.hxx
+++ b/src/utils/FdUtils.hxx
@@ -35,6 +35,7 @@
 #ifndef _UTILS_FD_UTILS_HXX_
 #define _UTILS_FD_UTILS_HXX_
 
+#include "utils/logging.h"
 #include "utils/macros.h"
 
 struct FdUtils

--- a/src/utils/logging.h
+++ b/src/utils/logging.h
@@ -45,6 +45,8 @@
 #include <inttypes.h>
 #include "os/os.h"
 
+/// Loglevel that is always printed.
+static const int ALWAYS = -1;
 /// Loglevel that kills the current process.
 static const int FATAL = 0;
 /// Loglevel that is always printed, reporting an error.


### PR DESCRIPTION
other minor fixes:
- fixes missing include of logging.h in FdUtils.hxx
- Adds the ability to send cflags and cxxflags via the environment or makefile to linux.x86 targets.