### PR TITLE
Adds minimal API to create secure sockets with the CC32xx wifi module.

### DIFF
--- a/src/freertos_drivers/net_cc32xx/CC32xxSocket.cxx
+++ b/src/freertos_drivers/net_cc32xx/CC32xxSocket.cxx
@@ -147,6 +147,9 @@ int CC32xxSocket::socket(int domain, int type, int protocol)
         case IPPROTO_RAW:
             protocol = SL_IPPROTO_RAW;
             break;
+        case CC32xxWiFi::IPPROTO_TCP_TLS:
+            protocol = SL_SEC_SOCKET;
+            break;
         default:
             cc32xxSockets[reserved] = nullptr;
             fd_free(fd);
@@ -669,6 +672,19 @@ int CC32xxSocket::getsockopt(int socket, int level, int option_name,
                 }
             }
             break;
+        case CC32xxWiFi::IPPROTO_TCP_TLS:
+            switch (option_name)
+            {
+                default:
+                    errno = EINVAL;
+                    return -1;
+                case CC32xxWiFi::SO_SIMPLELINK_SD:
+                    int *opt_sd = static_cast<int *>(option_value);
+                    *opt_sd = s->sd;
+                    *option_len = sizeof(int);
+                    result = 0;
+                    break;
+            }
     }
                     
     if (result < 0)

--- a/src/freertos_drivers/net_cc32xx/CC32xxWiFi.cxx
+++ b/src/freertos_drivers/net_cc32xx/CC32xxWiFi.cxx
@@ -1251,6 +1251,11 @@ void CC32xxWiFi::sock_event_handler(SockEvent *event)
             }
             break;
         case SL_SOCKET_ASYNC_EVENT:
+            LOG(ALWAYS, "Socket async event %d, sd %u type %u val %d",
+                (int)event->SocketAsyncEvent.SockAsyncData.Type,
+                (unsigned)event->SocketAsyncEvent.SockAsyncData.Sd,
+                (unsigned)event->SocketAsyncEvent.SockAsyncData.Type,
+                (int)event->SocketAsyncEvent.SockAsyncData.Val);
             switch (event->SocketAsyncEvent.SockAsyncData.Type)
             {
                 default:
@@ -1258,6 +1263,7 @@ void CC32xxWiFi::sock_event_handler(SockEvent *event)
             }
             break;
         default:
+            LOG(ALWAYS, "Socket event %d", (int)event->Event);
             break;
     }
 }

--- a/src/freertos_drivers/net_cc32xx/CC32xxWiFi.hxx
+++ b/src/freertos_drivers/net_cc32xx/CC32xxWiFi.hxx
@@ -96,6 +96,12 @@ public:
      * 0 to NUM_PROFILES-1.*/
     static constexpr int NUM_PROFILES = 7;
 
+    /** Pass this option as protocol to ::socket to create a secure socket. */
+    static constexpr unsigned IPPROTO_TCP_TLS = 254;
+
+    /** Retrieves the socket descriptor for setting TLS parameters. */
+    static constexpr unsigned SO_SIMPLELINK_SD = 65537;
+    
     /** CC32xx SimpleLink forward declaration */
     struct WlanEvent;
 


### PR DESCRIPTION
At this point achieving it requires a combination of the new BSD codes
and using the simplelink API directly. This is the same as how the TI_RTOS's BSD
API solves the same problem.