### PR TITLE
Handle delay in initialization of FreeRTOSTCP task

### DIFF
--- a/etc/path.mk
+++ b/etc/path.mk
@@ -220,6 +220,7 @@ SEARCHPATH := \
   /opt/FreeRTOSPlus/TCP \
   /opt/FreeRTOSPlus/default/TCP \
   /opt/FreeRTOS/plus-tcp \
+  /opt/FreeRTOS-Plus/default/Source/FreeRTOS-Plus-TCP \
   $(HOME)/FreeRTOSPlus/Source/FreeRTOS-Plus-TCP \
   /d/FreeRTOSPlus/default/TCP \
 


### PR DESCRIPTION
Fixes an issue where calls to FreeRTOS_socket would fail should the FreeRTOSTCP task not have completed initialization.

Adds another location for finding the FreeRTOSTCP source to path.mk