### PR TITLE
Openmrnlite missing newline

### DIFF
--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -463,7 +463,7 @@ public:
         ConfigDef cfg(config.offset());
         cfg.config_renderer().render_cdi(&cdi_string);
         
-        cdi_string += '\n';   // Add missing but needed newline  RPH
+        cdi_string += '\0';   // Add missing but needed NUL (EOS)  RPH
 
         bool need_write = false;
         FILE *ff = fopen(filename, "rb");

--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -463,7 +463,7 @@ public:
         ConfigDef cfg(config.offset());
         cfg.config_renderer().render_cdi(&cdi_string);
         
-        cdi_string += '\0';   // Add missing but needed NUL (EOS)  RPH
+        cdi_string += '\0';
 
         bool need_write = false;
         FILE *ff = fopen(filename, "rb");

--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -462,6 +462,8 @@ public:
         string cdi_string;
         ConfigDef cfg(config.offset());
         cfg.config_renderer().render_cdi(&cdi_string);
+        
+        cdi_string += '\n';   // Add missing but needed newline  RPH
 
         bool need_write = false;
         FILE *ff = fopen(filename, "rb");


### PR DESCRIPTION
This just adds the missing but needed NUL (EOS) in OpenMRNLite.h.  The spec for CDI strings requires this byte.