### PR TITLE
Fixes assertion when starting an emscripten binary.

### DIFF
--- a/applications/js_hub/targets/js.emscripten/Makefile
+++ b/applications/js_hub/targets/js.emscripten/Makefile
@@ -1,3 +1,3 @@
 -include ../../config.mk
 include $(OPENMRNPATH)/etc/prog.mk
-LDFLAGS += --bind
+LDFLAGS += --bind -s DEMANGLE_SUPPORT=1

--- a/src/executor/Executor.cxx
+++ b/src/executor/Executor.cxx
@@ -223,6 +223,7 @@ void *ExecutorBase::entry()
     started_ = 1;
     sequence_ = 0;
     ExecutorBase* b = this;
+    unlock_from_thread();
     emscripten_set_main_loop_arg(&executor_loop_some, b, 100, true);
     return nullptr;
 }


### PR DESCRIPTION
we were causing assertions on the lock_to_thread call because this was effectively nested due to the JS exception based stack unroll that the emscripten main loop does.