### PR TITLE
Exclude node_modules directories from doxygen generation.

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -850,7 +850,8 @@ EXCLUDE_PATTERNS       = */applications/*.cxx \
                        */boards/*.hxx \
                        */boards/*.c \
                        */boards/*.h \                       
-                       */*.d
+                       */*.d \
+                       */node_modules/* \
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
These are installed by npm into the application target directories if someone uses a javascript compiled application.