### PR TITLE
gc_format fixes

### DIFF
--- a/src/utils/gc_format.cxx
+++ b/src/utils/gc_format.cxx
@@ -82,6 +82,11 @@ static int ascii_to_nibble(const char c)
 int gc_format_parse(const char* buf, struct can_frame* can_frame)
 {
     CLR_CAN_FRAME_ERR(*can_frame);
+    if (*buf == ':')
+    {
+        // skip leading :
+        ++buf;
+    }
     if (*buf == 'X')
     {
         SET_CAN_FRAME_EFF(*can_frame);
@@ -136,7 +141,7 @@ int gc_format_parse(const char* buf, struct can_frame* can_frame)
         SET_CAN_FRAME_ID(*can_frame, id);
     }
     int index = 0;
-    while (*buf)
+    while ((*buf != 0) && (*buf != ';'))
     {
         int nh = ascii_to_nibble(*buf++);
         int nl = ascii_to_nibble(*buf++);
@@ -242,7 +247,7 @@ char* gc_format_generate(const struct can_frame* can_frame, char* buf, int doubl
         output(buf, nibble_to_ascii(can_frame->data[offset] & 0xf));
     }
     output(buf, ';');
-    if (config_gc_generate_newlines()) {
+    if (config_gc_generate_newlines() == CONSTANT_TRUE) {
         output(buf, '\n');
     }
     return buf;

--- a/src/utils/gc_format.cxxtest
+++ b/src/utils/gc_format.cxxtest
@@ -82,6 +82,17 @@ TEST(GCParseTest, ExtFrameWithData) {
   }
 }
 
+TEST(GCParseTest, FullFormat) {
+  struct can_frame frame;
+  ASSERT_EQ(0, gc_format_parse(":X195B4576NF0F1F2F3F4F5F6F7;", &frame));
+  EXPECT_TRUE(IS_CAN_FRAME_EFF(frame));
+  EXPECT_EQ(0x195b4576UL, GET_CAN_FRAME_ID_EFF(frame));
+  EXPECT_EQ(8, frame.can_dlc);
+  for (int i = 0; i < 8; i++) {
+    EXPECT_EQ(0xf0 | i, frame.data[i]);
+  }
+}
+
 TEST(GCParseTest, ExtFrameWithNoData) {
   struct can_frame frame;
   ASSERT_EQ(0, gc_format_parse("X195B4576N", &frame));


### PR DESCRIPTION
- Adds support for parsing an entire gridconnect packet including leading : and trailing ;.
- Fixes constant override for generate newlines.