### PR TITLE
STM32 Arduino fixes.

### DIFF
--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -146,7 +146,7 @@ private:
         auto *b = txtHub_.alloc();
         b->data()->skipMember_ = &writePort_;
         b->data()->resize(av);
-        port_->read(b->data()->data(), b->data()->size());
+        port_->readBytes((uint8_t*)b->data()->data(), b->data()->size());
         txtHub_.send(b);
     }
 

--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -124,7 +124,7 @@ private:
         size_t to_write = writeBuffer_->data()->size() - writeOfs_;
         if (len > to_write)
             len = to_write;
-        port_->write(writeBuffer_->data()->data() + writeOfs_, len);
+        port_->write((const uint8_t*)writeBuffer_->data()->data() + writeOfs_, len);
         writeOfs_ += len;
         if (writeOfs_ >= writeBuffer_->data()->size())
         {
@@ -146,7 +146,7 @@ private:
         auto *b = txtHub_.alloc();
         b->data()->skipMember_ = &writePort_;
         b->data()->resize(av);
-        port_->readBytes((uint8_t*)b->data()->data(), b->data()->size());
+        port_->readBytes((char*)b->data()->data(), b->data()->size());
         txtHub_.send(b);
     }
 

--- a/arduino/examples/ESP32SerialBridge/ESP32SerialBridge.ino
+++ b/arduino/examples/ESP32SerialBridge/ESP32SerialBridge.ino
@@ -161,7 +161,7 @@ void setup() {
 #endif // PRINT_PACKETS
 
     // Add Serial1 as a bridge
-    openmrn.add_gridconnect_port(new Esp32HardwareSerialAdapter(Serial1));
+    openmrn.add_gridconnect_port(&Serial1);
 
     // Add the hardware CAN device as a bridge
     openmrn.add_can_port(

--- a/arduino/libify.sh
+++ b/arduino/libify.sh
@@ -169,6 +169,9 @@ copy_file src/freertos_drivers/arduino \
 copy_file src/freertos_drivers/esp32 \
           src/freertos_drivers/esp32/*
 
+copy_file src/freertos_drivers/stm32 \
+          src/freertos_drivers/st/Stm32Can.*
+
 copy_file src/os src/os/*.h src/os/*.c src/os/*.hxx \
           src/os/{OSImpl,MDNS,OSSelectWakeup}.cxx
 

--- a/arduino/libify.sh
+++ b/arduino/libify.sh
@@ -156,8 +156,6 @@ copy_file src/openlcb src/openlcb/*.hxx src/openlcb/*.cxx
 rm -f ${TARGET_LIB_DIR}/src/openlcb/CompileCdiMain.cxx \
     ${TARGET_LIB_DIR}/src/openlcb/Stream.cxx \
     ${TARGET_LIB_DIR}/src/openlcb/Stream.hxx \
-    ${TARGET_LIB_DIR}/src/openlcb/IfTcp.cxx \
-    ${TARGET_LIB_DIR}/src/utils/HubDeviceSelect.cxx \
 
 copy_file src/freertos_drivers/arduino \
           src/freertos_drivers/common/DeviceBuffer.{hxx,cxx} \

--- a/arduino/libify.sh
+++ b/arduino/libify.sh
@@ -155,7 +155,7 @@ copy_file src/openlcb src/openlcb/*.hxx src/openlcb/*.cxx
 
 rm -f ${TARGET_LIB_DIR}/src/openlcb/CompileCdiMain.cxx \
     ${TARGET_LIB_DIR}/src/openlcb/Stream.cxx \
-    ${TARGET_LIB_DIR}/src/openlcb/Stream.hxx \
+    ${TARGET_LIB_DIR}/src/openlcb/Stream.hxx
 
 copy_file src/freertos_drivers/arduino \
           src/freertos_drivers/common/DeviceBuffer.{hxx,cxx} \

--- a/arduino/libify.sh
+++ b/arduino/libify.sh
@@ -155,7 +155,9 @@ copy_file src/openlcb src/openlcb/*.hxx src/openlcb/*.cxx
 
 rm -f ${TARGET_LIB_DIR}/src/openlcb/CompileCdiMain.cxx \
     ${TARGET_LIB_DIR}/src/openlcb/Stream.cxx \
-    ${TARGET_LIB_DIR}/src/openlcb/Stream.hxx
+    ${TARGET_LIB_DIR}/src/openlcb/Stream.hxx \
+    ${TARGET_LIB_DIR}/src/openlcb/IfTcp.cxx \
+    ${TARGET_LIB_DIR}/src/utils/HubDeviceSelect.cxx \
 
 copy_file src/freertos_drivers/arduino \
           src/freertos_drivers/common/DeviceBuffer.{hxx,cxx} \

--- a/src/freertos_drivers/common/CpuLoad.cxx
+++ b/src/freertos_drivers/common/CpuLoad.cxx
@@ -31,9 +31,10 @@
  * @date 30 August 2015
  */
 
-#ifdef __FreeRTOS__
 
 #include "CpuLoad.hxx"
+
+#ifdef OPENMRN_FEATURE_THREAD_FREERTOS
 
 #include "os/os.h"
 #include "freertos_includes.h"
@@ -145,4 +146,4 @@ void cpuload_tick(unsigned irq)
 
 DEFINE_SINGLETON_INSTANCE(CpuLoad);
 
-#endif // __FreeRTOS__
+#endif // OPENMRN_FEATURE_THREAD_FREERTOS

--- a/src/freertos_drivers/common/CpuLoad.cxx
+++ b/src/freertos_drivers/common/CpuLoad.cxx
@@ -31,6 +31,8 @@
  * @date 30 August 2015
  */
 
+#ifdef __FreeRTOS__
+
 #include "CpuLoad.hxx"
 
 #include "os/os.h"
@@ -142,3 +144,5 @@ void cpuload_tick(unsigned irq)
 }
 
 DEFINE_SINGLETON_INSTANCE(CpuLoad);
+
+#endif // __FreeRTOS__

--- a/src/freertos_drivers/common/CpuLoad.hxx
+++ b/src/freertos_drivers/common/CpuLoad.hxx
@@ -31,6 +31,8 @@
  * @date 30 August 2015
  */
 
+#ifdef __FreeRTOS__
+
 #ifndef _OS_CPULOAD_HXX_
 #define _OS_CPULOAD_HXX_
 
@@ -253,3 +255,4 @@ private:
 };
 
 #endif // _OS_CPULOAD_HXX_
+#endif // __FreeRTOS__

--- a/src/freertos_drivers/common/CpuLoad.hxx
+++ b/src/freertos_drivers/common/CpuLoad.hxx
@@ -31,7 +31,9 @@
  * @date 30 August 2015
  */
 
-#ifdef __FreeRTOS__
+#include "openmrn_features.h"
+
+#ifdef OPENMRN_FEATURE_THREAD_FREERTOS
 
 #ifndef _OS_CPULOAD_HXX_
 #define _OS_CPULOAD_HXX_
@@ -255,4 +257,4 @@ private:
 };
 
 #endif // _OS_CPULOAD_HXX_
-#endif // __FreeRTOS__
+#endif // OPENMRN_FEATURE_THREAD_FREERTOS

--- a/src/freertos_drivers/st/Stm32Can.cxx
+++ b/src/freertos_drivers/st/Stm32Can.cxx
@@ -31,6 +31,8 @@
  * @date 3 May 2015
  */
 
+#if (!defined(ARDUINO)) || defined(ARDUINO_ARCH_STM32)
+
 #include "Stm32Can.hxx"
 
 #include <stdint.h>
@@ -444,8 +446,9 @@ void can1_rx0_interrupt_handler(void)
 
 } // extern "C"
 
+#endif // !ARDUINO || STM32
 
-#ifdef ARDUINO
+#if defined(ARDUINO_ARCH_STM32)
 
 #include "stm32_def.h"
 #include "PinAF_STM32F1.h"
@@ -500,3 +503,4 @@ void USB_LP_CAN_RX0_IRQHandler(void)
 } // extern "C"
 
 #endif
+

--- a/src/freertos_drivers/st/Stm32Can.hxx
+++ b/src/freertos_drivers/st/Stm32Can.hxx
@@ -36,7 +36,12 @@
 
 #include <cstdint>
 
+#ifdef ARDUINO
+#include <Arduino.h>
+#include "freertos_drivers/arduino/Can.hxx"
+#else
 #include "freertos_drivers/common/Can.hxx"
+#endif
 
 #if defined(STM32F072xB) || defined(STM32F091xC) 
 #include "stm32f0xx_hal_can.h"

--- a/src/openlcb/IfTcp.cxx
+++ b/src/openlcb/IfTcp.cxx
@@ -32,6 +32,12 @@
  * @date 16 Apr 2017
  */
 
+#include "openmrn_features.h"
+
+// Only compile this if we can use select based reads in the
+// executor. TcpHubDeviceSelect is an integral part of this implementation.
+#ifdef OPENMRN_FEATURE_EXECUTOR_SELECT
+
 #include "openlcb/IfTcp.hxx"
 #include "openlcb/IfImpl.hxx"
 #include "openlcb/IfTcpImpl.hxx"
@@ -205,3 +211,5 @@ IfTcp::~IfTcp()
 }
 
 } // namespace openlcb
+
+#endif // OPENMRN_FEATURE_EXECUTOR_SELECT

--- a/src/os/OSSelectWakeup.hxx
+++ b/src/os/OSSelectWakeup.hxx
@@ -231,6 +231,9 @@ public:
             ::select(nfds, readfds, writefds, exceptfds, &timeout);
 #elif !defined(OPENMRN_FEATURE_SINGLE_THREADED)
         #error no select implementation in multi threaded OS.
+#else
+        // Single threaded OS: nothing to wake up.
+        int ret = 0;
 #endif
         {
             AtomicHolder l(this);

--- a/src/os/os.c
+++ b/src/os/os.c
@@ -918,7 +918,7 @@ int ignore_fn(void)
     return 0;
 }
 
-#if !defined(ARDUINO)
+#if !defined(ARDUINO) && !defined(ESP32)
 
 #if !defined (__MINGW32__)
 int main(int argc, char *argv[]) __attribute__ ((weak));

--- a/src/os/os.c
+++ b/src/os/os.c
@@ -918,7 +918,7 @@ int ignore_fn(void)
     return 0;
 }
 
-#if !defined(ESP32)
+#if !defined(ARDUINO)
 
 #if !defined (__MINGW32__)
 int main(int argc, char *argv[]) __attribute__ ((weak));

--- a/src/utils/HubDeviceSelect.hxx
+++ b/src/utils/HubDeviceSelect.hxx
@@ -36,9 +36,9 @@
 
 #include "openmrn_features.h"
 
-#ifndef OPENMRN_FEATURE_EXECUTOR_SELECT
-#error OS does not have implementation for Executor::select, cannot compile HubDeviceSelect.
-#endif
+// Only compile HubDeviceSelect if the OS has implementation for
+// Executor::select.
+#ifdef OPENMRN_FEATURE_EXECUTOR_SELECT
 
 #include <unistd.h>
 #include <stdio.h>
@@ -457,5 +457,8 @@ protected:
     /// being writeable.
     WriteFlow writeFlow_;
 };
+
+#endif // FEATURE_EXECUTOR_SELECT
+
 
 #endif // _UTILS_HUBDEVICESELECT_HXX_


### PR DESCRIPTION
- Upgrade Arduino API to be build compatible with ESP32 1.0.4 and STM32 1.8.0.
- Fixes breakages of STM32.
- Updates Serial bridge to be compatible with current HardwareSerial API for both STM32 and ESP32.
- blacklists some modules that do not compile under single-threaded environment.
- adds STM32Can to be exported via libify.
- Adds a guard around CpuLoad to be only compiled under freertos (esp-arduino or openmrn native), and Stm32Can to only be compiled for openmrn-native or arduino-stm32.
