### PR TITLE
ESP32: WiFi update based on comments

### DIFF
--- a/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
@@ -1084,14 +1084,15 @@ size_t Esp32WiFiManager::get_ssid_scan_result_count()
 }
 
 // Returns one SSID record from the last scan.
-const wifi_ap_record_t& Esp32WiFiManager::get_ssid_scan_result(size_t index)
+wifi_ap_record_t Esp32WiFiManager::get_ssid_scan_result(size_t index)
 {
     OSMutexLock l(&ssidScanResultsLock_);
+    wifi_ap_record_t record = wifi_ap_record_t();
     if (index < ssidScanResults_.size())
     {
-        return ssidScanResults_[index];
+        record = ssidScanResults_[index];
     }
-    return defaultApRecord_;
+    return record;
 }
 
 // Clears all cached SSID scan results.

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
@@ -204,7 +204,7 @@ public:
     ///
     /// @param index is the index of the SSID to retrieve. If the index is
     /// invalid or no records exist a blank wifi_ap_record_t will be returned.
-    const wifi_ap_record_t& get_ssid_scan_result(size_t index);
+    wifi_ap_record_t get_ssid_scan_result(size_t index);
 
     /// Clears the SSID scan results.
     void clear_ssid_scan_results();
@@ -355,10 +355,6 @@ private:
 
     /// WiFi SSID scan results holder.
     std::vector<wifi_ap_record_t> ssidScanResults_;
-
-    /// Default SSID record to return when there are no records or the index
-    /// provided to @ref get_ssid_scan_result is invalid.
-    const wifi_ap_record_t defaultApRecord_{};
 
     /// Protects ssidScanResults_ vector.
     OSMutex ssidScanResultsLock_;


### PR DESCRIPTION
This PR switches from returning a reference to the SSID vector element to instead return a copy of the element.