### PR TITLE
Fixes a major priority computation bug in stm32 uart driver.

### DIFF
--- a/src/freertos_drivers/st/Stm32Uart.cxx
+++ b/src/freertos_drivers/st/Stm32Uart.cxx
@@ -151,8 +151,8 @@ Stm32Uart::Stm32Uart(const char *name, USART_TypeDef *base, IRQn_Type interrupt)
 #if defined(GCC_ARMCM0)    
     HAL_NVIC_SetPriority(interrupt, 3, 0);
 #elif defined(GCC_ARMCM3)    
-    // Below kernel interrupt priority.
-    NVIC_SetPriority(interrupt, configKERNEL_INTERRUPT_PRIORITY + 0x20);
+    // Below kernel-compatible interrupt priority.
+    NVIC_SetPriority(interrupt, configMAX_SYSCALL_INTERRUPT_PRIORITY + 0x20);
 #else
 #error not defined how to set interrupt priority
 #endif    


### PR DESCRIPTION
KERNEL_INTERRUPT_PRIORITY is 255, so K_I_P + 0x20 is not a valid interrupt priority.