### PR TITLE
stm32-dcc-decoder bugfixes

### DIFF
--- a/src/freertos_drivers/common/DccDecoder.hxx
+++ b/src/freertos_drivers/common/DccDecoder.hxx
@@ -220,12 +220,15 @@ private:
     /// DCC packet decoder state machine and internal state.
     dcc::DccDecoder decoder_ {Module::get_ticks_per_usec()};
 
-    /// How many usec the railcom has before the cutout
+    /// How many usec the railcom has before the cutout (measured from the
+    /// packet end 1 bit complete)
     static const auto RAILCOM_CUTOUT_PRE = 26;
-    /// How many usec the railcom has to the middle of window
-    static const auto RAILCOM_CUTOUT_MID = 173;
-    /// How many usec the railcom has to the end of the window
-    static const auto RAILCOM_CUTOUT_END = 470;
+    /// How many usec the railcom has to the middle of window (measured from the
+    /// packet end 1 bit complete)
+    static const auto RAILCOM_CUTOUT_MID = 185;
+    /// How many usec the railcom has to the end of the window (measured from
+    /// the packet end 1 bit complete)
+    static const auto RAILCOM_CUTOUT_END = 471;
 
     DISALLOW_COPY_AND_ASSIGN(DccDecoder);
 };

--- a/src/freertos_drivers/common/DccDecoder.hxx
+++ b/src/freertos_drivers/common/DccDecoder.hxx
@@ -392,8 +392,8 @@ DccDecoder<Module>::rcom_interrupt_handler()
             }
             default:
             {
-                Module::set_cap_timer_delay_usec(RAILCOM_CUTOUT_END);
                 Module::stop_cap_timer_time();
+                Module::set_cap_timer_capture();
                 railcomDriver_->end_cutout();
                 inCutout_ = false;
                 break;

--- a/src/freertos_drivers/st/Stm32DCCDecoder.hxx
+++ b/src/freertos_drivers/st/Stm32DCCDecoder.hxx
@@ -216,17 +216,9 @@ public:
     /// signal bits.
     static void set_cap_timer_capture()
     {
-        TIM_IC_InitTypeDef channel_init;
-        memset(&channel_init, 0, sizeof(channel_init));
-        channel_init.ICPolarity = TIM_ICPOLARITY_BOTHEDGE;
-        channel_init.ICSelection = TIM_ICSELECTION_DIRECTTI;
-        channel_init.ICPrescaler = TIM_ICPSC_DIV1;
-        channel_init.ICFilter = HW::CAPTURE_FILTER;
-        HASSERT(HAL_TIM_IC_ConfigChannel(capture_timer_handle(), &channel_init,
-                    HW::CAPTURE_CHANNEL) == HAL_OK);
-
-        HASSERT(HAL_TIM_IC_Start_IT(
-                    capture_timer_handle(), HW::CAPTURE_CHANNEL) == HAL_OK);
+        __HAL_TIM_CLEAR_IT(capture_timer_handle(), HW::CAPTURE_IF);
+        /// @todo consider clearing the overflow flag as well.
+        __HAL_TIM_ENABLE_IT(capture_timer_handle(), HW::CAPTURE_IF);
     }
 
     /// Sets the timer to oneshot (timer) mode. Called once, then
@@ -239,24 +231,8 @@ public:
         } else {
             usecTimerStart_ =  __HAL_TIM_GET_COUNTER(usec_timer_handle());
         }
-        TIM_OC_InitTypeDef channel_init;
-        memset(&channel_init, 0, sizeof(channel_init));
-        channel_init.OCMode = TIM_OCMODE_TIMING; // frozen -- no output
-        channel_init.Pulse = (__HAL_TIM_GET_COUNTER(usec_timer_handle()) + 1) &
-            0xffff; // will be reloaded in the delay_usec function.
-        // the rest are irrelevant.
-        channel_init.OCPolarity = TIM_OCPOLARITY_HIGH;
-        channel_init.OCNPolarity = TIM_OCNPOLARITY_HIGH;
-        channel_init.OCFastMode = TIM_OCFAST_DISABLE;
-        channel_init.OCIdleState = TIM_OCIDLESTATE_RESET;
-        channel_init.OCNIdleState = TIM_OCNIDLESTATE_RESET;
-        HASSERT(HAL_TIM_OC_ConfigChannel(usec_timer_handle(), &channel_init,
-                    HW::USEC_CHANNEL) == HAL_OK);
-
-        HASSERT(HAL_TIM_OC_Start_IT(usec_timer_handle(), HW::USEC_CHANNEL) ==
-            HAL_OK);
-        // Disable interrupt until the delay_usec() is called.
-        __HAL_TIM_DISABLE_IT(usec_timer_handle(), HW::USEC_IF);
+        /// @TODO __HAL_TIM_DISABLE_IT(capture_timer_handle(), HW::CAPTURE_IF);
+        // channel setup already happened in module_enable.
     }
 
     /// Called once inline in an interrupt. Signals that the delay timer is not
@@ -264,7 +240,7 @@ public:
     static void stop_cap_timer_time()
     {
         __HAL_TIM_DISABLE_IT(usec_timer_handle(), HW::USEC_IF);
-        TIM_CCxChannelCmd(usec_timer(), HW::USEC_CHANNEL, TIM_CCx_DISABLE);
+        //TIM_CCxChannelCmd(usec_timer(), HW::USEC_CHANNEL, TIM_CCx_DISABLE);
     }
 
 private:
@@ -369,6 +345,45 @@ template <class HW> void Stm32DccTimerModule<HW>::module_enable()
     {
         init_timer(usec_timer_handle(), usec_timer());
     }
+
+    // Set up capture channel.
+    {
+        TIM_IC_InitTypeDef channel_init;
+        memset(&channel_init, 0, sizeof(channel_init));
+        channel_init.ICPolarity = TIM_ICPOLARITY_BOTHEDGE;
+        channel_init.ICSelection = TIM_ICSELECTION_DIRECTTI;
+        channel_init.ICPrescaler = TIM_ICPSC_DIV1;
+        channel_init.ICFilter = HW::CAPTURE_FILTER;
+        HASSERT(HAL_TIM_IC_ConfigChannel(capture_timer_handle(), &channel_init,
+                    HW::CAPTURE_CHANNEL) == HAL_OK);
+    }
+
+    HASSERT(HAL_TIM_IC_Start_IT(capture_timer_handle(), HW::CAPTURE_CHANNEL) ==
+        HAL_OK);
+    // Disable interrupt until the set_cap_timer_capture() is called.
+    __HAL_TIM_DISABLE_IT(capture_timer_handle(), HW::CAPTURE_IF);
+
+    // Set up timing channel
+    {
+        TIM_OC_InitTypeDef channel_init;
+        memset(&channel_init, 0, sizeof(channel_init));
+        channel_init.OCMode = TIM_OCMODE_TIMING; // frozen -- no output
+        channel_init.Pulse = (__HAL_TIM_GET_COUNTER(usec_timer_handle()) + 1) &
+            0xffff; // will be reloaded in the delay_usec function.
+        // the rest are irrelevant.
+        channel_init.OCPolarity = TIM_OCPOLARITY_HIGH;
+        channel_init.OCNPolarity = TIM_OCNPOLARITY_HIGH;
+        channel_init.OCFastMode = TIM_OCFAST_DISABLE;
+        channel_init.OCIdleState = TIM_OCIDLESTATE_RESET;
+        channel_init.OCNIdleState = TIM_OCNIDLESTATE_RESET;
+        HASSERT(HAL_TIM_OC_ConfigChannel(usec_timer_handle(), &channel_init,
+                    HW::USEC_CHANNEL) == HAL_OK);
+    }
+
+    HASSERT(
+        HAL_TIM_OC_Start_IT(usec_timer_handle(), HW::USEC_CHANNEL) == HAL_OK);
+    // Disable interrupt until the delay_usec() is called.
+    __HAL_TIM_DISABLE_IT(usec_timer_handle(), HW::USEC_IF);
 
 #if defined(GCC_ARMCM0)
     HAL_NVIC_SetPriority(HW::CAPTURE_IRQn, 0, 0);


### PR DESCRIPTION
- Fixes DCC cutout timing as generated by the dcc decoder based on the standard text.
- Clarifies documentation comment on timing values and API.
- Ensures that we set back the timer to capture mode after the end of the railcom cutout in the shared driver.
- Fixes incorrect interpretation of the usec delay on STM32.
- Performance improvement of the DCC cutout start/stop interrupt on STM32.