### PR TITLE
Adds CDI_READ_TRIM_DEFAULT.

### DIFF
--- a/src/openlcb/ConfigEntry.hxx
+++ b/src/openlcb/ConfigEntry.hxx
@@ -284,7 +284,27 @@ public:
         }
         return value;
     }
-    
+
+    /// Reads data from configuration file if the value is valid. If the
+    /// value violates the trimming constraints, the configuration file will be
+    /// overwritten with the default value.
+    ///
+    /// @param fd the descriptor of the config file.
+    /// @param min_value minimum acceptable value
+    /// @param max_value maximum acceptable value
+    /// @param def_value default value to write when out of range
+    /// @return current value after trimming.
+    TR read_or_write_default(int fd, TR min_value, TR max_value, TR def_value)
+    {
+        TR value = read(fd);
+        if (value < min_value || value > max_value)
+        {
+            value = def_value;
+            write(fd, value);
+        }
+        return value;
+    }
+
     /// Writes the data to the configuration file.
     ///
     /// @param fd file descriptor of the config file.

--- a/src/openlcb/ConfigRepresentation.hxx
+++ b/src/openlcb/ConfigRepresentation.hxx
@@ -301,6 +301,17 @@ public:
     PATH().read_or_write_trimmed(                                              \
         fd, PATH##_options().minvalue(), PATH##_options().maxvalue())
 
+/// Requests a readout of a numeric variable with verifying range. If the value
+/// currently present in the config file is outside the defined
+/// minimum/maximum, then sets the value to the default value in the config
+/// file (overwriting). Returns the current value after trimming.
+///
+/// Usage:
+///   uint16_t my_value = CDI_READ_TRIM_DEFAULT(cfg.seg().foo_bar, fd);
+#define CDI_READ_TRIM_DEFAULT(PATH, fd)                                        \
+    PATH().read_or_write_default(fd, PATH##_options().minvalue(),              \
+        PATH##_options().maxvalue(), PATH##_options().defaultvalue())
+
 /// Defines a repeated group of a given type and a given number of repeats.
 ///
 /// Typical usage:


### PR DESCRIPTION
Adds an alternative to read-trimmed that trims to default_value instead of the min/max.

This works much better when trying to initialize a field that is set to 0xFF from flash initialization.