### PR TITLE
Switches the default hard fault handler to keep interrupts disabled.

### DIFF
--- a/boards/armv7m/default_handlers.h
+++ b/boards/armv7m/default_handlers.h
@@ -273,7 +273,8 @@ void hard_fault_handler_step_3(void) {
             " BKPT #1            \n"
             ::: "r0", "r1", "r2", "r3");
     }
-    while (1) {
+    while (1)
+    {
         // In gdb use `break hard_fault_debug` to get the best possible
         // backtrace if you find a target in this infinite loop.
         __asm volatile (


### PR DESCRIPTION
Switches the default hard fault handler to keep interrupts disabled.
It is not safe to reenable interrupts during hard fault handler.

In exchange we wait with an infinite loop by inline calling the blinker
routine.

---

Fixes missing blinking in the default interrupt handler.