### PR TITLE
Fixes NVIC_SetPriority usage for STM32 targets

### DIFF
--- a/applications/dcc_decoder/targets/freertos.armv6m.st-stm32f091rc-nucleo/HwInit.cxx
+++ b/applications/dcc_decoder/targets/freertos.armv6m.st-stm32f091rc-nucleo/HwInit.cxx
@@ -307,7 +307,7 @@ void hw_preinit(void)
         HASSERT(0);
     }
     __HAL_DBGMCU_FREEZE_TIM14();
-    NVIC_SetPriority(TIM14_IRQn, 0);
+    SetInterruptPriority(TIM14_IRQn, 0);
     NVIC_EnableIRQ(TIM14_IRQn);
 }
 

--- a/boards/st-stm32f072b-discovery/HwInit.cxx
+++ b/boards/st-stm32f072b-discovery/HwInit.cxx
@@ -218,7 +218,7 @@ void hw_preinit(void)
         /* Starting Error */
         HASSERT(0);
     }
-    NVIC_SetPriority(TIM14_IRQn, 0);
+    SetInterruptPriority(TIM14_IRQn, 0);
     NVIC_EnableIRQ(TIM14_IRQn);
 }
 

--- a/boards/st-stm32f091rc-nucleo-dev-board/HwInit.cxx
+++ b/boards/st-stm32f091rc-nucleo-dev-board/HwInit.cxx
@@ -323,7 +323,7 @@ void hw_preinit(void)
         HASSERT(0);
     }
     __HAL_DBGMCU_FREEZE_TIM14();
-    NVIC_SetPriority(TIM14_IRQn, 0);
+    SetInterruptPriority(TIM14_IRQn, 0);
     NVIC_EnableIRQ(TIM14_IRQn);
 }
 

--- a/boards/st-stm32f091rc-nucleo/HwInit.cxx
+++ b/boards/st-stm32f091rc-nucleo/HwInit.cxx
@@ -228,7 +228,7 @@ void hw_preinit(void)
         HASSERT(0);
     }
     __HAL_DBGMCU_FREEZE_TIM14();
-    NVIC_SetPriority(TIM14_IRQn, 0);
+    SetInterruptPriority(TIM14_IRQn, 0);
     NVIC_EnableIRQ(TIM14_IRQn);
 }
 

--- a/boards/st-stm32f103rb-cmsis/Stm32Can.cxx
+++ b/boards/st-stm32f103rb-cmsis/Stm32Can.cxx
@@ -134,8 +134,8 @@ private:
     {
         init_can_filter();
         // Sets the CAN interrupt priorities to be compatible with FreeRTOS.
-        NVIC_SetPriority(USB_LP_CAN1_RX0_IRQn, configKERNEL_INTERRUPT_PRIORITY);
-        NVIC_SetPriority(USB_HP_CAN1_TX_IRQn, configKERNEL_INTERRUPT_PRIORITY);
+        SetInterruptPriority(USB_LP_CAN1_RX0_IRQn, configKERNEL_INTERRUPT_PRIORITY);
+        SetInterruptPriority(USB_HP_CAN1_TX_IRQn, configKERNEL_INTERRUPT_PRIORITY);
         CAN_ITConfig(instance_, CAN_IT_TME, DISABLE);
         NVIC_EnableIRQ(USB_LP_CAN1_RX0_IRQn);
         NVIC_EnableIRQ(USB_HP_CAN1_TX_IRQn);

--- a/boards/st-stm32f103rb-cmsis/hw_init.cxx
+++ b/boards/st-stm32f103rb-cmsis/hw_init.cxx
@@ -156,7 +156,7 @@ void setblink(uint32_t pattern)
     LPC_TIM1->MR0 = 125;
     LPC_TIM1->MCR = 3; // reset and interrupt on match 0
 
-    NVIC_SetPriority(TIMER1_IRQn, 0);
+    SetInterruptPriority(TIMER1_IRQn, 0);
     NVIC_EnableIRQ(TIMER1_IRQn);
 
     LPC_TIM1->TCR = 1; // Timer go.*/

--- a/boards/st-stm32f103rb-maple/hw_init.cxx
+++ b/boards/st-stm32f103rb-maple/hw_init.cxx
@@ -92,7 +92,7 @@ void setblink(uint32_t pattern)
     LPC_TIM1->MR0 = 125;
     LPC_TIM1->MCR = 3; // reset and interrupt on match 0
 
-    NVIC_SetPriority(TIMER1_IRQn, 0);
+    SetInterruptPriority(TIMER1_IRQn, 0);
     NVIC_EnableIRQ(TIMER1_IRQn);
 
     LPC_TIM1->TCR = 1; // Timer go.*/

--- a/boards/st-stm32f303-discovery/HwInit.cxx
+++ b/boards/st-stm32f303-discovery/HwInit.cxx
@@ -245,7 +245,7 @@ void hw_preinit(void)
         /* Starting Error */
         HASSERT(0);
     }
-    NVIC_SetPriority(TIM7_IRQn, 0);
+    SetInterruptPriority(TIM7_IRQn, 0);
     NVIC_EnableIRQ(TIM7_IRQn);
 }
 

--- a/boards/st-stm32f303re-nucleo-dev-board/HwInit.cxx
+++ b/boards/st-stm32f303re-nucleo-dev-board/HwInit.cxx
@@ -356,7 +356,7 @@ void hw_preinit(void)
         HASSERT(0);
     }
     __HAL_DBGMCU_FREEZE_TIM17();
-    NVIC_SetPriority(TIM17_IRQn, 0);
+    SetInterruptPriority(TIM17_IRQn, 0);
     NVIC_EnableIRQ(TIM17_IRQn);
 }
 

--- a/boards/st-stm32f303re-nucleo/HwInit.cxx
+++ b/boards/st-stm32f303re-nucleo/HwInit.cxx
@@ -248,7 +248,7 @@ void hw_preinit(void)
         HASSERT(0);
     }
     __HAL_DBGMCU_FREEZE_TIM17();
-    NVIC_SetPriority(TIM17_IRQn, 0);
+    SetInterruptPriority(TIM17_IRQn, 0);
     NVIC_EnableIRQ(TIM17_IRQn);
 }
 

--- a/boards/st-stm32f767zi-nucleo/HwInit.cxx
+++ b/boards/st-stm32f767zi-nucleo/HwInit.cxx
@@ -290,7 +290,7 @@ void hw_preinit(void)
         /* Starting Error */
         HASSERT(0);
     }
-    NVIC_SetPriority(TIM8_TRG_COM_TIM14_IRQn, 0);
+    SetInterruptPriority(TIM8_TRG_COM_TIM14_IRQn, 0);
     NVIC_EnableIRQ(TIM8_TRG_COM_TIM14_IRQn);
 }
 

--- a/src/freertos_drivers/st/Stm32Can.cxx
+++ b/src/freertos_drivers/st/Stm32Can.cxx
@@ -37,6 +37,8 @@
 
 #include <stdint.h>
 
+#include "stm32f_hal_conf.hxx"
+
 #if defined (STM32F072xB) || defined (STM32F091xC)
 
 #include "stm32f0xx_hal_cortex.h"

--- a/src/freertos_drivers/st/Stm32Can.cxx
+++ b/src/freertos_drivers/st/Stm32Can.cxx
@@ -103,11 +103,11 @@ Stm32Can::Stm32Can(const char *name)
     /* The priority of CAN interrupt is as high as possible while maintaining
      * FreeRTOS compatibility.
      */
-    NVIC_SetPriority(CAN_IRQN, configKERNEL_INTERRUPT_PRIORITY);
+    SetInterruptPriority(CAN_IRQN, configKERNEL_INTERRUPT_PRIORITY);
 
 #ifdef SPLIT_INT
     HAL_NVIC_DisableIRQ(CAN_SECOND_IRQN);
-    NVIC_SetPriority(CAN_SECOND_IRQN, configKERNEL_INTERRUPT_PRIORITY);
+    SetInterruptPriority(CAN_SECOND_IRQN, configKERNEL_INTERRUPT_PRIORITY);
 #endif
 #endif
 }

--- a/src/freertos_drivers/st/Stm32DCCDecoder.hxx
+++ b/src/freertos_drivers/st/Stm32DCCDecoder.hxx
@@ -390,9 +390,9 @@ template <class HW> void Stm32DccTimerModule<HW>::module_enable()
     HAL_NVIC_SetPriority(HW::TIMER_IRQn, 0, 0);
     HAL_NVIC_SetPriority(HW::OS_IRQn, 3, 0);
 #elif defined(GCC_ARMCM3)
-    NVIC_SetPriority(HW::CAPTURE_IRQn, 0x20);
-    NVIC_SetPriority(HW::TIMER_IRQn, 0x20);
-    NVIC_SetPriority(HW::OS_IRQn, configKERNEL_INTERRUPT_PRIORITY);
+    SetInterruptPriority(HW::CAPTURE_IRQn, 0x20);
+    SetInterruptPriority(HW::TIMER_IRQn, 0x20);
+    SetInterruptPriority(HW::OS_IRQn, configKERNEL_INTERRUPT_PRIORITY);
 #else
 #error not defined how to set interrupt priority
 #endif

--- a/src/freertos_drivers/st/Stm32I2C.cxx
+++ b/src/freertos_drivers/st/Stm32I2C.cxx
@@ -159,9 +159,9 @@ Stm32I2C::Stm32I2C(const char *name, I2C_TypeDef *port, uint32_t ev_interrupt,
     // call above.
     i2cHandle_.Init.Timing = (uint32_t) this;
 
-    NVIC_SetPriority((IRQn_Type)ev_interrupt, configKERNEL_INTERRUPT_PRIORITY);
+    SetInterruptPriority((IRQn_Type)ev_interrupt, configKERNEL_INTERRUPT_PRIORITY);
     HAL_NVIC_EnableIRQ((IRQn_Type)ev_interrupt);
-    NVIC_SetPriority((IRQn_Type)er_interrupt, configKERNEL_INTERRUPT_PRIORITY);
+    SetInterruptPriority((IRQn_Type)er_interrupt, configKERNEL_INTERRUPT_PRIORITY);
     HAL_NVIC_EnableIRQ((IRQn_Type)er_interrupt);
 }
 

--- a/src/freertos_drivers/st/Stm32Uart.cxx
+++ b/src/freertos_drivers/st/Stm32Uart.cxx
@@ -33,6 +33,8 @@
 
 #include "Stm32Uart.hxx"
 
+#include "stm32f_hal_conf.hxx"
+
 #if defined(STM32F072xB) || defined(STM32F091xC)
 #include "stm32f0xx_hal_cortex.h"
 #elif defined(STM32F103xB)

--- a/src/freertos_drivers/st/Stm32Uart.cxx
+++ b/src/freertos_drivers/st/Stm32Uart.cxx
@@ -152,7 +152,7 @@ Stm32Uart::Stm32Uart(const char *name, USART_TypeDef *base, IRQn_Type interrupt)
     HAL_NVIC_SetPriority(interrupt, 3, 0);
 #elif defined(GCC_ARMCM3)    
     // Below kernel-compatible interrupt priority.
-    NVIC_SetPriority(interrupt, configMAX_SYSCALL_INTERRUPT_PRIORITY + 0x20);
+    SetInterruptPriority(interrupt, configMAX_SYSCALL_INTERRUPT_PRIORITY + 0x20);
 #else
 #error not defined how to set interrupt priority
 #endif    

--- a/src/freertos_drivers/st/stm32f0xx_hal_conf.h
+++ b/src/freertos_drivers/st/stm32f0xx_hal_conf.h
@@ -336,7 +336,12 @@ extern const uint32_t HSEValue;
 #else
   #define assert_param(expr) ((void)0)
 #endif /* USE_FULL_ASSERT */    
-    
+
+  static inline void SetInterruptPriority(uint32_t irq, uint8_t priority)
+  {
+      NVIC_SetPriority(irq, priority >> (8U - __NVIC_PRIO_BITS));
+  }
+ 
 #ifdef __cplusplus
 }
 #endif

--- a/src/freertos_drivers/st/stm32f0xx_hal_conf.h
+++ b/src/freertos_drivers/st/stm32f0xx_hal_conf.h
@@ -339,7 +339,7 @@ extern const uint32_t HSEValue;
 
   static inline void SetInterruptPriority(uint32_t irq, uint8_t priority)
   {
-      NVIC_SetPriority(irq, priority >> (8U - __NVIC_PRIO_BITS));
+      NVIC_SetPriority((IRQn_Type)irq, priority >> (8U - __NVIC_PRIO_BITS));
   }
  
 #ifdef __cplusplus

--- a/src/freertos_drivers/st/stm32f1xx_hal_conf.h
+++ b/src/freertos_drivers/st/stm32f1xx_hal_conf.h
@@ -406,6 +406,11 @@
   #define assert_param(expr) ((void)0)
 #endif /* USE_FULL_ASSERT */
 
+  static inline void SetInterruptPriority(uint32_t irq, uint8_t priority)
+  {
+      NVIC_SetPriority((IRQn_Type)irq, priority >> (8U - __NVIC_PRIO_BITS));
+  }
+ 
 #ifdef __cplusplus
 }
 #endif

--- a/src/freertos_drivers/st/stm32f3xx_hal_conf.h
+++ b/src/freertos_drivers/st/stm32f3xx_hal_conf.h
@@ -374,7 +374,7 @@
 
   static inline void SetInterruptPriority(uint32_t irq, uint8_t priority)
   {
-      NVIC_SetPriority(irq, priority >> (8U - __NVIC_PRIO_BITS));
+      NVIC_SetPriority((IRQn_Type)irq, priority >> (8U - __NVIC_PRIO_BITS));
   }
  
 #ifdef __cplusplus

--- a/src/freertos_drivers/st/stm32f3xx_hal_conf.h
+++ b/src/freertos_drivers/st/stm32f3xx_hal_conf.h
@@ -371,7 +371,12 @@
 #else
   #define assert_param(expr) ((void)0)
 #endif /* USE_FULL_ASSERT */    
-    
+
+  static inline void SetInterruptPriority(uint32_t irq, uint8_t priority)
+  {
+      NVIC_SetPriority(irq, priority >> (8U - __NVIC_PRIO_BITS));
+  }
+ 
 #ifdef __cplusplus
 }
 #endif

--- a/src/freertos_drivers/st/stm32f7xx_hal_conf.h
+++ b/src/freertos_drivers/st/stm32f7xx_hal_conf.h
@@ -466,6 +466,10 @@
   #define assert_param(expr) ((void)0U)
 #endif /* USE_FULL_ASSERT */
 
+  static inline void SetInterruptPriority(uint32_t irq, uint8_t priority)
+  {
+      NVIC_SetPriority(irq, priority >> (8U - __NVIC_PRIO_BITS));
+  }
 
 #ifdef __cplusplus
 }

--- a/src/freertos_drivers/st/stm32f7xx_hal_conf.h
+++ b/src/freertos_drivers/st/stm32f7xx_hal_conf.h
@@ -468,7 +468,7 @@
 
   static inline void SetInterruptPriority(uint32_t irq, uint8_t priority)
   {
-      NVIC_SetPriority(irq, priority >> (8U - __NVIC_PRIO_BITS));
+      NVIC_SetPriority((IRQn_Type)irq, priority >> (8U - __NVIC_PRIO_BITS));
   }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Introduces an inline function SetInterruptPriority that can be used with configKERNEL_INTERRUPT_PRIORITY.
Replaces usages of NVIC_SetPriority in STM32 related code with the new function.

Fixes #395 