### PR TITLE
Fixes FIFO overflow error in C32xxSPI driver

### DIFF
--- a/src/freertos_drivers/ti/CC32xxSPI.hxx
+++ b/src/freertos_drivers/ti/CC32xxSPI.hxx
@@ -206,7 +206,7 @@ private:
         do
         {
             /* fill TX FIFO but make sure we don't fill it to overflow */
-            if (tx_len && (rx_len - tx_len) < (8 * sizeof(T)))
+            if (tx_len && ((rx_len - tx_len) < (32 / sizeof(T))))
             {
                 if (data_put_non_blocking(*tx_buf) != 0)
                 {


### PR DESCRIPTION
causing infinite loop in the case a more than 32-byte long
transfer is initiated with 2 or 4 byte words.