### PR TITLE
Feature macro work to remove ARDUINO ifdefs.

### DIFF
--- a/include/openmrn_features.h
+++ b/include/openmrn_features.h
@@ -48,6 +48,10 @@
 #define OPENMRN_FEATURE_REENT 1
 #endif
 
+#if defined(__linux__) || defined(__MACH__) || defined(__WINNT__) || defined(ESP32) || defined(OPENMRN_FEATURE_DEVTAB)
+#define OPENMRN_HAVE_POSIX_FD 1
+#endif
+
 /// @todo this should probably be a whitelist: __linux__ || __MACH__.
 #if !defined(__FreeRTOS__) && !defined(__WINNT__) && !defined(ESP32) &&        \
     !defined(ARDUINO) && !defined(ESP_NONOS)

--- a/include/openmrn_features.h
+++ b/include/openmrn_features.h
@@ -49,6 +49,9 @@
 #endif
 
 #if defined(__linux__) || defined(__MACH__) || defined(__WINNT__) || defined(ESP32) || defined(OPENMRN_FEATURE_DEVTAB)
+/// Enables the code using ::open ::close ::read ::write for non-volatile
+/// storage, FileMemorySpace for the configuration space, and
+/// SNIP_DYNAMIC_FILE_NAME for node names.
 #define OPENMRN_HAVE_POSIX_FD 1
 #endif
 

--- a/src/executor/Executor.cxx
+++ b/src/executor/Executor.cxx
@@ -37,6 +37,7 @@
 
 #include "executor/Executor.hxx"
 
+#include "openmrn_features.h"
 #include <unistd.h>
 
 #ifdef __WINNT__
@@ -228,14 +229,6 @@ void *ExecutorBase::entry()
     return nullptr;
 }
 
-#elif defined(ARDUINO) && !defined(ESP32)
-
-void *ExecutorBase::entry()
-{
-    DIE("Arduino code should not start the executor.");
-    return nullptr;
-}
-
 #elif defined(ESP_NONOS)
 
 #define EXECUTOR_TASK_PRIO USER_TASK_PRIO_0
@@ -282,6 +275,14 @@ void ICACHE_FLASH_ATTR *ExecutorBase::entry()
     os_timer_setfn(&appl_task_timer, &timer_fun, this);
     system_os_task(appl_task, EXECUTOR_TASK_PRIO, appl_task_queue, 1);
     system_os_post(EXECUTOR_TASK_PRIO, 0, (uint32_t)this);
+    return nullptr;
+}
+
+#elif OPENMRN_FEATURE_SINGLE_THREADED
+
+void *ExecutorBase::entry()
+{
+    DIE("Arduino code should not start the executor.");
     return nullptr;
 }
 

--- a/src/openlcb/SimpleInfoProtocol.hxx
+++ b/src/openlcb/SimpleInfoProtocol.hxx
@@ -38,6 +38,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "openmrn_features.h"
 #include "openlcb/If.hxx"
 #include "executor/StateFlow.hxx"
 
@@ -217,7 +218,7 @@ private:
                 }
                 break;
             }
-#if (!defined(ARDUINO)) || defined(ESP32)
+#if OPENMRN_HAVE_POSIX_FD
             case SimpleInfoDescriptor::FILE_CHAR_ARRAY:
                 open_and_seek_next_file();
                 // fall through
@@ -227,7 +228,7 @@ private:
                 currentLength_ = d.arg;
                 HASSERT(currentLength_);
                 break;
-#if (!defined(ARDUINO)) || defined(ESP32)
+#if OPENMRN_HAVE_POSIX_FD
             case SimpleInfoDescriptor::FILE_LITERAL_BYTE:
             {
                 open_and_seek_next_file();
@@ -240,7 +241,7 @@ private:
                 byteOffset_ = 0;
                 break;
             }
-#endif // NOT ARDUINO, YES ESP32
+#endif // if have fd
             default:
                 currentLength_ = 0;
         }

--- a/src/openlcb/SimpleNodeInfo.cxx
+++ b/src/openlcb/SimpleNodeInfo.cxx
@@ -34,6 +34,8 @@
 
 #include "openlcb/SimpleNodeInfo.hxx"
 
+#include "openmrn_features.h"
+
 namespace openlcb
 {
 
@@ -46,15 +48,15 @@ const SimpleInfoDescriptor SNIPHandler::SNIP_RESPONSE[] = {
     {SimpleInfoDescriptor::C_STRING, 0, 0, SNIP_STATIC_DATA.model_name},
     {SimpleInfoDescriptor::C_STRING, 0, 0, SNIP_STATIC_DATA.hardware_version},
     {SimpleInfoDescriptor::C_STRING, 0, 0, SNIP_STATIC_DATA.software_version},
-#if defined(ARDUINO) && (!defined(ESP32))
+#if OPENMRN_HAVE_POSIX_FD
+    {SimpleInfoDescriptor::FILE_LITERAL_BYTE, 2, 0, SNIP_DYNAMIC_FILENAME},
+    {SimpleInfoDescriptor::FILE_C_STRING, 63, 1, SNIP_DYNAMIC_FILENAME},
+    {SimpleInfoDescriptor::FILE_C_STRING, 64, 64, SNIP_DYNAMIC_FILENAME},
+#else
     /// @todo(balazs.racz) Add eeprom support to arduino.
     {SimpleInfoDescriptor::LITERAL_BYTE, 2, 0, nullptr},
     {SimpleInfoDescriptor::LITERAL_BYTE, 0, 0, nullptr},
     {SimpleInfoDescriptor::LITERAL_BYTE, 0, 0, nullptr},
-#else
-    {SimpleInfoDescriptor::FILE_LITERAL_BYTE, 2, 0, SNIP_DYNAMIC_FILENAME},
-    {SimpleInfoDescriptor::FILE_C_STRING, 63, 1, SNIP_DYNAMIC_FILENAME},
-    {SimpleInfoDescriptor::FILE_C_STRING, 64, 64, SNIP_DYNAMIC_FILENAME},
 #endif
     {SimpleInfoDescriptor::END_OF_DATA, 0, 0, 0}};
 

--- a/src/openlcb/SimpleStack.cxx
+++ b/src/openlcb/SimpleStack.cxx
@@ -53,6 +53,7 @@
 
 #include "openlcb/SimpleStack.hxx"
 
+#include "openmrn_features.h"
 #include "openlcb/EventHandler.hxx"
 #include "openlcb/NodeInitializeFlow.hxx"
 #include "openlcb/SimpleNodeInfo.hxx"
@@ -103,12 +104,12 @@ SimpleTcpStack::SimpleTcpStack(const openlcb::NodeID node_id)
 
 void SimpleStackBase::start_stack(bool delay_start)
 {
-#if (!defined(ARDUINO)) || defined(ESP32)
+#if OPENMRN_HAVE_POSIX_FD
     // Opens the eeprom file and sends configuration update commands to all
     // listeners.
     configUpdateFlow_.open_file(CONFIG_FILENAME);
     configUpdateFlow_.init_flow();
-#endif // NOT ARDUINO, YES ESP32
+#endif // have posix fd
 
     if (!delay_start)
     {
@@ -138,7 +139,7 @@ void SimpleStackBase::default_start_node()
             node(), MemoryConfigDefs::SPACE_ACDI_SYS, space);
         additionalComponents_.emplace_back(space);
     }
-#if (!defined(ARDUINO)) || defined(ESP32)
+#if OPENMRN_HAVE_POSIX_FD 
     {
         auto *space = new FileMemorySpace(
             SNIP_DYNAMIC_FILENAME, sizeof(SimpleNodeDynamicValues));
@@ -156,7 +157,7 @@ void SimpleStackBase::default_start_node()
             node(), MemoryConfigDefs::SPACE_CDI, space);
         additionalComponents_.emplace_back(space);
     }
-#if (!defined(ARDUINO)) || defined(ESP32)
+#if OPENMRN_HAVE_POSIX_FD
     if (CONFIG_FILENAME != nullptr)
     {
         auto *space = new FileMemorySpace(CONFIG_FILENAME, CONFIG_FILE_SIZE);

--- a/src/utils/Queue.hxx
+++ b/src/utils/Queue.hxx
@@ -38,6 +38,7 @@
 #include <cstdlib>
 #include <cstdarg>
 
+#include "openmrn_features.h"
 #include "executor/Executable.hxx"
 #include "executor/Notifiable.hxx"
 #include "os/OS.hxx"
@@ -868,7 +869,7 @@ public:
         return result;
     }
 
-#if !(defined(ESP_NONOS) || defined(ARDUINO))
+#if OPENMRN_FEATURE_SEM_TIMEDWAIT
     /** Wait for an item from the front of the queue.
      * @param timeout time to wait in nanoseconds
      * @return item retrieved from queue, else NULL with errno set:


### PR DESCRIPTION
Adds feature macro OPENMRN_HAVE_POSIX_FD.
Replaces uses of ifdef ARDUINO with feature macros.