### PR TITLE
Add linux.aarch64 target.

### DIFF
--- a/applications/hub/targets/linux.aarch64/Makefile
+++ b/applications/hub/targets/linux.aarch64/Makefile
@@ -1,0 +1,3 @@
+-include ../../config.mk
+include $(OPENMRNPATH)/etc/prog.mk
+

--- a/etc/linux.aarch64.mk
+++ b/etc/linux.aarch64.mk
@@ -1,0 +1,45 @@
+# Get the toolchain paths for openmrn
+include $(OPENMRNPATH)/etc/path.mk
+
+
+ifndef TOOLPATH
+#TOOLPATHCOMMAND := $(shell \
+#sh -c "which aarch64-linux-gnu-gcc" \
+#)
+TOOLPATH := $(AARCH64LINUXGCCPATH)
+endif
+
+$(info armv7alinux toolpath '$(TOOLPATH)')
+
+# Get the $(CFLAGSENV), $(CXXFLAGSENV), $(LDFLAGSENV)
+include $(OPENMRNPATH)/etc/env.mk
+
+CC = $(TOOLPATH)/aarch64-linux-gnu-gcc
+CXX = $(TOOLPATH)/aarch64-linux-gnu-g++
+AR = $(TOOLPATH)/aarch64-linux-gnu-ar
+LD = $(TOOLPATH)/aarch64-linux-gnu-g++
+OBJDUMP = $(TOOLPATH)/aarch64-linux-gnu-objdump
+
+AROPTS=D
+
+HOST_TARGET := 1
+
+STARTGROUP := -Wl,--start-group
+ENDGROUP := -Wl,--end-group
+
+ARCHOPTIMIZATION = -g3 -O0 -march=armv8-a
+
+CSHAREDFLAGS = -c $(ARCHOPTIMIZATION) -Wall -Werror -Wno-unknown-pragmas \
+               -MD -MP -fno-stack-protector -D_GNU_SOURCE
+
+CFLAGS = $(CSHAREDFLAGS) -std=gnu99
+
+CXXFLAGS = $(CSHAREDFLAGS) -std=c++0x -D__STDC_FORMAT_MACROS \
+           -D__STDC_LIMIT_MACROS -D__USE_LIBSTDCPP__
+
+LDFLAGS = $(ARCHOPTIMIZATION) -Wl,-Map="$(@:%=%.map)"
+SYSLIB_SUBDIRS +=
+SYSLIBRARIES = -lrt -lpthread
+
+EXTENTION =
+

--- a/etc/path.mk
+++ b/etc/path.mk
@@ -301,6 +301,17 @@ ARMLINUXGCCPATH:=$(TRYPATH)
 endif
 endif #ARMLINUXGCCPATH
 
+################### AARCH64-LINUX GCC PATH #####################
+ifndef AARCH64LINUXGCCPATH
+SEARCHPATH := \
+    /usr/bin \
+
+TRYPATH:=$(call findfirst,aarch64-linux-gnu-gcc,$(SEARCHPATH))
+ifneq ($(TRYPATH),)
+AARCH64LINUXGCCPATH:=$(TRYPATH)
+endif
+endif #AARCH64LINUXGCCPATH
+
 ################### TI-CC3200-SDK #####################
 ifndef TICC3200SDKPATH
 SEARCHPATH := \

--- a/targets/linux.aarch64/Makefile
+++ b/targets/linux.aarch64/Makefile
@@ -1,0 +1,1 @@
+include $(OPENMRNPATH)/etc/core_target.mk

--- a/targets/linux.aarch64/console/Makefile
+++ b/targets/linux.aarch64/console/Makefile
@@ -1,0 +1,3 @@
+OPENMRNPATH ?= $(realpath ../../..)
+include $(OPENMRNPATH)/etc/lib.mk
+

--- a/targets/linux.aarch64/cue/Makefile
+++ b/targets/linux.aarch64/cue/Makefile
@@ -1,0 +1,1 @@
+include $(OPENMRNPATH)/etc/lib.mk

--- a/targets/linux.aarch64/dcc/Makefile
+++ b/targets/linux.aarch64/dcc/Makefile
@@ -1,0 +1,1 @@
+include $(OPENMRNPATH)/etc/lib.mk

--- a/targets/linux.aarch64/executor/Makefile
+++ b/targets/linux.aarch64/executor/Makefile
@@ -1,0 +1,1 @@
+include $(OPENMRNPATH)/etc/lib.mk

--- a/targets/linux.aarch64/lib/Makefile
+++ b/targets/linux.aarch64/lib/Makefile
@@ -1,0 +1,1 @@
+include $(OPENMRNPATH)/etc/target_lib.mk

--- a/targets/linux.aarch64/openlcb/Makefile
+++ b/targets/linux.aarch64/openlcb/Makefile
@@ -1,0 +1,1 @@
+include $(OPENMRNPATH)/etc/lib.mk

--- a/targets/linux.aarch64/os/Makefile
+++ b/targets/linux.aarch64/os/Makefile
@@ -1,0 +1,3 @@
+OPENMRNPATH ?= $(realpath ../../..)
+include $(OPENMRNPATH)/etc/lib.mk
+

--- a/targets/linux.aarch64/utils/Makefile
+++ b/targets/linux.aarch64/utils/Makefile
@@ -1,0 +1,1 @@
+include $(OPENMRNPATH)/etc/lib.mk

--- a/targets/linux.aarch64/withrottle/Makefile
+++ b/targets/linux.aarch64/withrottle/Makefile
@@ -1,0 +1,1 @@
+include $(OPENMRNPATH)/etc/lib.mk


### PR DESCRIPTION
Add 64-bit ARM Linux as a OpenMRN target.   Initially supporting my Banana Pi M64 (Allwinner A64 SBC with a Raspberry Pi B+ form factor, including the Raspberry Pi 40-pin GPIO header.  I'm guessing this will also support a 'Pi 4 or really any 64-bit ARM Linux SBC running a 64-bit (aarch64) Linux O/S.

This is *lightly* tested -- I built and tested the hub application.  Not sure how to run more detailed tests.