### PR TITLE
Adds the ability to run tests under performance profiling.

### DIFF
--- a/etc/cov.mk
+++ b/etc/cov.mk
@@ -18,10 +18,12 @@ HOST_TARGET := 1
 STARTGROUP := -Wl,--start-group
 ENDGROUP := -Wl,--end-group
 
+TESTOPTIMIZATION=-O0
+
 ifdef SKIP_COVERAGE
-ARCHOPTIMIZATION = -g -O0
+ARCHOPTIMIZATION = -g $(TESTOPTIMIZATION)
 else
-ARCHOPTIMIZATION = -g -O0 -fprofile-arcs -ftest-coverage
+ARCHOPTIMIZATION = -g $(TESTOPTIMIZATION) -fprofile-arcs -ftest-coverage
 endif
 
 CSHAREDFLAGS = -c -frandom-seed=$(shell echo $(abspath $<) | md5sum  | sed 's/\(.*\) .*/\1/') $(ARCHOPTIMIZATION) $(INCLUDES) -Wall -Werror -Wno-unknown-pragmas -MD -MP -fno-stack-protector -D_GNU_SOURCE -DGTEST
@@ -35,6 +37,15 @@ CXXFLAGS = $(CSHAREDFLAGS) -std=c++1y -D__STDC_FORMAT_MACROS \
 LDFLAGS = $(ARCHOPTIMIZATION) -Wl,-Map="$(@:%=%.map)"
 SYSLIB_SUBDIRS +=
 SYSLIBRARIES = -lrt -lpthread -lavahi-client -lavahi-common $(SYSLIBRARIESEXTRA)
+
+ifdef RUN_GPERF
+CXXFLAGS += -DWITHGPERFTOOLS
+LDFLAGS += -DWITHGPERFTOOLS
+SYSLIBRARIES += -lprofiler
+TESTOPTIMIZATION = -O3
+SKIP_COVERAGE = 1
+endif
+
 
 ifndef SKIP_COVERAGE
 LDFLAGS += -pg

--- a/etc/test.mk
+++ b/etc/test.mk
@@ -45,11 +45,13 @@ LIBS = $(STARTGROUP) \
        $(ENDGROUP) \
        $(LINKCORELIBS)
 
+TESTOPTIMIZATION=-O0
+
 INCLUDES     += -I$(GTESTPATH)/include -I$(GMOCKPATH)/include -I$(GMOCKPATH) \
                 -I$(OPENMRNPATH)/src -I$(OPENMRNPATH)/include
-CFLAGS       += -DGTEST $(INCLUDES) -Wno-unused-but-set-variable -fprofile-arcs -ftest-coverage -O0
-CXXFLAGS     += -DGTEST $(INCLUDES) -Wno-unused-but-set-variable -fprofile-arcs -ftest-coverage -O0
-SYSLIBRARIES += -lgcov -fprofile-arcs -ftest-coverage -O0
+CFLAGS       += -DGTEST $(INCLUDES) -Wno-unused-but-set-variable -fprofile-arcs -ftest-coverage $(TESTOPTIMIZATION)
+CXXFLAGS     += -DGTEST $(INCLUDES) -Wno-unused-but-set-variable -fprofile-arcs -ftest-coverage $(TESTOPTIMIZATION)
+SYSLIBRARIES += -lgcov -fprofile-arcs -ftest-coverage $(TESTOPTIMIZATION)
 LDFLAGS      += -L$(LIBDIR)
 
 .SUFFIXES:

--- a/src/utils/test_main.hxx
+++ b/src/utils/test_main.hxx
@@ -44,6 +44,7 @@
 #include <stdarg.h>
 #include <memory>
 #include <string>
+#include <functional>
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
@@ -53,6 +54,15 @@
 #include "os/TempFile.hxx"
 #include "os/os.h"
 #include "utils/StringPrintf.hxx"
+
+#ifdef WITHGPERFTOOLS
+#include <gperftools/profiler.h>
+
+std::function<void()> profiler_enable{&ProfilerEnable};
+std::function<void()> profiler_disable{&ProfilerDisable};
+#endif
+
+
 
 int appl_main(int argc, char *argv[])
 {

--- a/src/utils/test_main.hxx
+++ b/src/utils/test_main.hxx
@@ -62,8 +62,6 @@ std::function<void()> profiler_enable{&ProfilerEnable};
 std::function<void()> profiler_disable{&ProfilerDisable};
 #endif
 
-
-
 int appl_main(int argc, char *argv[])
 {
     testing::InitGoogleMock(&argc, argv);


### PR DESCRIPTION
Adds an easy to override flag for which optimization level tests should be built.
For this apt-get install libgoogle-perftools-dev needs to be installed.