### PR TITLE
Adds a partial implementation of VirtualMemorySpace

### DIFF
--- a/src/openlcb/VirtualMemorySpace.cxxtest
+++ b/src/openlcb/VirtualMemorySpace.cxxtest
@@ -1,5 +1,5 @@
 /** \copyright
- * Copyright (c) 2014, Balazs Racz
+ * Copyright (c) 2020, Balazs Racz
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/openlcb/VirtualMemorySpace.cxxtest
+++ b/src/openlcb/VirtualMemorySpace.cxxtest
@@ -1,0 +1,195 @@
+/** \copyright
+ * Copyright (c) 2014, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file VirtualMemorySpace.cxxtest
+ *
+ * Unit tests for the virtual memory space.
+ *
+ * @author Balazs Racz
+ * @date 10 Aug 2020
+ */
+
+#include "openlcb/VirtualMemorySpace.hxx"
+
+#include "openlcb/ConfigRepresentation.hxx"
+#include "openlcb/MemoryConfigClient.hxx"
+#include "utils/async_datagram_test_helper.hxx"
+
+namespace openlcb
+{
+
+string arg1;
+string arg2;
+
+CDI_GROUP(ExampleMemorySpace);
+CDI_GROUP_ENTRY(skipped, EmptyGroup<5>);
+CDI_GROUP_ENTRY(first, StringConfigEntry<13>);
+CDI_GROUP_ENTRY(skipped2, EmptyGroup<8>);
+CDI_GROUP_ENTRY(second, StringConfigEntry<20>);
+CDI_GROUP_END();
+
+ExampleMemorySpace cfg(44);
+
+const unsigned arg1_ofs = 44 + 5;
+const unsigned arg2_ofs = 44 + 5 + 13 + 8;
+
+class VirtualMemorySpaceTest : public AsyncDatagramTest
+{
+protected:
+    ~VirtualMemorySpaceTest()
+    {
+        wait();
+    }
+
+    MemoryConfigHandler memCfg_ {&datagram_support_, node_, 3};
+    std::unique_ptr<VirtualMemorySpace> space_;
+    MemoryConfigClient client_ {node_, &memCfg_};
+};
+
+class TestSpace : public VirtualMemorySpace
+{
+public:
+    TestSpace()
+    {
+        arg1.clear();
+        arg2.clear();
+        register_string(
+            cfg.first(), string_reader(&arg1), string_writer(&arg1));
+        register_string(
+            cfg.second(), string_reader(&arg2), string_writer(&arg2));
+    }
+
+    std::function<bool(
+        unsigned repeat, string *contents, BarrierNotifiable *done)>
+    string_reader(string *ptr)
+    {
+        return
+            [ptr](unsigned repeat, string *contents, BarrierNotifiable *done) {
+                *contents = *ptr;
+                done->notify();
+                return true;
+            };
+    }
+
+    std::function<void(
+        unsigned repeat, string contents, BarrierNotifiable *done)>
+    string_writer(string *ptr)
+    {
+        return
+            [ptr](unsigned repeat, string contents, BarrierNotifiable *done) {
+                *ptr = std::move(contents);
+                done->notify();
+            };
+    }
+};
+
+class TestSpaceTest : public VirtualMemorySpaceTest
+{
+protected:
+    TestSpaceTest()
+    {
+        space_.reset(new TestSpace);
+        memCfg_.registry()->insert(node_, SPACE, space_.get());
+    }
+
+    const uint8_t SPACE = 0x52;
+};
+
+TEST_F(TestSpaceTest, create)
+{
+}
+
+TEST_F(TestSpaceTest, read_payload)
+{
+    arg1 = "hello";
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs, 13);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_STREQ("hello", b->data()->payload.c_str());
+    EXPECT_EQ(13u, b->data()->payload.size());
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs, 20);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_STREQ("", b->data()->payload.c_str());
+    EXPECT_EQ(20u, b->data()->payload.size());
+
+    // prefix read
+    b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs, 3);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ("hel", b->data()->payload);
+}
+
+TEST_F(TestSpaceTest, read_early)
+{
+    arg1 = "hello";
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs - 2, 10);
+    ASSERT_EQ(0, b->data()->resultCode);
+    string exp("\0\0hello\0\0\0", 10);
+    EXPECT_EQ(exp, b->data()->payload);
+    EXPECT_EQ(10u, b->data()->payload.size());
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs - 4, 3);
+    ASSERT_EQ(0, b->data()->resultCode);
+    string exp2("\0\0\0", 3);
+    EXPECT_EQ(exp2, b->data()->payload);
+    EXPECT_EQ(3u, b->data()->payload.size());
+}
+
+TEST_F(TestSpaceTest, write_payload)
+{
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs, "xyzw");
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ("xyzw", arg1);
+    EXPECT_EQ(4u, arg1.size());
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs, "abcde");
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ("abcde", arg2);
+    EXPECT_EQ(5u, arg2.size());
+}
+
+TEST_F(TestSpaceTest, write_early)
+{
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs-2, "xyzw");
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ("zw", arg1);
+    EXPECT_EQ(2u, arg1.size());
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs-1, "qwert");
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ("wert", arg2);
+    EXPECT_EQ(4u, arg2.size());
+}
+
+} // namespace openlcb

--- a/src/openlcb/VirtualMemorySpace.cxxtest
+++ b/src/openlcb/VirtualMemorySpace.cxxtest
@@ -180,7 +180,7 @@ TEST_F(TestSpaceTest, read_early)
 TEST_F(TestSpaceTest, read_hole)
 {
     auto b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
-        NodeHandle(node_->node_id()), SPACE, arg2_ofs-5, 3);
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs - 5, 3);
     ASSERT_EQ(0, b->data()->resultCode);
     string exp("\0\0\0", 3);
     EXPECT_EQ(exp, b->data()->payload);
@@ -188,7 +188,7 @@ TEST_F(TestSpaceTest, read_hole)
     /// @todo this return seems to be wrong, although this address is out of
     /// the memory space limits.
     b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
-        NodeHandle(node_->node_id()), SPACE, arg1_ofs-5, 2);
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs - 5, 2);
     ASSERT_EQ(0, b->data()->resultCode);
     EXPECT_EQ(string(), b->data()->payload);
 
@@ -221,13 +221,13 @@ TEST_F(TestSpaceTest, write_payload)
 TEST_F(TestSpaceTest, write_early)
 {
     auto b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
-        NodeHandle(node_->node_id()), SPACE, arg1_ofs-2, "xyzw");
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs - 2, "xyzw");
     ASSERT_EQ(0, b->data()->resultCode);
     EXPECT_EQ("zw", arg1);
     EXPECT_EQ(2u, arg1.size());
 
     b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
-        NodeHandle(node_->node_id()), SPACE, arg2_ofs-1, "qwert");
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs - 1, "qwert");
     ASSERT_EQ(0, b->data()->resultCode);
     EXPECT_EQ("wert", arg2);
     EXPECT_EQ(4u, arg2.size());
@@ -237,17 +237,134 @@ TEST_F(TestSpaceTest, write_early)
 TEST_F(TestSpaceTest, write_hole)
 {
     auto b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
-        NodeHandle(node_->node_id()), SPACE, arg2_ofs-5, "xyz");
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs - 5, "xyz");
     ASSERT_EQ(0, b->data()->resultCode);
 
     b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
-        NodeHandle(node_->node_id()), SPACE, arg1_ofs-5, "qw");
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs - 5, "qw");
     ASSERT_EQ(0, b->data()->resultCode);
 
     b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
-        NodeHandle(node_->node_id()), SPACE, arg2_ofs+100, "qw");
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs + 100, "qw");
     ASSERT_EQ(0, b->data()->resultCode);
 }
 
+class TestSpaceAsync : public VirtualMemorySpace
+{
+public:
+    TestSpaceAsync()
+    {
+        arg1.clear();
+        arg2.clear();
+        register_string(
+            cfg.first(), string_reader(&arg1), string_writer(&arg1));
+        register_string(
+            cfg.second(), string_reader(&arg2), string_writer(&arg2));
+    }
+
+    /// Creates a ReaderFunction that just returns a string from a given
+    /// variable.
+    /// @param ptr the string whose contents to return as read value. Must stay
+    /// alive as long as the function is in use.
+    /// @return the ReaderFunction.
+    std::function<bool(
+        unsigned repeat, string *contents, BarrierNotifiable *done)>
+    string_reader(string *ptr)
+    {
+        return [this, ptr](
+                   unsigned repeat, string *contents, BarrierNotifiable *done) {
+            attempt++;
+            if ((attempt & 1) == 0)
+            {
+                *contents = *ptr;
+                done->notify();
+                return true;
+            }
+            else
+            {
+                g_executor.add(
+                    new CallbackExecutable([done]() { done->notify(); }));
+                return false;
+            }
+        };
+    }
+
+    /// Creates a WriterFunction that just stores the data in a given string
+    /// variable.
+    /// @param ptr the string whose contents to return as read value. Must stay
+    /// alive as long as the function is in use.
+    /// @return the ReaderFunction.
+    std::function<void(
+        unsigned repeat, string contents, BarrierNotifiable *done)>
+    string_writer(string *ptr)
+    {
+        return [this, ptr](
+                   unsigned repeat, string contents, BarrierNotifiable *done) {
+            attempt++;
+            if ((attempt & 1) == 0)
+            {
+                *ptr = std::move(contents);
+                done->notify();
+                return true;
+            }
+            else
+            {
+                g_executor.add(
+                    new CallbackExecutable([done]() { done->notify(); }));
+                return false;
+            }
+        };
+    }
+
+private:
+    size_t attempt = 0;
+};
+
+class TestSpaceAsyncTest : public VirtualMemorySpaceTest
+{
+protected:
+    TestSpaceAsyncTest()
+    {
+        space_.reset(new TestSpaceAsync);
+        memCfg_.registry()->insert(node_, SPACE, space_.get());
+    }
+
+    /// Memory space number where the test space is registered.
+    const uint8_t SPACE = 0x52;
+};
+
+/// Basic tests reading variables from async space.
+TEST_F(TestSpaceAsyncTest, read_payload_async)
+{
+    arg1 = "hello";
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs, 13);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_STREQ("hello", b->data()->payload.c_str());
+    EXPECT_EQ(13u, b->data()->payload.size());
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs, 20);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_STREQ("", b->data()->payload.c_str());
+    EXPECT_EQ(20u, b->data()->payload.size());
+}
+
+/// Basic tests writing variables from the exact offset but not including
+/// partial writes.
+TEST_F(TestSpaceAsyncTest, write_payload_async)
+{
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs, "xyzw");
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ("xyzw", arg1);
+    EXPECT_EQ(4u, arg1.size());
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs, "abcde");
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ("abcde", arg2);
+    EXPECT_EQ(5u, arg2.size());
+}
 
 } // namespace openlcb

--- a/src/openlcb/VirtualMemorySpace.cxxtest
+++ b/src/openlcb/VirtualMemorySpace.cxxtest
@@ -176,6 +176,30 @@ TEST_F(TestSpaceTest, read_early)
     EXPECT_EQ(3u, b->data()->payload.size());
 }
 
+/// Test writing a variable to a offset that is not covered at all.
+TEST_F(TestSpaceTest, read_hole)
+{
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs-5, 3);
+    ASSERT_EQ(0, b->data()->resultCode);
+    string exp("\0\0\0", 3);
+    EXPECT_EQ(exp, b->data()->payload);
+
+    /// @todo this return seems to be wrong, although this address is out of
+    /// the memory space limits.
+    b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs-5, 2);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ(string(), b->data()->payload);
+
+    /// @todo this return seems to be wrong, although this address is out of
+    /// the memory space limits.
+    b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs + 100, 4);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ(string(), b->data()->payload);
+}
+
 /// Basic tests writing variables from the exact offset but not including
 /// partial writes.
 TEST_F(TestSpaceTest, write_payload)

--- a/src/openlcb/VirtualMemorySpace.cxxtest
+++ b/src/openlcb/VirtualMemorySpace.cxxtest
@@ -82,6 +82,11 @@ public:
             cfg.second(), string_reader(&arg2), string_writer(&arg2));
     }
 
+    /// Creates a ReaderFunction that just returns a string from a given
+    /// variable.
+    /// @param ptr the string whose contents to return as read value. Must stay
+    /// alive as long as the function is in use.
+    /// @return the ReaderFunction.
     std::function<bool(
         unsigned repeat, string *contents, BarrierNotifiable *done)>
     string_reader(string *ptr)
@@ -94,6 +99,11 @@ public:
             };
     }
 
+    /// Creates a WriterFunction that just stores the data in a given string
+    /// variable.
+    /// @param ptr the string whose contents to return as read value. Must stay
+    /// alive as long as the function is in use.
+    /// @return the ReaderFunction.
     std::function<void(
         unsigned repeat, string contents, BarrierNotifiable *done)>
     string_writer(string *ptr)
@@ -115,6 +125,7 @@ protected:
         memCfg_.registry()->insert(node_, SPACE, space_.get());
     }
 
+    /// Memory space number where the test space is registered.
     const uint8_t SPACE = 0x52;
 };
 
@@ -122,6 +133,8 @@ TEST_F(TestSpaceTest, create)
 {
 }
 
+/// Basic tests reading variables from the exact offset including partial
+/// reads.
 TEST_F(TestSpaceTest, read_payload)
 {
     arg1 = "hello";
@@ -144,6 +157,7 @@ TEST_F(TestSpaceTest, read_payload)
     EXPECT_EQ("hel", b->data()->payload);
 }
 
+/// Test reading a variable from an imprecise offset (too early).
 TEST_F(TestSpaceTest, read_early)
 {
     arg1 = "hello";
@@ -162,6 +176,8 @@ TEST_F(TestSpaceTest, read_early)
     EXPECT_EQ(3u, b->data()->payload.size());
 }
 
+/// Basic tests writing variables from the exact offset but not including
+/// partial writes.
 TEST_F(TestSpaceTest, write_payload)
 {
     auto b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
@@ -177,6 +193,7 @@ TEST_F(TestSpaceTest, write_payload)
     EXPECT_EQ(5u, arg2.size());
 }
 
+/// Test writing a variable to a offset that is too early.
 TEST_F(TestSpaceTest, write_early)
 {
     auto b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,

--- a/src/openlcb/VirtualMemorySpace.cxxtest
+++ b/src/openlcb/VirtualMemorySpace.cxxtest
@@ -209,4 +209,21 @@ TEST_F(TestSpaceTest, write_early)
     EXPECT_EQ(4u, arg2.size());
 }
 
+/// Test writing a variable to a offset that is not covered at all.
+TEST_F(TestSpaceTest, write_hole)
+{
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs-5, "xyz");
+    ASSERT_EQ(0, b->data()->resultCode);
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs-5, "qw");
+    ASSERT_EQ(0, b->data()->resultCode);
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs+100, "qw");
+    ASSERT_EQ(0, b->data()->resultCode);
+}
+
+
 } // namespace openlcb

--- a/src/openlcb/VirtualMemorySpace.hxx
+++ b/src/openlcb/VirtualMemorySpace.hxx
@@ -79,7 +79,7 @@ public:
     size_t write(address_t destination, const uint8_t *data, size_t len,
         errorcode_t *error, Notifiable *again) override
     {
-        if (destination > maxAddress_ || destination + len <= minAddress_)
+        if ((destination > maxAddress_) || ((destination + len) <= minAddress_))
         {
             *error = MemoryConfigDefs::ERROR_OUT_OF_BOUNDS;
             return 0;
@@ -129,7 +129,7 @@ public:
     size_t read(address_t source, uint8_t *dst, size_t len, errorcode_t *error,
         Notifiable *again) override
     {
-        if (source > maxAddress_ || source + len <= minAddress_)
+        if ((source > maxAddress_) || ((source + len) <= minAddress_))
         {
             *error = MemoryConfigDefs::ERROR_OUT_OF_BOUNDS;
             return 0;

--- a/src/openlcb/VirtualMemorySpace.hxx
+++ b/src/openlcb/VirtualMemorySpace.hxx
@@ -27,7 +27,7 @@
  * \file VirtualMemorySpace.hxx
  *
  * Implementation of a memory space where the values are not stored in a
- * contiguous storage area but are read anf written via callbacks.
+ * contiguous storage area but are read and written via callbacks.
  *
  * @author Balazs Racz
  * @date 10 Aug 2020
@@ -44,7 +44,7 @@ namespace openlcb
 {
 
 /// Implementation of a memory space where the values are not stored in a
-/// contiguous storage area but are read anf written via callbacks.
+/// contiguous storage area but are read and written via callbacks.
 class VirtualMemorySpace : public MemorySpace
 {
 public:

--- a/src/openlcb/VirtualMemorySpace.hxx
+++ b/src/openlcb/VirtualMemorySpace.hxx
@@ -1,0 +1,323 @@
+/** \copyright
+ * Copyright (c) 2020, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file VirtualMemorySpace.hxx
+ *
+ * Implementation of a memory space where the values are not stored in a
+ * contiguous storage area but are read anf written via callbacks.
+ *
+ * @author Balazs Racz
+ * @date 10 Aug 2020
+ */
+
+#ifndef _OPENLCB_VIRTUALMEMORYSPACE_HXX
+#define _OPENLCB_VIRTUALMEMORYSPACE_HXX
+
+#include "openlcb/ConfigEntry.hxx"
+#include "openlcb/MemoryConfig.hxx"
+#include "utils/SortedListMap.hxx"
+
+namespace openlcb
+{
+
+/// Implementation of a memory space where the values are not stored in a
+/// contiguous storage area but are read anf written via callbacks.
+class VirtualMemorySpace : public MemorySpace
+{
+public:
+    /// @returns whether the memory space does not accept writes.
+    bool read_only() override
+    {
+        return isReadOnly_;
+    }
+    /// @returns the lowest address that's valid for this block.
+    address_t min_address() override
+    {
+        return minAddress_;
+    }
+    /// @returns the largest valid address for this block.  A read of 1 from
+    /// this address should succeed in returning the last byte.
+    address_t max_address() override
+    {
+        return maxAddress_;
+    }
+
+    /// @return the number of bytes successfully written (before hitting end
+    /// of space).
+    /// @param destination address to write to
+    /// @param data to write
+    /// @param len how many bytes to write
+    /// @param error if set to non-null, then the operation has failed. If the
+    /// operation needs to be continued, then sets error to
+    /// MemorySpace::ERROR_AGAIN, and calls the Notifiable
+    /// @param again when a re-try makes sense. The caller should call write
+    /// once more, with the offset adjusted with the previously returned
+    /// bytes.
+    size_t write(address_t destination, const uint8_t *data, size_t len,
+        errorcode_t *error, Notifiable *again) override
+    {
+        if (destination > maxAddress_ || destination + len <= minAddress_)
+        {
+            *error = MemoryConfigDefs::ERROR_OUT_OF_BOUNDS;
+            return 0;
+        }
+        *error = 0;
+        unsigned repeat;
+        const DataElement *element = nullptr;
+        ssize_t skip = find_data_element(destination, len, &element, &repeat);
+        string payload;
+        if (skip > 0)
+        {
+            // Will cause a new call be delivered with adjusted data and len.
+            return skip;
+        }
+        else if (skip < 0)
+        {
+            // We have some missing bytes that we need to read out first, then
+            // can perform the write.
+            DIE("unimplemented");
+            // if (!element->readImpl_(repeat, &payload,
+        }
+        HASSERT(element);
+        payload.assign(
+            (const char *)data, std::min((size_t)len, (size_t)element->size_));
+        size_t written_len = payload.size();
+        bn_.reset(again);
+        element->writeImpl_(repeat, std::move(payload), bn_.new_child());
+        if (!bn_.abort_if_almost_done())
+        {
+            // did not succeed synchronously.
+            *error = MemorySpace::ERROR_AGAIN;
+            return 0;
+        }
+        return written_len;
+    }
+
+    /** @returns the number of bytes successfully read (before hitting end of
+     * space). If *error is set to non-null, then the operation has failed. If
+     * the operation needs to be continued, then sets error to ERROR_AGAIN, and
+     * calls the Notifiable @param again when a re-try makes sense. The caller
+     * should call read once more, with the offset adjusted with the previously
+     * returned bytes. */
+    size_t read(address_t source, uint8_t *dst, size_t len, errorcode_t *error,
+        Notifiable *again) override
+    {
+        if (source > maxAddress_ || source + len <= minAddress_)
+        {
+            *error = MemoryConfigDefs::ERROR_OUT_OF_BOUNDS;
+            return 0;
+        }
+        *error = 0;
+        unsigned repeat;
+        const DataElement *element = nullptr;
+        ssize_t skip = find_data_element(source, len, &element, &repeat);
+        if (skip > 0)
+        {
+            memset(dst, 0, skip);
+            return skip;
+        }
+        else if (skip < 0)
+        {
+            DIE("unimplemented");
+        }
+        HASSERT(element);
+        string payload;
+        bn_.reset(again);
+        element->readImpl_(repeat, &payload, bn_.new_child());
+        if (!bn_.abort_if_almost_done())
+        {
+            // did not succeed synchronously.
+            *error = MemorySpace::ERROR_AGAIN;
+            return 0;
+        }
+        payload.resize(element->size_); // pads with zeroes
+        size_t data_len = std::min(payload.size(), len);
+        memcpy(dst, payload.data(), data_len);
+        return data_len;
+    }
+
+protected:
+    /// Function that will be called for writes.
+    /// @param repeat 0 to number of repeats if this is in a repeated
+    /// group. Always 0 if not repeated group.
+    /// @param contents data payload that needs to be written. The data
+    /// bytes of this container start at the address_.
+    /// @param done must be notified when the write is complete (possibly
+    /// inline).
+    using WriteFunction = std::function<void(
+        unsigned repeat, string contents, BarrierNotifiable *done)>;
+    /// Function that will be called for reads.
+    /// @param repeat 0 to number of repeats if this is in a repeated
+    /// group. Always 0 if not repeated group.
+    /// @param contents the payload to be returned from this variable shall
+    /// be written here. Will be zero-padded to size_ bytes if shorter.
+    /// @param done must be notified when the read values are ready. The
+    /// call will be re-tried in this case.
+    /// @return true if the read was successful, false if the read needs to be
+    /// re-tried later,
+    using ReadFunction = std::function<bool(
+        unsigned repeat, string *contents, BarrierNotifiable *done)>;
+
+    /// Setup the address bounds from a single CDI group declaration.
+    /// @param group is an instance of a group, for example a segment.
+    template <class G> void set_bounds_from_group(const G &group)
+    {
+        minAddress_ = group.offset();
+        maxAddress_ = group.offset() + group.size() - 1;
+    }
+
+    /// Expand the address bounds from a single CDI group declaration.
+    /// @param group is an instance of a group, for example a segment.
+    template <class G> void expand_bounds_from_group(const G &group)
+    {
+        minAddress_ = std::min(minAddress_, group.offset());
+        maxAddress_ = std::max(maxAddress_, group.offset() + group.size() - 1);
+    }
+
+    /// Register an untyped element.
+    /// @param address the address in the memory space
+    /// @param size how many bytes this elements occupes
+    /// @param read_f will be called to read this data
+    /// @param write_f will be called to write this data
+    void register_element(address_t address, address_t size,
+        ReadFunction read_f, WriteFunction write_f)
+    {
+        elements_.insert(DataElement(address, size, read_f, write_f));
+    }
+
+    /// Registers a string typed element.
+    /// @param entry is the CDI ConfigRepresentation.
+    /// @param read_f will be called to read this data
+    /// @param write_f will be called to write this data
+    template <unsigned SIZE>
+    void register_string(const StringConfigEntry<SIZE> &entry,
+        ReadFunction read_f, WriteFunction write_f)
+    {
+        expand_bounds_from_group(entry);
+        register_element(entry.offset(), SIZE, read_f, write_f);
+    }
+
+    /// Bounds for valid addresses.
+    address_t minAddress_ = 0xFFFFFFFFu;
+    /// Bounds for valid addresses.  A read of length 1 from this address
+    /// should succeed in returning the last byte.
+    address_t maxAddress_ = 0;
+    /// Whether the space should report as RO.
+    bool isReadOnly_ = false;
+
+private:
+    /// We keep one of these for each variable that was declared.
+    struct DataElement
+    {
+        DataElement(address_t address, address_t size, ReadFunction read_f,
+            WriteFunction write_f)
+            : address_(address)
+            , size_(size)
+            , writeImpl_(write_f)
+            , readImpl_(read_f)
+        {
+        }
+        /// Base offset of this variable (first repeat only).
+        address_t address_;
+        /// Size of this variable. This is how many bytes of address space this
+        /// variable occupies.
+        address_t size_;
+        /// Function that will be called for writes.
+        WriteFunction writeImpl_;
+        /// Function that will be called for reads.
+        ReadFunction readImpl_;
+    };
+
+    struct Comparator
+    {
+        /// Sorting operator by address.
+        bool operator()(const DataElement &a, const DataElement &b) const
+        {
+            return a.address_ < b.address_;
+        }
+        /// Sorting operator by address.
+        bool operator()(unsigned a, const DataElement &b) const
+        {
+            return a < b.address_;
+        }
+    };
+
+    /// Look up the first matching data element given an address in the virtual
+    /// memory space.
+    /// @param address byte offset to look up.
+    /// @param len how many bytes long range to search from address.
+    /// @param ptr will be filled with a pointer to the data element when
+    /// found, or filled with nullptr if no data element overlaps with the
+    /// given range.
+    /// @param repeat output argument, filled with zero or the repetition
+    /// number.
+    /// @return 0 if an exact match is found. -N if a data element is found,
+    /// but N first bytes of this element are not covered. A number N in
+    /// [1..len-1] if a data element is found, but this many bytes need to be
+    /// skipped from address to arrive at the given data element's offset. len
+    /// if there was no data element found (in which case also set ptr to
+    /// null).
+    ssize_t find_data_element(address_t address, address_t len,
+        const DataElement **ptr, unsigned *repeat)
+    {
+        *repeat = 0;
+        *ptr = nullptr;
+        auto it = elements_.upper_bound(address);
+        if (it != elements_.begin())
+        {
+            auto pit = it - 1;
+            // now: pit->address_ <= address
+            if (pit->address_ + pit->size_ > address)
+            {
+                // found overlap
+                *ptr = &*pit;
+                return (ssize_t)pit->address_ -
+                    (ssize_t)address; // may be negative!
+            }
+            // else: no overlap, look at the next item
+        }
+        // now: it->address_ > address
+        if (address + len > it->address_)
+        {
+            // found overlap, but some data needs to be discarded.
+            *ptr = &*it;
+            return it->address_ - address;
+        }
+        /// @todo try repeated fields here first.
+
+        // now: no overlap either before or after.
+        return len;
+    }
+
+    /// Stores all the registered variables.
+    SortedListSet<DataElement, Comparator> elements_;
+    /// Helper object in the function calls.
+    BarrierNotifiable bn_;
+}; // class VirtualMemorySpace
+
+} // namespace openlcb
+
+#endif // _OPENLCB_VIRTUALMEMORYSPACE_HXX


### PR DESCRIPTION
The VirtualMemorySpace is an implementation of a MemorySpace interface which does not have a linear storage space behind. Instead, each variable is registered with a callback to write and read. This allows various advanced features, such as remapping address space, creating holes, really huge repetitions, etc.
This is the first cut of an implementation that is not feature complete, only one data type is supported, and has todos left.