### PR TITLE
Moving socket listener stack size and backlog count to constants.

### DIFF
--- a/include/nmranet_config.h
+++ b/include/nmranet_config.h
@@ -146,5 +146,10 @@ DECLARE_CONST(enable_all_memory_space);
  * standard. */
 DECLARE_CONST(node_init_identify);
 
+/** Stack size for @ref SocketListener threads. */
+DECLARE_CONST(socket_listener_stack_size);
+
+/** Number of sockets to allow for @ref SocketListener backlog. */
+DECLARE_CONST(socket_listener_backlog);
 
 #endif /* _nmranet_config_h_ */

--- a/src/utils/constants.cxx
+++ b/src/utils/constants.cxx
@@ -152,3 +152,15 @@ DEFAULT_CONST(gridconnect_bridge_max_incoming_packets, 1);
 DEFAULT_CONST(gridconnect_bridge_max_outgoing_packets, 1);
 
 DEFAULT_CONST_FALSE(gridconnect_tcp_use_select);
+
+#ifdef ESP32
+/// Use a stack size of 3kb for SocketListener tasks.
+DEFAULT_CONST(socket_listener_stack_size, 3072);
+/// Allow one socket to be pending for accept() in SocketListener.
+DEFAULT_CONST(socket_listener_backlog, 1);
+#else
+/// Use a stack size of 1000 for SocketListener tasks.
+DEFAULT_CONST(socket_listener_stack_size, 1000);
+/// Allow up to five sockets to be pending for accept() in SocketListener.
+DEFAULT_CONST(socket_listener_backlog, 5);
+#endif

--- a/src/utils/socket_listener.cxx
+++ b/src/utils/socket_listener.cxx
@@ -51,34 +51,27 @@
 #include <signal.h>
 #include <unistd.h>
 
+#include "nmranet_config.h"
+#include "utils/logging.h"
+#include "utils/macros.h"
 #include "utils/socket_listener.hxx"
 
-#include "utils/macros.h"
-#include "utils/logging.h"
-
-
-static void* accept_thread_start(void* arg) {
+static void* accept_thread_start(void* arg)
+{
   SocketListener* l = static_cast<SocketListener*>(arg);
   l->AcceptThreadBody();
   return NULL;
 }
 
-#ifdef ESP32
-/// Stack size to use for the accept_thread_.
-static constexpr size_t listener_stack_size = 2048;
-#else
-/// Stack size to use for the accept_thread_.
-static constexpr size_t listener_stack_size = 1000;
-#endif // ESP32
-
-SocketListener::SocketListener(int port, connection_callback_t callback)
+SocketListener::SocketListener(int port, connection_callback_t callback,
+                               const char *thread_name)
     : startupComplete_(0),
       shutdownRequested_(0),
       shutdownComplete_(0),
       port_(port),
       callback_(callback),
-      accept_thread_("accept_thread", 0, listener_stack_size,
-        accept_thread_start, this)
+      accept_thread_(thread_name, 0, config_socket_listener_stack_size(),
+                     accept_thread_start, this)
 {
 #if OPENMRN_FEATURE_BSD_SOCKETS_IGNORE_SIGPIPE
     // We expect write failures to occur but we want to handle them where the
@@ -87,8 +80,10 @@ SocketListener::SocketListener(int port, connection_callback_t callback)
 #endif // OPENMRN_FEATURE_BSD_SOCKETS_IGNORE_SIGPIPE
 }
 
-SocketListener::~SocketListener() {
-    if (!shutdownComplete_) {
+SocketListener::~SocketListener()
+{
+    if (!shutdownComplete_)
+    {
         shutdown();
     }
 }
@@ -96,12 +91,14 @@ SocketListener::~SocketListener() {
 void SocketListener::shutdown()
 {
     shutdownRequested_ = 1;
-    while (!shutdownComplete_) {
+    while (!shutdownComplete_)
+    {
         usleep(1000);
     }
 }
 
-void SocketListener::AcceptThreadBody() {
+void SocketListener::AcceptThreadBody()
+{
   socklen_t namelen;
   struct sockaddr_in addr;
   int listenfd;
@@ -129,7 +126,7 @@ void SocketListener::AcceptThreadBody() {
 
   // FreeRTOS+TCP uses the parameter to listen to set the maximum number of
   // connections to the given socket, so allow some room
-  ERRNOCHECK("listen", listen(listenfd, 5));
+  ERRNOCHECK("listen", listen(listenfd, config_socket_listener_backlog()));
 
   LOG(INFO, "Listening on port %d, fd %d", ntohs(addr.sin_port), listenfd);
 
@@ -147,16 +144,20 @@ void SocketListener::AcceptThreadBody() {
 
   startupComplete_ = 1;
 
-  while (!shutdownRequested_) {
+  while (!shutdownRequested_)
+  {
     namelen = sizeof(addr);
     connfd = accept(listenfd,
                     (struct sockaddr *)&addr,
                     &namelen);
-    if (connfd < 0) {
-      if (errno == EINTR || errno == EAGAIN || errno == EMFILE) {
+    if (connfd < 0)
+    {
+      if (errno == EINTR || errno == EAGAIN || errno == EMFILE)
+      {
         continue;
       }
-      else if (errno == ECONNABORTED) {
+      else if (errno == ECONNABORTED)
+      {
         break;
       }
       print_errno_and_exit("accept");

--- a/src/utils/socket_listener.cxx
+++ b/src/utils/socket_listener.cxx
@@ -40,6 +40,12 @@
 #define _DEFAULT_SOURCE
 #endif
 
+#include "utils/socket_listener.hxx"
+
+#include "nmranet_config.h"
+#include "utils/logging.h"
+#include "utils/macros.h"
+
 #ifndef ESP32 // these don't exist on the ESP32 with LWiP
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -50,11 +56,6 @@
 #include <sys/types.h>
 #include <signal.h>
 #include <unistd.h>
-
-#include "nmranet_config.h"
-#include "utils/logging.h"
-#include "utils/macros.h"
-#include "utils/socket_listener.hxx"
 
 static void* accept_thread_start(void* arg)
 {

--- a/src/utils/socket_listener.hxx
+++ b/src/utils/socket_listener.hxx
@@ -60,7 +60,9 @@ public:
     ///
     /// @param port which TCP port number to listen upon.
     /// @param callback will be called on each incoming connection.
-    SocketListener(int port, connection_callback_t callback);
+    /// @param thread_name name to assign to the OSThread.
+    SocketListener(int port, connection_callback_t callback,
+                   const char *thread_name = "accept_thread");
     ~SocketListener();
 
     /// Implementation of the accept thread.


### PR DESCRIPTION
As we discussed over email, the default number of sockets available for use is 10 with a max of 16. With the default backlog size of five it leaves only five additional sockets before errors will be reported by LwIP. ESP-IDF examples limit the backlog to one and thus that is the default with this PR.

This PR also includes optional naming of the SocketListener thread (useful when more than one listener is in use)

Fixes https://github.com/bakerstu/openmrn/issues/256