### PR TITLE
Refactors all usages of strncpy.

### DIFF
--- a/src/freertos_drivers/net_cc32xx/CC32xxWiFi.cxx
+++ b/src/freertos_drivers/net_cc32xx/CC32xxWiFi.cxx
@@ -765,7 +765,7 @@ void CC32xxWiFi::wlan_setup_ap(const char *ssid, const char *security_key,
                (uint8_t*)ssid);
     if (wlanRole == WlanRole::AP)
     {
-        strncpy(this->ssid, ssid, sizeof(this->ssid));
+        str_populate(this->ssid, ssid);
     }
     
     sl_WlanSet(SL_WLAN_CFG_AP_ID, SL_WLAN_AP_OPT_SECURITY_TYPE, 1,

--- a/src/openlcb/SimpleNodeInfo.cxx
+++ b/src/openlcb/SimpleNodeInfo.cxx
@@ -35,6 +35,7 @@
 #include "openlcb/SimpleNodeInfo.hxx"
 
 #include "openmrn_features.h"
+#include "utils/format_utils.hxx"
 
 namespace openlcb
 {
@@ -67,9 +68,8 @@ void init_snip_user_file(int fd, const char *user_name,
     SimpleNodeDynamicValues data;
     memset(&data, 0, sizeof(data));
     data.version = 2;
-    strncpy(data.user_name, user_name, sizeof(data.user_name));
-    strncpy(data.user_description, user_description,
-            sizeof(data.user_description));
+    str_populate(data.user_name, user_name);
+    str_populate(data.user_description, user_description);
     int ofs = 0;
     auto *p = (const uint8_t *)&data;
     const int len = sizeof(data);

--- a/src/openlcb/SimpleNodeInfoMockUserFile.cxx
+++ b/src/openlcb/SimpleNodeInfoMockUserFile.cxx
@@ -37,7 +37,9 @@
 #define  _POSIX_C_SOURCE  200112L
 #endif
 
-#include "SimpleNodeInfoMockUserFile.hxx"
+#include "openlcb/SimpleNodeInfoMockUserFile.hxx"
+
+#include "utils/format_utils.hxx"
 
 #ifdef __FreeRTOS__
 openlcb::MockSNIPUserFile::MockSNIPUserFile(const char *user_name,
@@ -45,9 +47,8 @@ openlcb::MockSNIPUserFile::MockSNIPUserFile(const char *user_name,
     : snipData_{2}
     , userFile_(MockSNIPUserFile::snip_user_file_path, &snipData_, false)
 {
-    strncpy(snipData_.user_name, user_name, sizeof(snipData_.user_name));
-    strncpy(snipData_.user_description, user_description,
-            sizeof(snipData_.user_description));
+    str_populate(snipData_.user_name, user_name);
+    str_populate(snipData_.user_description, user_description);
 }
 
 openlcb::MockSNIPUserFile::~MockSNIPUserFile()
@@ -63,8 +64,7 @@ openlcb::MockSNIPUserFile::MockSNIPUserFile(const char *user_name,
 {
     init_snip_user_file(userFile_.fd(), user_name, user_description);
     HASSERT(userFile_.name().size() < sizeof(snip_user_file_path));
-    strncpy(snip_user_file_path, userFile_.name().c_str(),
-            sizeof(snip_user_file_path));
+    str_populate(snip_user_file_path, userFile_.name().c_str());
 }
 
 char openlcb::MockSNIPUserFile::snip_user_file_path[128] = "/dev/zero";

--- a/src/os/MDNS.cxx
+++ b/src/os/MDNS.cxx
@@ -296,7 +296,7 @@ void MDNS::resolve_callback(AvahiServiceResolver *r,
                     sa_in->sin6_flowinfo = 0;
                     sa_in->sin6_family = AF_INET6;
                     sa_in->sin6_port = htons(port);
-                    memcpy(&sa_in->sin6_addr.s6_addr,
+                    memcpy(&(sa_in->sin6_addr.s6_addr),
                            address->data.ipv6.address,
                            sizeof(address->data.ipv6.address));
                     break;

--- a/src/utils/EntryModel.hxx
+++ b/src/utils/EntryModel.hxx
@@ -120,8 +120,7 @@ public:
                 }
                 break;
         }
-        strncpy(data_, str.c_str(), sizeof(data_) - 1);
-        data_[sizeof(data_) - 1] = '\0';
+        str_populate(data_, str.c_str());
         hasInitial_ = true;
     }
 

--- a/src/utils/format_utils.hxx
+++ b/src/utils/format_utils.hxx
@@ -36,6 +36,7 @@
 #define _UTILS_FORMAT_UTILS_HXX_
 
 #include <string>
+#include <string.h>
 
 /** Renders an integer to string, left-justified. @param buffer must be an at
  * @param buffer must be an at least 10 character long array.
@@ -161,6 +162,19 @@ string ipv4_to_string(uint8_t ip[4]);
 inline string ipv4_to_string(uint32_t ip)
 {
     return ipv4_to_string((uint8_t*)&ip);
+}
+
+/// Populates a character array with a C string. Copies the C string,
+/// appropriately truncating if it is too long and filling the remaining space
+/// with zeroes. Ensures that at least one null terminator character is
+/// present.
+/// @param dst a character array of fixed length, declared as char sdata[N]
+/// @param src a C string to fill it with.
+template <unsigned int N>
+inline void str_populate(char (&dst)[N], const char *src)
+{
+    strncpy(dst, src, N - 1);
+    dst[N - 1] = 0;
 }
 
 #endif // _UTILS_FORMAT_UTILS_HXX_


### PR DESCRIPTION
Adds a new function str_populate that invokes strncpy in length-safe manner,
ensuring that a terminating null is present even if the string is truncated.
Using C++ templates this also allows the caller not to need to specify the
length of the char[] array, which is safer.

Replaces all calls to strncpy that were writing into a fixed size C array
with the new function.

Fixes #424 