### PR TITLE
 Completes VirtualMemorySpace implementation

### DIFF
--- a/src/openlcb/VirtualMemorySpace.cxxtest
+++ b/src/openlcb/VirtualMemorySpace.cxxtest
@@ -201,6 +201,25 @@ TEST_F(TestSpaceTest, read_hole)
     EXPECT_EQ(string(), b->data()->payload);
 }
 
+/// Test reading beyond eof.
+TEST_F(TestSpaceTest, read_eof)
+{
+    unsigned reg_last = cfg.second().offset();
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, reg_last, 50);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ(20u, b->data()->payload.size());
+    b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, reg_last + 20, 50);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ(0u, b->data()->payload.size());
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, reg_last + 23, 50);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ(0u, b->data()->payload.size());
+}
+
 /// Basic tests writing variables from the exact offset but not including
 /// partial writes.
 TEST_F(TestSpaceTest, write_payload)
@@ -565,6 +584,7 @@ using GroupRept = RepeatedGroup<ExampleMemorySpace, 3>;
 CDI_GROUP_ENTRY(grp, GroupRept);
 CDI_GROUP_ENTRY(skipped3, EmptyGroup<8>);
 CDI_GROUP_ENTRY(after, StringConfigEntry<20>);
+CDI_GROUP_ENTRY(grp2, GroupRept);
 CDI_GROUP_END();
 
 RepeatMemoryDef spacerept(22);
@@ -585,6 +605,9 @@ public:
         register_string(
             spacerept.after(), string_reader(&after_), string_writer(&after_));
         register_repeat(spacerept.grp());
+        register_string(spacerept.grp2().entry<0>().second(),
+            string_reader(&arg2), string_writer(&arg2));
+        register_repeat(spacerept.grp2());
     }
 
     /// Creates a ReaderFunction that just returns a string from a given
@@ -759,5 +782,26 @@ TEST_F(ReptSpaceTest, mid_repeat)
     EXPECT_EQ(string("\0\0aho", 5), b->data()->payload);
     EXPECT_EQ(2u, s_.lastRepeat_);
 }
+
+/// Test reading beyond eof.
+TEST_F(ReptSpaceTest, read_eof)
+{
+    unsigned reg_last = spacerept.grp2().entry<2>().second().offset();
+    EXPECT_EQ(reg_last + 27, s_.max_address());
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, reg_last, 50);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ(20u, b->data()->payload.size());
+    b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, reg_last + 20, 50);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ(0u, b->data()->payload.size());
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, reg_last + 23, 50);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ(0u, b->data()->payload.size());
+}
+
 
 } // namespace openlcb

--- a/src/openlcb/VirtualMemorySpace.cxxtest
+++ b/src/openlcb/VirtualMemorySpace.cxxtest
@@ -300,28 +300,25 @@ TEST_F(TestSpaceTest, write_middle)
     payload.push_back(0);
 
     b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
-        NodeHandle(node_->node_id()), SPACE, arg2_ofs,
-        payload.substr(0, 10));
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs, payload.substr(0, 10));
     ASSERT_EQ(0, b->data()->resultCode);
     EXPECT_EQ("0123456789", arg2);
-    
+
     b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
         NodeHandle(node_->node_id()), SPACE, arg2_ofs + 10,
-                    payload.substr(10, 3));
+        payload.substr(10, 3));
     ASSERT_EQ(0, b->data()->resultCode);
     EXPECT_STREQ("0123456789abc", arg2.c_str());
     b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
         NodeHandle(node_->node_id()), SPACE, arg2_ofs + 13,
-                    payload.substr(13, 2));
+        payload.substr(13, 2));
     ASSERT_EQ(0, b->data()->resultCode);
     EXPECT_STREQ("0123456789abcde", arg2.c_str());
     b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
-        NodeHandle(node_->node_id()), SPACE, arg2_ofs + 15,
-                    payload.substr(15));
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs + 15, payload.substr(15));
     ASSERT_EQ(0, b->data()->resultCode);
     EXPECT_STREQ("0123456789abcdef", arg2.c_str());
 }
-
 
 /// Test writing a variable to a offset that is not covered at all.
 TEST_F(TestSpaceTest, write_hole)
@@ -891,6 +888,5 @@ TEST_F(ReptSpaceTest, read_eof)
     ASSERT_EQ(0, b->data()->resultCode);
     EXPECT_EQ(0u, b->data()->payload.size());
 }
-
 
 } // namespace openlcb

--- a/src/openlcb/VirtualMemorySpace.cxxtest
+++ b/src/openlcb/VirtualMemorySpace.cxxtest
@@ -177,6 +177,27 @@ TEST_F(TestSpaceTest, read_early)
     EXPECT_EQ(3u, b->data()->payload.size());
 }
 
+/// Test reading a variable from an imprecise offset (too late -- middle of
+/// variable).
+TEST_F(TestSpaceTest, read_middle)
+{
+    arg1 = "hello";
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs + 2, 10);
+    ASSERT_EQ(0, b->data()->resultCode);
+    string exp("llo\0\0\0\0\0\0\0", 10);
+    EXPECT_EQ(exp, b->data()->payload);
+    EXPECT_EQ(10u, b->data()->payload.size());
+
+    arg2 = "abcdefghij";
+    b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs + 2, 3);
+    ASSERT_EQ(0, b->data()->resultCode);
+    string exp2("cde", 3);
+    EXPECT_EQ(exp2, b->data()->payload);
+    EXPECT_EQ(3u, b->data()->payload.size());
+}
+
 /// Test writing a variable to a offset that is not covered at all.
 TEST_F(TestSpaceTest, read_hole)
 {
@@ -252,6 +273,55 @@ TEST_F(TestSpaceTest, write_early)
     EXPECT_EQ("wert", arg2);
     EXPECT_EQ(4u, arg2.size());
 }
+
+/// Test writing into to a offset that is in the middle of a variable.
+TEST_F(TestSpaceTest, write_middle)
+{
+    arg1 = "hellllo";
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs + 3, "xy");
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ(string("helxylo\0\0\0\0\0\0", 13), arg1);
+
+    // Writes to middle then beyond the end of the variable.
+    string payload(19, 'a');
+    payload += "bbbbbbbbb";
+    arg2 = "0123456789i123456789";
+    b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs + 3, payload);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ("helaaaaaaaaaa", arg1);
+    EXPECT_EQ(13u, arg1.size());
+    EXPECT_EQ("abbbbbbbbb", arg2);
+    EXPECT_EQ(10u, arg2.size());
+
+    // Writes a string in multiple datagrams.
+    payload = "0123456789abcdef";
+    payload.push_back(0);
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs,
+        payload.substr(0, 10));
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ("0123456789", arg2);
+    
+    b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs + 10,
+                    payload.substr(10, 3));
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_STREQ("0123456789abc", arg2.c_str());
+    b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs + 13,
+                    payload.substr(13, 2));
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_STREQ("0123456789abcde", arg2.c_str());
+    b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs + 15,
+                    payload.substr(15));
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_STREQ("0123456789abcdef", arg2.c_str());
+}
+
 
 /// Test writing a variable to a offset that is not covered at all.
 TEST_F(TestSpaceTest, write_hole)
@@ -783,22 +853,41 @@ TEST_F(ReptSpaceTest, mid_repeat)
     EXPECT_EQ(2u, s_.lastRepeat_);
 }
 
-/// Test reading beyond eof.
+/// Test reading beyond eof.  The end of the space there is a repeated group
+/// where the registry entries do not cover all bytes. This is a difficult
+/// cornercase and we test that all bytes until the end of the repetition can
+/// be read but not beyond.
 TEST_F(ReptSpaceTest, read_eof)
 {
     unsigned reg_last = spacerept.grp2().entry<2>().second().offset();
+    // EOF is 28 bytes away from here.
     EXPECT_EQ(reg_last + 27, s_.max_address());
     auto b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
         NodeHandle(node_->node_id()), SPACE, reg_last, 50);
     ASSERT_EQ(0, b->data()->resultCode);
-    EXPECT_EQ(20u, b->data()->payload.size());
+    EXPECT_EQ(28u, b->data()->payload.size());
     b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
         NodeHandle(node_->node_id()), SPACE, reg_last + 20, 50);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ(8u, b->data()->payload.size());
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, reg_last + 23, 50);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ(5u, b->data()->payload.size());
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, reg_last + 27, 50);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ(1u, b->data()->payload.size());
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, reg_last + 28, 50);
     ASSERT_EQ(0, b->data()->resultCode);
     EXPECT_EQ(0u, b->data()->payload.size());
 
     b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
-        NodeHandle(node_->node_id()), SPACE, reg_last + 23, 50);
+        NodeHandle(node_->node_id()), SPACE, reg_last + 29, 50);
     ASSERT_EQ(0, b->data()->resultCode);
     EXPECT_EQ(0u, b->data()->payload.size());
 }

--- a/src/openlcb/VirtualMemorySpace.cxxtest
+++ b/src/openlcb/VirtualMemorySpace.cxxtest
@@ -539,6 +539,27 @@ TEST_F(TestSpaceAsyncTest, read_payload_async)
     EXPECT_EQ(20u, b->data()->payload.size());
 }
 
+/// Test reading a variable from an imprecise offset (too late -- middle of
+/// variable).
+TEST_F(TestSpaceAsyncTest, read_middle)
+{
+    arg1 = "hello";
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs + 2, 10);
+    ASSERT_EQ(0, b->data()->resultCode);
+    string exp("llo\0\0\0\0\0\0\0", 10);
+    EXPECT_EQ(exp, b->data()->payload);
+    EXPECT_EQ(10u, b->data()->payload.size());
+
+    arg2 = "abcdefghij";
+    b = invoke_flow(&client_, MemoryConfigClientRequest::READ_PART,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs + 2, 3);
+    ASSERT_EQ(0, b->data()->resultCode);
+    string exp2("cde", 3);
+    EXPECT_EQ(exp2, b->data()->payload);
+    EXPECT_EQ(3u, b->data()->payload.size());
+}
+
 /// Basic tests writing variables from the exact offset but not including
 /// partial writes.
 TEST_F(TestSpaceAsyncTest, write_payload_async)
@@ -554,6 +575,52 @@ TEST_F(TestSpaceAsyncTest, write_payload_async)
     ASSERT_EQ(0, b->data()->resultCode);
     EXPECT_EQ("abcde", arg2);
     EXPECT_EQ(5u, arg2.size());
+}
+
+/// Test writing into to a offset that is in the middle of a variable.
+TEST_F(TestSpaceAsyncTest, write_middle)
+{
+    arg1 = "hellllo";
+    auto b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs + 3, "xy");
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ(string("helxylo\0\0\0\0\0\0", 13), arg1);
+
+    // Writes to middle then beyond the end of the variable.
+    string payload(19, 'a');
+    payload += "bbbbbbbbb";
+    arg2 = "0123456789i123456789";
+    b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg1_ofs + 3, payload);
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ("helaaaaaaaaaa", arg1);
+    EXPECT_EQ(13u, arg1.size());
+    EXPECT_EQ("abbbbbbbbb", arg2);
+    EXPECT_EQ(10u, arg2.size());
+
+    // Writes a string in multiple datagrams.
+    payload = "0123456789abcdef";
+    payload.push_back(0);
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs, payload.substr(0, 10));
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_EQ("0123456789", arg2);
+
+    b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs + 10,
+        payload.substr(10, 3));
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_STREQ("0123456789abc", arg2.c_str());
+    b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs + 13,
+        payload.substr(13, 2));
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_STREQ("0123456789abcde", arg2.c_str());
+    b = invoke_flow(&client_, MemoryConfigClientRequest::WRITE,
+        NodeHandle(node_->node_id()), SPACE, arg2_ofs + 15, payload.substr(15));
+    ASSERT_EQ(0, b->data()->resultCode);
+    EXPECT_STREQ("0123456789abcdef", arg2.c_str());
 }
 
 /// Tests reading and writing numeric variables with endianness.

--- a/src/openlcb/VirtualMemorySpace.hxx
+++ b/src/openlcb/VirtualMemorySpace.hxx
@@ -85,6 +85,10 @@ public:
             *error = MemoryConfigDefs::ERROR_OUT_OF_BOUNDS;
             return 0;
         }
+        if (destination + len > maxAddress_ + 1)
+        {
+            len = maxAddress_ + 1 - destination;
+        }
         *error = 0;
         unsigned repeat;
         const DataElement *element = nullptr;
@@ -134,6 +138,10 @@ public:
         {
             *error = MemoryConfigDefs::ERROR_OUT_OF_BOUNDS;
             return 0;
+        }
+        if (source + len > maxAddress_ + 1)
+        {
+            len = maxAddress_ + 1 - source;
         }
         *error = 0;
         unsigned repeat;

--- a/src/openlcb/VirtualMemorySpace.hxx
+++ b/src/openlcb/VirtualMemorySpace.hxx
@@ -49,6 +49,11 @@ namespace openlcb
 class VirtualMemorySpace : public MemorySpace
 {
 public:
+    VirtualMemorySpace()
+        : isReadOnly_(false)
+    {
+    }
+
     /// @returns whether the memory space does not accept writes.
     bool read_only() override
     {
@@ -94,6 +99,7 @@ public:
         const DataElement *element = nullptr;
         ssize_t skip = find_data_element(destination, len, &element, &repeat);
         string payload;
+        size_t written_len;        
         if (skip > 0)
         {
             // Will cause a new call be delivered with adjusted data and len.
@@ -101,19 +107,43 @@ public:
         }
         else if (skip < 0)
         {
+            HASSERT(element);
             // We have some missing bytes that we need to read out first, then
             // can perform the write.
-            DIE("unimplemented");
-            // if (!element->readImpl_(repeat, &payload,
+            address_t field_start = destination + skip;
+            if (!(cacheOffset_ == field_start &&
+                    (cachedData_.size() >= (size_t)-skip)))
+            {
+                cacheOffset_ = field_start;
+                cachedData_.clear();
+                bn_.reset(again);
+                element->readImpl_(repeat, &cachedData_, bn_.new_child());
+                if (!bn_.abort_if_almost_done())
+                {
+                    // did not succeed synchronously.
+                    bn_.notify(); // our slice
+                    *error = MemorySpace::ERROR_AGAIN;
+                    return 0;
+                }
+                cachedData_.resize(element->size_); // pads with zeroes
+            }
+            // Now: cachedData_ contains the payload in the current storage.
+            payload = cachedData_;
+            written_len = std::min((size_t)len, (size_t)(element->size_ + skip));
+            memcpy(&payload[-skip], (const char *)data, written_len);
         }
-        HASSERT(element);
-        payload.assign(
-            (const char *)data, std::min((size_t)len, (size_t)element->size_));
-        size_t written_len = payload.size();
+        else // exact address write.
+        {
+            HASSERT(element);
+            payload.assign((const char *)data,
+                std::min((size_t)len, (size_t)element->size_));
+            written_len = payload.size();
+        }
         bn_.reset(again);
         element->writeImpl_(repeat, std::move(payload), bn_.new_child());
         if (bn_.abort_if_almost_done())
         {
+            cachedData_.clear();
             return written_len;
         }
         else
@@ -152,10 +182,7 @@ public:
             memset(dst, 0, skip);
             return skip;
         }
-        else if (skip < 0)
-        {
-            DIE("unimplemented");
-        }
+        // Now: skip <= 0
         HASSERT(element);
         string payload;
         bn_.reset(again);
@@ -168,8 +195,8 @@ public:
             return 0;
         }
         payload.resize(element->size_); // pads with zeroes
-        size_t data_len = std::min(payload.size(), len);
-        memcpy(dst, payload.data(), data_len);
+        size_t data_len = std::min(payload.size() + skip, len);
+        memcpy(dst, payload.data() - skip, data_len);
         return data_len;
     }
 
@@ -299,7 +326,7 @@ protected:
     /// should succeed in returning the last byte.
     address_t maxAddress_ = 0;
     /// Whether the space should report as RO.
-    bool isReadOnly_ = false;
+    unsigned isReadOnly_ : 1;
 
 private:
     /// We keep one of these for each variable that was declared.
@@ -397,17 +424,23 @@ private:
         ElementsType::iterator e = elements_.end();
         // Align in the known repetitions first.
         auto rit = repeats_.upper_bound(address);
+        int max_repeat = 0;
         if (rit == repeats_.end())
         {
             // not a repeat.
         }
         else
         {
-            if (rit->start_ <= address && rit->end_ > address)
+            if (rit->start_ <= address && address < rit->end_)
             {
                 // we are in the repeat.
                 unsigned cnt = (address - rit->start_) / rit->repeatSize_;
                 *repeat = cnt;
+                if (address + rit->repeatSize_ < rit->end_)
+                {
+                    // Try one repetition later too.
+                    max_repeat = 1;
+                }
                 // re-aligns address to the first repetition.
                 address -= cnt * rit->repeatSize_;
                 in_repeat = true;
@@ -415,10 +448,13 @@ private:
                 e = elements_.lower_bound(rit->start_ + rit->repeatSize_);
             }
         }
-        LOG(INFO, "searching for element at address %u in_repeat=%d address=%u",
-            (unsigned)original_address, in_repeat, (unsigned)address);
+        LOG(INFO,
+            "searching for element at address %u in_repeat=%d address=%u "
+            "len=%u",
+            (unsigned)original_address, in_repeat, (unsigned)address,
+            (unsigned)len);
 
-        for (int is_repeat = 0; is_repeat <= 1; ++is_repeat)
+        for (int is_repeat = 0; is_repeat <= max_repeat; ++is_repeat)
         {
             auto it = std::upper_bound(b, e, address, DataComparator());
             if (it != elements_.begin())
@@ -468,6 +504,11 @@ private:
         return len;
     }
 
+    static constexpr unsigned NO_CACHE = static_cast<address_t>(-1);
+    /// Offset in the memory space at which cachedData_ starts.
+    address_t cacheOffset_ = NO_CACHE;
+    /// Stored information for read-modify-write calls.
+    string cachedData_;
     /// Container type for storing the data elements.
     typedef SortedListSet<DataElement, DataComparator> ElementsType;
     /// Stores all the registered variables.

--- a/src/openlcb/VirtualMemorySpace.hxx
+++ b/src/openlcb/VirtualMemorySpace.hxx
@@ -449,7 +449,7 @@ private:
                 e = elements_.lower_bound(rit->start_ + rit->repeatSize_);
             }
         }
-        LOG(INFO,
+        LOG(VERBOSE,
             "searching for element at address %u in_repeat=%d address=%u "
             "len=%u",
             (unsigned)original_address, in_repeat, (unsigned)address,
@@ -501,7 +501,7 @@ private:
         }
 
         // now: no overlap either before or after.
-        LOG(INFO, "element not found for address %u",
+        LOG(VERBOSE, "element not found for address %u",
             (unsigned)original_address);
         return len;
     }

--- a/src/openlcb/VirtualMemorySpace.hxx
+++ b/src/openlcb/VirtualMemorySpace.hxx
@@ -99,7 +99,7 @@ public:
         const DataElement *element = nullptr;
         ssize_t skip = find_data_element(destination, len, &element, &repeat);
         string payload;
-        size_t written_len;        
+        size_t written_len;
         if (skip > 0)
         {
             // Will cause a new call be delivered with adjusted data and len.
@@ -129,7 +129,8 @@ public:
             }
             // Now: cachedData_ contains the payload in the current storage.
             payload = cachedData_;
-            written_len = std::min((size_t)len, (size_t)(element->size_ + skip));
+            written_len =
+                std::min((size_t)len, (size_t)(element->size_ + skip));
             memcpy(&payload[-skip], (const char *)data, written_len);
         }
         else // exact address write.
@@ -500,7 +501,8 @@ private:
         }
 
         // now: no overlap either before or after.
-        LOG(INFO, "element not found for address %u", (unsigned)original_address);
+        LOG(INFO, "element not found for address %u",
+            (unsigned)original_address);
         return len;
     }
 

--- a/src/openlcb/VirtualMemorySpace.hxx
+++ b/src/openlcb/VirtualMemorySpace.hxx
@@ -415,6 +415,8 @@ private:
                 e = elements_.lower_bound(rit->start_ + rit->repeatSize_);
             }
         }
+        LOG(INFO, "searching for element at address %u in_repeat=%d address=%u",
+            (unsigned)original_address, in_repeat, (unsigned)address);
 
         for (int is_repeat = 0; is_repeat <= 1; ++is_repeat)
         {
@@ -462,6 +464,7 @@ private:
         }
 
         // now: no overlap either before or after.
+        LOG(INFO, "element not found for address %u", (unsigned)original_address);
         return len;
     }
 

--- a/src/openlcb/VirtualMemorySpace.hxx
+++ b/src/openlcb/VirtualMemorySpace.hxx
@@ -425,7 +425,7 @@ private:
                 // else: no overlap, look at the next item
             }
             // now: it->address_ > address
-            if (address + len > it->address_)
+            if ((it != elements_.end()) && (address + len > it->address_))
             {
                 // found overlap, but some data needs to be discarded.
                 *ptr = &*it;


### PR DESCRIPTION
This PR fixes bugs and implements missing features in the VirtualMemorySpace:
- A bug caused returning more data read than the end of space when hitting the last variable in the last repeat of a group.
- Correctly trims reads and writes at the end of the space.
- Implements reading from the middle of a variable.
- Implements writing to a middle of a variable.
- Updates unittests with new test cases.