### PR TITLE
Makes the total number of open file descriptors configurable.

### DIFF
--- a/src/freertos_drivers/common/Devtab.hxx
+++ b/src/freertos_drivers/common/Devtab.hxx
@@ -46,13 +46,6 @@ class FileSystem;
 class Notifiable;
 class DeviceBufferBase;
 
-#ifdef TARGET_LPC11Cxx
-#define NUM_OPEN_FILES     4
-#else
-/// How many concurrently open fd we support.
-#define NUM_OPEN_FILES     20 //12
-#endif
-
 /** File information.
  */
 struct File
@@ -259,6 +252,10 @@ protected:
      */
     static int fd_lookup(File *file);
 
+    /** @return the maximum number of open file descriptors possible (the size
+     * of the files[] array. */
+    static const unsigned int numOpenFiles;
+    
     /** File descriptor pool */
     static File files[];
 

--- a/src/freertos_drivers/common/Fileio.cxx
+++ b/src/freertos_drivers/common/Fileio.cxx
@@ -39,16 +39,14 @@
 #include <unistd.h>
 #include <sys/select.h>
 
-
 OSMutex FileIO::mutex;
-File FileIO::files[NUM_OPEN_FILES];
 
 /** Allocate a free file descriptor.
  * @return file number on success, else -1 on failure
  */
 int FileIO::fd_alloc(void)
 {
-    for (unsigned int i = 0; i < NUM_OPEN_FILES; i++)
+    for (unsigned int i = 0; i < numOpenFiles; i++)
     {
         if (files[i].inuse == false)
         {
@@ -82,7 +80,7 @@ void FileIO::fd_free(int fd)
  */
 File* FileIO::file_lookup(int fd)
 {
-    if (fd < 0 || fd >= NUM_OPEN_FILES)
+    if (fd < 0 || fd >= (int)numOpenFiles)
     {
         errno = EBADF;
         return nullptr;
@@ -101,7 +99,7 @@ File* FileIO::file_lookup(int fd)
  */
 int FileIO::fd_lookup(File *file)
 {
-    HASSERT(file >= files && file <= (files + NUM_OPEN_FILES) && file->inuse);
+    HASSERT(file >= files && file <= (files + numOpenFiles) && file->inuse);
 
     return (file - files);
 }

--- a/src/freertos_drivers/common/FileioWeak.cxx
+++ b/src/freertos_drivers/common/FileioWeak.cxx
@@ -1,0 +1,41 @@
+/** \copyright
+ * Copyright (c) 2020, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ * 
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file FileioWeak.cxx
+ *
+ * Weak definitions for FileIO. These can be overridden by client applications.
+ *
+ * @author Balazs Racz
+ * @date 18 September 2020
+ */
+
+#include "Devtab.hxx"
+
+// Override both of these symbols in a .cxx file in your application (without
+// the weak attribute) if you want to change the nuber of open files.
+
+const unsigned int __attribute__((weak)) FileIO::numOpenFiles = 20;
+File __attribute__((weak)) FileIO::files[FileIO::numOpenFiles];

--- a/src/freertos_drivers/sources
+++ b/src/freertos_drivers/sources
@@ -4,6 +4,7 @@ VPATH := $(SRCDIR): \
 CSRCS +=
 
 CXXSRCS += Fileio.cxx \
+           FileioWeak.cxx \
            Device.cxx \
            FileSystem.cxx \
            DeviceBuffer.cxx \

--- a/src/freertos_drivers/spiffs/SPIFFS.hxx
+++ b/src/freertos_drivers/spiffs/SPIFFS.hxx
@@ -101,7 +101,7 @@ public:
     void flush_cache()
     {
         mutex.lock();
-        for (unsigned int i = 0; i < NUM_OPEN_FILES; i++)
+        for (unsigned int i = 0; i < numOpenFiles; i++)
         {
             if (files[i].inuse && files[i].dev == this && files[i].dirty)
             {


### PR DESCRIPTION
The configuration works with weak symbols that the application owner has
to override in their own .cxx file if needed to be changed.

It was not possible to make use of the usual OVERRIDE_CONST facility,
because it is important to have the files[] array allocated in .bss
and an array definition does not compile with the C++ compiler when
using an extern size symbol. Having files[] in .bss allows us not to
worry about initialization time race conditions.