### PR TITLE
Adds support for using the stored setting for AP/STA mode.

### DIFF
--- a/src/freertos_drivers/common/WifiDefs.hxx
+++ b/src/freertos_drivers/common/WifiDefs.hxx
@@ -32,9 +32,10 @@ enum class WlanState : uint8_t
  */
 enum class WlanRole : uint8_t
 {
-    UNKNOWN = 0, /**< Wi-Fi station mode */
-    STA,         /**< Wi-Fi station mode */
-    AP           /**< Wi-Fi access point mode */
+    UNKNOWN = 0,       /**< Default mode (from stored configuration) */
+    DEFAULT = UNKNOWN, /**< Default mode (from stored configuration) */
+    STA,               /**< Wi-Fi station mode */
+    AP                 /**< Wi-Fi access point mode */
 };
 
 enum class CountryCode : uint8_t

--- a/src/freertos_drivers/net_cc32xx/CC32xxWiFi.hxx
+++ b/src/freertos_drivers/net_cc32xx/CC32xxWiFi.hxx
@@ -226,6 +226,13 @@ public:
         return wlanRole;
     }
 
+    /** Change the default Wlan Role. This will be used in the next start(...)
+     * if the UNKNOWN role is specified. The new setting takes effect when the
+     * device is restarted (either via reboot or stop + start).
+     * @param role new role. Must not be UNKNOWN
+     */
+    void wlan_set_role(WlanRole new_role);
+
     /** @return 0 if !wlan_ready, else a debugging status code. */
     WlanState wlan_startup_state()
     {


### PR DESCRIPTION
Adds WlanRole::DEFAULT as an argument to the start() method that allows
using the AP/STA setting from the NWP stored configuration instead of
from the application.

Adds wlan_set_role to override such configuration.

Fixes a bug where the IP address handed out via DHCP was incorrectly
saved in the AP's own IP address variable. This caused the "is local
connection" check in SocketClient to misbehave in AP mode.