### PR TITLE
Adds railcom driver middle-cutout hook

### DIFF
--- a/boards/bracz-railcom/hardware.hxx
+++ b/boards/bracz-railcom/hardware.hxx
@@ -178,6 +178,7 @@ struct RailcomDefs
     static bool need_ch1_cutout() {
         return true;
     }
+    static void middle_cutout_hook() {}
 
     static void enable_measurement(bool);
     static void disable_measurement();

--- a/boards/ti-bracz-acc3/hardware.v3.hxx
+++ b/boards/ti-bracz-acc3/hardware.v3.hxx
@@ -174,7 +174,8 @@ struct RailcomHw
 
     static bool need_ch1_cutout() { return true; }
     static uint8_t get_feedback_channel() { return 0xff; }
-
+    static void middle_cutout_hook() {}
+    
     /// @returns a bitmask telling which pins are active. Bit 0 will be set if
     /// channel 0 is active (drawing current).
     static uint8_t sample() {

--- a/boards/ti-ek-tm4c123gxl-launchpad/HwInit.cxx
+++ b/boards/ti-ek-tm4c123gxl-launchpad/HwInit.cxx
@@ -172,6 +172,7 @@ struct RailcomDefs
     static void disable_measurement() {}
     static bool need_ch1_cutout() { return true; }
     static uint8_t get_feedback_channel() { return 0xff; }
+    static void middle_cutout_hook() {}
 
     /** @returns a bitmask telling which pins are active. Bit 0 will be set if
      * channel 0 is active (drawing current).*/

--- a/src/freertos_drivers/ti/TivaRailcom.hxx
+++ b/src/freertos_drivers/ti/TivaRailcom.hxx
@@ -394,6 +394,7 @@ private:
             }
             HWREG(HW::UART_BASE[i] + UART_O_CTL) |= UART_CTL_RXE;
         }
+        HW::middle_cutout_hook();
         Debug::RailcomDriverCutout::set(true);
     }
 


### PR DESCRIPTION
Adds a hook to the Tiva railcom driver that calls a hardware-specific function
in the middle of the cutout, between the two windows.