### PR TITLE
Fixes deletion order in CC32xx socket shutdown.

### DIFF
--- a/src/freertos_drivers/net_cc32xx/CC32xxSocket.cxx
+++ b/src/freertos_drivers/net_cc32xx/CC32xxSocket.cxx
@@ -755,8 +755,8 @@ int CC32xxSocket::close(File *file)
         portENTER_CRITICAL();
         remove_instance_from_sd(sd);
         portEXIT_CRITICAL();
-        delete this;
         sl_Close(sd);
+        delete this;
     }
     else
     {


### PR DESCRIPTION
This change ensures that threads higher priority than the closing call
have a chance to exit their kernel processing before the socket object
gets deleted.

This makes https://github.com/bakerstu/openmrn/issues/440 slightly better.