### PR TITLE
Always report from railcom driver

### DIFF
--- a/src/freertos_drivers/common/RailcomDriver.hxx
+++ b/src/freertos_drivers/common/RailcomDriver.hxx
@@ -58,6 +58,9 @@ public:
   /** Instructs the driver that the railcom cutout is over now. The driver
    *  will use this information to disable the UART receiver. */
   virtual void end_cutout() = 0;
+  /** Called instead of start/mid/end-cutout at the end of the current packet
+   * if there was no cutout requested. */
+  virtual void no_cutout() = 0;
   /** Specifies the feedback key to write into the received railcom data
    *  packets. This feedback key is used by the application layer to correlate
    *  the stream of DCC packets to the stream of Railcom packets. This method
@@ -74,6 +77,7 @@ class NoRailcomDriver : public RailcomDriver {
   void start_cutout() OVERRIDE {}
   void middle_cutout() OVERRIDE {}
   void end_cutout() OVERRIDE {}
+  void no_cutout() OVERRIDE {}
   void set_feedback_key(uint32_t key) OVERRIDE {}
 };
 

--- a/src/freertos_drivers/ti/TivaDCC.hxx
+++ b/src/freertos_drivers/ti/TivaDCC.hxx
@@ -546,6 +546,7 @@ inline void TivaDCC<HW>::interrupt_handler()
             }
             else
             {
+                railcomDriver_->no_cutout();
                 current_bit = DCC_ONE;
                 state_ = DCC_LEADOUT;
             }
@@ -697,6 +698,8 @@ inline void TivaDCC<HW>::interrupt_handler()
             }
             break;
         case MM_LEADOUT:
+            // MM packets never have a cutout.
+            railcomDriver_->no_cutout();
             current_bit = MM_PREAMBLE;
             if (++preamble_count >= 2) {
                 get_next_packet = true;

--- a/src/freertos_drivers/ti/TivaRailcom.hxx
+++ b/src/freertos_drivers/ti/TivaRailcom.hxx
@@ -440,6 +440,24 @@ private:
         Debug::RailcomCh2Data::set(false);
         Debug::RailcomDriverCutout::set(false);
     }
+
+    void no_cutout() OVERRIDE
+    {
+        for (unsigned i = 0; i < ARRAYSIZE(HW::UART_BASE); ++i)
+        {
+            if (!returnedPackets_[i])
+            {
+                returnedPackets_[i] = this->alloc_new_packet(i);
+            }
+            if (returnedPackets_[i])
+            {
+                this->feedbackQueue_.commit_back();
+                Debug::RailcomPackets::toggle();
+                returnedPackets_[i] = nullptr;
+                MAP_IntPendSet(HW::OS_INTERRUPT);
+            }
+        }
+    }
 };
 
 #endif // _FREERTOS_DRIVERS_TI_TIVARAILCOM_HXX_


### PR DESCRIPTION
Ensures that the railcom driver returns data from the feedback channel even if
there was no cutout generated.