### PR TITLE
Fix OpenMRNLite problem -- need to #undef DEFAULT

### DIFF
--- a/src/freertos_drivers/common/WifiDefs.hxx
+++ b/src/freertos_drivers/common/WifiDefs.hxx
@@ -28,20 +28,12 @@ enum class WlanState : uint8_t
     UPDATE_DISPLAY = 20,
 };
 
-// This is needed when this file is included into a ESP32 OpenMRNLite 
-// application.  The esp32 Arduino.h file defines DEFAULT as a macro
-// constant and that breaks the compilation of of the WlanRole enum
-// class below.  RPH November 2020
-#ifdef DEFAULT
-#undef DEFAULT
-#endif
-
 /** Operating Role.
  */
 enum class WlanRole : uint8_t
 {
     UNKNOWN = 0,       /**< Default mode (from stored configuration) */
-    DEFAULT = UNKNOWN, /**< Default mode (from stored configuration) */
+    DEFAULT_ROLE = UNKNOWN, /**< Default mode (from stored configuration) */
     STA,               /**< Wi-Fi station mode */
     AP                 /**< Wi-Fi access point mode */
 };

--- a/src/freertos_drivers/common/WifiDefs.hxx
+++ b/src/freertos_drivers/common/WifiDefs.hxx
@@ -28,6 +28,14 @@ enum class WlanState : uint8_t
     UPDATE_DISPLAY = 20,
 };
 
+// This is needed when this file is included into a ESP32 OpenMRNLite 
+// application.  The esp32 Arduino.h file defines DEFAULT as a macro
+// constant and that breaks the compilation of of the WlanRole enum
+// class below.  RPH November 2020
+#ifdef DEFAULT
+#undef DEFAULT
+#endif
+
 /** Operating Role.
  */
 enum class WlanRole : uint8_t


### PR DESCRIPTION
The symbol DEFAULT is defined in the ESP32 Arduino.h file, so when the OpenMRNLite library is included in a ESP32 Arduino sketch, the compiler barfs an error message when the WiFiDefs.hxx file is included.  This fix conditionally undefines the DEFAULT macro.