### PR TITLE
Protect unimplemented POSIX calls in BroadcastTime::clear_timezone() to allow OpenMRNLite to compile on Arduino flavored platforms.

### DIFF
--- a/src/freertos_drivers/common/WifiDefs.hxx
+++ b/src/freertos_drivers/common/WifiDefs.hxx
@@ -28,20 +28,12 @@ enum class WlanState : uint8_t
     UPDATE_DISPLAY = 20,
 };
 
-// This is needed when this file is included into a ESP32 OpenMRNLite 
-// application.  The esp32 Arduino.h file defines DEFAULT as a macro
-// constant and that breaks the compilation of of the WlanRole enum
-// class below.  RPH November 2020
-#ifdef DEFAULT
-#undef DEFAULT
-#endif
-
 /** Operating Role.
  */
 enum class WlanRole : uint8_t
 {
     UNKNOWN = 0,       /**< Default mode (from stored configuration) */
-    DEFAULT = UNKNOWN, /**< Default mode (from stored configuration) */
+    DEFAULT_ROLE = UNKNOWN, /**< Default mode (from stored configuration) */
     STA,               /**< Wi-Fi station mode */
     AP                 /**< Wi-Fi access point mode */
 };

--- a/src/freertos_drivers/common/WifiDefs.hxx
+++ b/src/freertos_drivers/common/WifiDefs.hxx
@@ -28,6 +28,14 @@ enum class WlanState : uint8_t
     UPDATE_DISPLAY = 20,
 };
 
+// This is needed when this file is included into a ESP32 OpenMRNLite 
+// application.  The esp32 Arduino.h file defines DEFAULT as a macro
+// constant and that breaks the compilation of of the WlanRole enum
+// class below.  RPH November 2020
+#ifdef DEFAULT
+#undef DEFAULT
+#endif
+
 /** Operating Role.
  */
 enum class WlanRole : uint8_t

--- a/src/openlcb/BroadcastTime.cxx
+++ b/src/openlcb/BroadcastTime.cxx
@@ -46,8 +46,10 @@ namespace openlcb
 //
 void BroadcastTime::clear_timezone()
 {
+#ifndef ARDUINO
         setenv("TZ", "GMT0", 1);
         tzset();
+#endif
 }
 
 } // namespace openlcb

--- a/src/openlcb/BroadcastTime.cxx
+++ b/src/openlcb/BroadcastTime.cxx
@@ -46,7 +46,7 @@ namespace openlcb
 //
 void BroadcastTime::clear_timezone()
 {
-#ifndef ARDUINO
+#ifndef ESP32
         setenv("TZ", "GMT0", 1);
         tzset();
 #endif


### PR DESCRIPTION
setenv() and tset() not available in the Arduino ESP32 platform.  This fix takes those calls out. I don't know what (if anything) could replace them, but making BroadcastTime::clear_timezone() seems like a harmless short term solution.