### PR TITLE
Adds more test helpers to run code on the main executor.

### DIFF
--- a/src/openlcb/IfCan.cxxtest
+++ b/src/openlcb/IfCan.cxxtest
@@ -36,8 +36,6 @@ TEST_F(AsyncIfTest, InjectFrame)
     wait();
 }
 
-#define RX(args) run_x([this]() { args; })
-
 TEST_F(AsyncIfTest, InjectFrameAndExpectHandler)
 {
     StrictMock<MockCanFrameHandler> h;

--- a/src/utils/test_main.hxx
+++ b/src/utils/test_main.hxx
@@ -178,6 +178,27 @@ void run_x(std::function<void()> fn)
     g_executor.sync_run(std::move(fn));
 }
 
+/// Runs some code in the constructor. Useful if custom code needs to be
+/// injected into the constructor initialization order.
+class RunInConstruct
+{
+public:
+    RunInConstruct(std::function<void()> f)
+    {
+        f();
+    }
+};
+
+/// Runs some code in the constructor on the main executor.
+class RunInConstructOnMain
+{
+public:
+    RunInConstructOnMain(std::function<void()> f)
+    {
+        run_x(f);
+    }
+};
+
 /// Structure holding returned objects for an invoke_flow_nowait command.
 template <class T> struct PendingInvocation
 {

--- a/src/utils/test_main.hxx
+++ b/src/utils/test_main.hxx
@@ -199,6 +199,10 @@ public:
     }
 };
 
+/// Helper macro to make running certain test commands run on the main executor
+/// simpler.
+#define RX(statement) run_x([&](){ statement; })
+
 /// Structure holding returned objects for an invoke_flow_nowait command.
 template <class T> struct PendingInvocation
 {


### PR DESCRIPTION
Adds more test helpers:
- RunInConstruct allows running a piece of code within a sequence of constructors called. This is helpful when a test is instantiating a bunch of objects, and something should be done between two of those objects' constructor (e.g. injecting something to a recently created object before the next object gets created). This could previously only be done by making everything a unique_ptr and constructing by hand.
- RunInConstructOnMainExecutor is the same but executes the code on the main executor. Needed for injecting aliases into IfCan objects.
- RX is a shorthand for run_x([this](){ statement }); which is a bit cumbersome to write.