### PR TITLE
Add support for C++11 compilation of std::make_unique()

### DIFF
--- a/src/openlcb/BulkAliasAllocator.cxx
+++ b/src/openlcb/BulkAliasAllocator.cxx
@@ -34,6 +34,7 @@
 
 #include "openlcb/BulkAliasAllocator.hxx"
 #include "openlcb/CanDefs.hxx"
+#include "utils/MakeUnique.hxx"
 
 namespace openlcb
 {

--- a/src/utils/MakeUnique.hxx
+++ b/src/utils/MakeUnique.hxx
@@ -1,0 +1,50 @@
+/**
+ * \file MakeUnique.hxx
+ *
+ * C++11 version of std::make_unique which is only available from c++14 or
+ * later.
+ * 
+ * This is based on https://isocpp.org/files/papers/N3656.txt.
+ * 
+ * The __cplusplus constant reference is from:
+ * http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2014/n3938.html
+ * 
+ */
+
+// Check if we are building with less than C++14 and if so we need to define
+// the std::make_unique() API.
+#if __cplusplus < 201402L
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace std
+{
+
+template <typename T, typename... Args>
+unique_ptr<T> make_unique_helper(false_type, Args&&... args)
+{
+  return unique_ptr<T>(new T(forward<Args>(args)...));
+}
+
+template <typename T, typename... Args>
+unique_ptr<T> make_unique_helper(true_type, Args&&... args)
+{
+   static_assert(extent<T>::value == 0,
+       "make_unique<T[N]>() is forbidden, please use make_unique<T[]>().");
+
+   typedef typename remove_extent<T>::type U;
+   return unique_ptr<T>(new U[sizeof...(Args)]{forward<Args>(args)...});
+}
+
+template <typename T, typename... Args>
+unique_ptr<T> make_unique(Args&&... args)
+{
+   return make_unique_helper<T>(is_array<T>(), forward<Args>(args)...);
+}
+
+}
+
+#endif // __cplusplus < 201402L
+


### PR DESCRIPTION
Since arduino-esp32 defaults to C++11 (due to ESP-IDF using the same) the usage of std::make_unique caused build failures for @RobertPHeller (as noted on groups.io). After a bit of digging into how to detect that we are building on an older version of the C++ standard I was able to include a version of std::make_unique as submitted for C++ standards as a header include.