### PR TITLE
Fixes todo in the bulk alias allocator that makes it actually operable.

### DIFF
--- a/src/openlcb/AliasAllocator.cxx
+++ b/src/openlcb/AliasAllocator.cxx
@@ -79,6 +79,50 @@ void seed_alias_allocator(AliasAllocator* aliases, Pool* pool, int n) {
     }
 }
 
+/** @return the number of aliases that are reserved and available for new
+ * virtual nodes to use. */
+unsigned AliasAllocator::num_reserved_aliases()
+{
+    unsigned cnt = 0;
+    NodeID found_id = CanDefs::get_reserved_alias_node_id(0);
+    NodeAlias found_alias = 0;
+    do
+    {
+        if (if_can()->local_aliases()->next_entry(
+                found_id, &found_id, &found_alias) &&
+            CanDefs::is_reserved_alias_node_id(found_id))
+        {
+            ++cnt;
+        }
+        else
+        {
+            break;
+        }
+    } while (true);
+    return cnt;
+}
+
+/** Removes all aliases that are reserved but not yet used. */
+void AliasAllocator::clear_reserved_aliases()
+{
+    do
+    {
+        NodeID found_id = CanDefs::get_reserved_alias_node_id(0);
+        NodeAlias found_alias = 0;
+        if (if_can()->local_aliases()->next_entry(
+                CanDefs::get_reserved_alias_node_id(0), &found_id,
+                &found_alias) &&
+            CanDefs::is_reserved_alias_node_id(found_id))
+        {
+            if_can()->local_aliases()->remove(found_alias);
+        }
+        else
+        {
+            break;
+        }
+    } while (true);
+}
+
 void AliasAllocator::return_alias(NodeID id, NodeAlias alias)
 {
     // This is synchronous allocation, which is not nice.

--- a/src/openlcb/AliasAllocator.cxxtest
+++ b/src/openlcb/AliasAllocator.cxxtest
@@ -334,7 +334,9 @@ TEST_F(AsyncAliasAllocatorTest, LateAllocationConflict)
     expect_packet(":X10700AA5N;");
     send_packet(":X10700555N;");
     twait();
+    RX(EXPECT_EQ(1u, ifCan_->alias_allocator()->num_reserved_aliases()));
     get_next_alias();
+    RX(EXPECT_EQ(0u, ifCan_->alias_allocator()->num_reserved_aliases()));
     EXPECT_EQ(0xAA5U, b_->data()->alias);
     EXPECT_EQ(AliasInfo::STATE_RESERVED, b_->data()->state);
 }
@@ -369,6 +371,7 @@ TEST_F(AsyncAliasAllocatorTest, DifferentGenerated)
 
 TEST_F(AsyncAliasAllocatorTest, BulkFew)
 {
+    RX(EXPECT_EQ(0u, ifCan_->alias_allocator()->num_reserved_aliases()));
     generate_aliases(ifCan_->alias_allocator(), 5);
     expect_cid(aliases_.begin(), aliases_.end());
     LOG(INFO, "invoke");
@@ -384,6 +387,11 @@ TEST_F(AsyncAliasAllocatorTest, BulkFew)
     clear_expect(true);
     auto end_time = os_get_time_monotonic();
     EXPECT_LT(MSEC_TO_NSEC(200), end_time - start_time);
+    RX({
+        EXPECT_EQ(5u, ifCan_->alias_allocator()->num_reserved_aliases());
+        ifCan_->alias_allocator()->clear_reserved_aliases();
+        EXPECT_EQ(0u, ifCan_->alias_allocator()->num_reserved_aliases());
+    });
 }
 
 TEST_F(AsyncAliasAllocatorTest, BulkConflict)

--- a/src/openlcb/AliasAllocator.hxx
+++ b/src/openlcb/AliasAllocator.hxx
@@ -140,6 +140,13 @@ public:
      * an asynchronous notification coming later. */
     NodeAlias get_allocated_alias(NodeID destination_id, Executable *done);
 
+    /** @return the number of aliases that are reserved and available for new
+     * virtual nodes to use. */
+    unsigned num_reserved_aliases();
+
+    /** Removes all aliases that are reserved but not yet used. */
+    void clear_reserved_aliases();
+
     /** Releases a given alias. Sends out an AMR frame and puts the alias into
      * the reserved aliases queue. */
     void return_alias(NodeID id, NodeAlias alias);

--- a/src/openlcb/BulkAliasAllocator.cxx
+++ b/src/openlcb/BulkAliasAllocator.cxx
@@ -134,7 +134,7 @@ public:
                 // we skip this alias because there was a conflict.
                 continue;
             }
-            /// @todo add alias to the cache as reserved alias.
+            if_can()->alias_allocator()->add_allocated_alias(a);
             ++num_sent;
             send_can_frame(a, CanDefs::RID_FRAME, 0);
         }


### PR DESCRIPTION
Adds new features to the alias allocator:
- get the number of reserved but unused aliases.
- clear these.