### PR TITLE
ESP32: Prep for Arduino-esp32 v1.0.5

### DIFF
--- a/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
@@ -48,17 +48,42 @@
 #include <mdns.h>
 #include <tcpip_adapter.h>
 
-// ESP-IDF v4+ has a slightly different directory structure to previous
-// versions.
-#ifdef ESP_IDF_VERSION_MAJOR
-// ESP-IDF v4+
+// Starting in ESP-IDF v4.0 a few header files have been relocated so we need
+// to adjust the include paths accordingly. If the __has_include preprocessor
+// directive is defined we can use it to find the appropriate header files.
+// If it is not usable then we will default the older header filenames.
+#if defined __has_include
+
+// rom/crc.h was relocated to esp32/rom/crc.h in ESP-IDF v4.0
+// TODO: This will need to be platform specific in IDF v4.1 since this is
+// exposed in unique header paths for each supported platform. Detecting the
+// operating platform (ESP32, ESP32-S2, ESP32-S3, etc) can be done by checking
+// for the presence of one of the following defines:
+// CONFIG_IDF_TARGET_ESP32      -- ESP32
+// CONFIG_IDF_TARGET_ESP32S2    -- ESP32-S2
+// CONFIG_IDF_TARGET_ESP32S3    -- ESP32-S3
+// If none of these are defined it means the ESP-IDF version is v4.0 or
+// earlier.
+#if __has_include("esp32/rom/crc.h")
 #include <esp32/rom/crc.h>
+#else
+#include <rom/crc.h>
+#endif
+
+// esp_wifi_internal.h was relocated to esp_private/wifi.h in ESP-IDF v4.0
+#if __has_include("esp_private/wifi.h")
 #include <esp_private/wifi.h>
 #else
-// ESP-IDF v3.x
+#include <esp_wifi_internal.h>
+#endif
+
+#else
+
+// We are unable to use __has_include, default to the old include paths.
 #include <esp_wifi_internal.h>
 #include <rom/crc.h>
-#endif // ESP_IDF_VERSION_MAJOR
+
+#endif // defined __has_include
 
 using openlcb::NodeID;
 using openlcb::SimpleCanStack;

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
@@ -52,7 +52,7 @@
 // to adjust the include paths accordingly. If the __has_include preprocessor
 // directive is defined we can use it to find the appropriate header files.
 // If it is not usable then we will default the older header filenames.
-#if defined __has_include
+#if defined(__has_include)
 
 // rom/crc.h was relocated to esp32/rom/crc.h in ESP-IDF v4.0
 // TODO: This will need to be platform specific in IDF v4.1 since this is


### PR DESCRIPTION
The ESP-IDF version detection that was in place was no longer working due to ESP-IDF v3.3 (picked up in arduino-esp32 1.0.5) defining `ESP_IDF_VERSION_MAJOR` which used to only be defined in in v4.0+.

Shifting to use __has_include to switch between the new and old include paths with fallback to use old paths when __has_include is not usable (though it always should be with GCC).

I'll be doing further work on this as part of the ESP-IDF v4.x support since there are a few breaking API changes in ESP-IDF v4.1 which I'll submit in another PR.

This has been tested with v1.0.4 and v1.0.5-rc2.