### PR TITLE
DeviceBuffer conditional compilation cleanup

### DIFF
--- a/src/freertos_drivers/common/DeviceBuffer.cxx
+++ b/src/freertos_drivers/common/DeviceBuffer.cxx
@@ -34,7 +34,9 @@
 
 #include "DeviceBuffer.hxx"
 
-#ifndef ARDUINO
+#include "openmrn_features.h"
+
+#ifdef OPENMRN_FEATURE_DEVTAB
 
 #include <sys/select.h>
 
@@ -61,4 +63,4 @@ void DeviceBufferBase::block_until_condition(File *file, bool read)
     ::select(fd + 1, read ? &fds : NULL, read ? NULL : &fds, NULL, NULL);
 }
 
-#endif
+#endif // OPENMRN_FEATURE_DEVTAB

--- a/src/freertos_drivers/common/DeviceBuffer.hxx
+++ b/src/freertos_drivers/common/DeviceBuffer.hxx
@@ -39,32 +39,34 @@
 #include <cstdint>
 #include <unistd.h>
 #include <stdlib.h>
+
+#include "openmrn_features.h"
 #include "utils/macros.h"
 
-#ifndef ARDUINO
+#ifdef OPENMRN_FEATURE_DEVTAB
 #include "Devtab.hxx"
-#endif
+#endif // OPENMRN_FEATURE_DEVTAB
 
 /** Helper for DeviceBuffer which allows for methods to not be inlined.
  */
 class DeviceBufferBase
 {
 public:
-#ifndef ARDUINO
+#ifdef OPENMRN_FEATURE_DEVTAB
     /** Wait for blocking condition to become true.
      * @param file file to wait on
      * @param read true if this is a read operation, false for write operation
      */
     static void block_until_condition(File *file, bool read);
-#endif
+#endif // OPENMRN_FEATURE_DEVTAB
 
     /** Signal the wakeup condition.  This will also wakeup select.
      */
     void signal_condition()
     {
-#ifndef ARDUINO
+#ifdef OPENMRN_FEATURE_DEVTAB
         Device::select_wakeup(&selectInfo);
-#endif        
+#endif // OPENMRN_FEATURE_DEVTAB
     }
 
     /** Signal the wakeup condition from an ISR context.  This will also
@@ -72,10 +74,10 @@ public:
      */
     void signal_condition_from_isr()
     {
-#ifndef ARDUINO
+#ifdef OPENMRN_FEATURE_DEVTAB
         int woken = 0;
         Device::select_wakeup_from_isr(&selectInfo, &woken);
-#endif
+#endif // OPENMRN_FEATURE_DEVTAB
     }
 
     /** flush all the data out of the buffer and reset the buffer.  It is
@@ -110,9 +112,9 @@ public:
      */
     void select_insert()
     {
-#ifndef ARDUINO
+#ifdef OPENMRN_FEATURE_DEVTAB
         return Device::select_insert(&selectInfo);
-#endif        
+#endif // OPENMRN_FEATURE_DEVTAB
     }
 
     /** Remove a number of items from the buffer by advancing the readIndex.
@@ -180,10 +182,10 @@ protected:
     {
     }
 
-#ifndef ARDUINO
+#ifdef OPENMRN_FEATURE_DEVTAB
     /** Metadata for select() logic */
     Device::SelectInfo selectInfo;
-#endif
+#endif // OPENMRN_FEATURE_DEVTAB
     
     /** level of space required in buffer in order to wakeup, 0 if unused */
     uint16_t level;


### PR DESCRIPTION
Cleanup in DeviceBuffer.cxx/hxx to use `OPENMRN_FEATURE_DEVTAB` instead of `ARDUINO` define. This is necessary as ARUDINO is not guaranteed to be defined in all cases and `OPENMRN_FEATURE_DEVTAB` is already used in a number of places to protect usages of these methods.