### PR TITLE
WIP: ESP32: TWAI (CAN) driver supporting select()

### DIFF
--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -69,6 +69,7 @@ constexpr UBaseType_t OPENMRN_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO - 1;
 
 #include "freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx"
 #include "freertos_drivers/esp32/Esp32HardwareSerialAdapter.hxx"
+#include "freertos_drivers/esp32/Esp32Twai.hxx"
 #include "freertos_drivers/esp32/Esp32WiFiManager.hxx"
 
 // On the ESP32 we have persistent file system access so enable
@@ -443,6 +444,25 @@ public:
     {
         loopMembers_.push_back(new CanBridge(port, stack()->can_hub()));
     }
+
+#ifdef OPENMRN_FEATURE_EXECUTOR_SELECT
+    /// Adds a hardware CAN port to the stack with select-based asynchronous
+    /// driver API.
+    ///
+    /// Example (ESP32):
+    /// Esp32Twai twai("/dev/twai", GPIO_NUM_4, GPIO_NUM_5);
+    /// void setup() {
+    ///   ...
+    ///   twai.hw_init();
+    ///   openmrn.begin();
+    ///   openmrn.add_can_port_select("/dev/twai/twai0");
+    /// }
+    /// @param device path to open for the CAN device.
+    void add_can_port_select(const char *device)
+    {
+        stack()->add_can_port_select(device);
+    }
+#endif // OPENMRN_FEATURE_EXECUTOR_SELECT
 
 #if defined(HAVE_FILESYSTEM)
     /// Creates the XML representation of the configuration structure and saves

--- a/arduino/examples/ESP32CanLoadTest/ESP32CanLoadTest.ino
+++ b/arduino/examples/ESP32CanLoadTest/ESP32CanLoadTest.ino
@@ -122,6 +122,7 @@ constexpr gpio_num_t CAN_RX_PIN = GPIO_NUM_4;
 /// the GPIO pin definitions for the outputs.
 constexpr gpio_num_t CAN_TX_PIN = GPIO_NUM_5;
 
+Esp32Twai twai("/dev/twai", CAN_RX_PIN, CAN_TX_PIN);
 #endif // USE_CAN
 
 /// This is the primary entrypoint for the OpenMRN/LCC stack.
@@ -318,11 +319,14 @@ void setup()
     // initialize all declared GPIO pins
     GpioInit::hw_init();
 
+#if defined(USE_CAN)
+    twai.hw_init();
+#endif // USE_CAN
+
     // Start the OpenMRN stack
     openmrn.begin();
     openmrn.start_executor_thread();
     cpu_log = new CpuLoadLog(openmrn.stack()->service());
-
 
 #if defined(PRINT_PACKETS)
     // Dump all packets as they are sent/received.
@@ -332,9 +336,7 @@ void setup()
 #endif // PRINT_PACKETS
 
 #if defined(USE_CAN)
-    // Add the hardware CAN device as a bridge
-    openmrn.add_can_port(
-        new Esp32HardwareCan("esp32can", CAN_RX_PIN, CAN_TX_PIN));
+    openmrn.add_can_port_select("/dev/twai/twai0");
 #endif // USE_CAN
 }
 

--- a/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
+++ b/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
@@ -113,6 +113,7 @@ constexpr gpio_num_t CAN_RX_PIN = GPIO_NUM_4;
 /// the GPIO pin definitions for the outputs.
 constexpr gpio_num_t CAN_TX_PIN = GPIO_NUM_5;
 
+Esp32Twai twai("/dev/twai", CAN_RX_PIN, CAN_TX_PIN);
 #endif // USE_CAN
 
 /// This is the primary entrypoint for the OpenMRN/LCC stack.
@@ -285,6 +286,10 @@ void setup()
     // initialize all declared GPIO pins
     GpioInit::hw_init();
 
+#if defined(USE_CAN)
+    twai.hw_init();
+#endif // USE_CAN
+
 #if defined(FACTORY_RESET_GPIO_PIN)
     // Check the factory reset pin which should normally read HIGH (set), if it
     // reads LOW (clr) delete the cdi.xml and openlcb_config
@@ -331,9 +336,7 @@ void setup()
 #endif // PRINT_PACKETS
 
 #if defined(USE_CAN)
-    // Add the hardware CAN device as a bridge
-    openmrn.add_can_port(
-        new Esp32HardwareCan("esp32can", CAN_RX_PIN, CAN_TX_PIN));
+    openmrn.add_can_port_select("/dev/twai/twai0");
 #endif // USE_CAN
 
 }

--- a/arduino/examples/ESP32SerialBridge/ESP32SerialBridge.ino
+++ b/arduino/examples/ESP32SerialBridge/ESP32SerialBridge.ino
@@ -74,6 +74,8 @@ constexpr gpio_num_t CAN_TX_PIN = GPIO_NUM_5;
 /// on the CAN bus.
 static constexpr uint64_t NODE_ID = UINT64_C(0x050101011822);
 
+Esp32Twai twai("/dev/twai", CAN_RX_PIN, CAN_TX_PIN);
+
 /// This is the primary entrypoint for the OpenMRN/LCC stack.
 OpenMRN openmrn(NODE_ID);
 
@@ -140,6 +142,8 @@ void setup() {
         }
     }
 
+    twai.hw_init();
+
     printf("\nSerial(rx:%d, tx:%d, speed:%d) is ready to exchange grid connect packets.\n",
         SERIAL_TX_PIN, SERIAL_TX_PIN, SERIAL_BAUD);
 
@@ -164,8 +168,7 @@ void setup() {
     openmrn.add_gridconnect_port(&Serial1);
 
     // Add the hardware CAN device as a bridge
-    openmrn.add_can_port(
-        new Esp32HardwareCan("esp32can", CAN_RX_PIN, CAN_TX_PIN));
+    openmrn.add_can_port_select("/dev/twai/twai0");
 }
 
 void loop() {

--- a/arduino/examples/ESP32WifiCanBridge/ESP32WifiCanBridge.ino
+++ b/arduino/examples/ESP32WifiCanBridge/ESP32WifiCanBridge.ino
@@ -104,6 +104,8 @@ string dummystring("abcdef");
 // layout. The argument of offset zero is ignored and will be removed later.
 static constexpr openlcb::ConfigDef cfg(0);
 
+Esp32Twai twai("/dev/twai", CAN_RX_PIN, CAN_TX_PIN);
+
 Esp32WiFiManager wifi_mgr(ssid, password, openmrn.stack(), cfg.seg().wifi());
 
 class FactoryResetHelper : public DefaultConfigUpdateListener {
@@ -160,6 +162,8 @@ void setup()
         }
     }
 
+    twai.hw_init();
+
     // Create the CDI.xml dynamically
     openmrn.create_config_descriptor_xml(cfg, openlcb::CDI_FILENAME);
 
@@ -179,8 +183,7 @@ void setup()
 #endif // PRINT_PACKETS
 
     // Add the hardware CAN device as a bridge
-    openmrn.add_can_port(
-        new Esp32HardwareCan("esp32can", CAN_RX_PIN, CAN_TX_PIN));
+    openmrn.add_can_port_select("/dev/twai/twai0");
 }
 
 void loop()

--- a/arduino/libify.sh
+++ b/arduino/libify.sh
@@ -135,7 +135,7 @@ copy_dir . arduino/examples
 
 copy_file src arduino/OpenMRNLite.{h,cpp} \
     include/{can_frame.h,nmranet_config.h,openmrn_features.h} \
-    include/freertos/{freertos_includes.h,endian.h} \
+    include/freertos/{freertos_includes.h,endian.h,can_ioctl.h,stropts.h} \
     include/freertos_select/ifaddrs.h
 
 # General DCC related files (all headers and DCC packet related cxx)
@@ -159,11 +159,13 @@ rm -f ${TARGET_LIB_DIR}/src/openlcb/CompileCdiMain.cxx \
 
 copy_file src/freertos_drivers/arduino \
           src/freertos_drivers/arduino/* \
-          src/freertos_drivers/common/DeviceBuffer.{hxx,cxx} \
-          src/freertos_drivers/common/GpioWrapper.hxx \
           src/freertos_drivers/common/CpuLoad.{hxx,cxx} \
+          src/freertos_drivers/common/DeviceBuffer.{hxx,cxx} \
+          src/freertos_drivers/common/DummyGPIO.hxx \
+          src/freertos_drivers/common/GpioWrapper.hxx \
+          src/freertos_drivers/common/RailcomDriver.hxx \
           src/freertos_drivers/common/WifiDefs.{hxx,cxx} \
-          src/freertos_drivers/common/libatomic.c \
+          src/freertos_drivers/common/libatomic.c
 
 copy_file src/freertos_drivers/esp32 \
           src/freertos_drivers/esp32/*

--- a/include/can_frame.h
+++ b/include/can_frame.h
@@ -63,7 +63,9 @@
         (_frame).can_id += ((_value) & CAN_SFF_MASK);   \
     }
 
-#elif defined (__nuttx__) || defined (__FreeRTOS__) || defined (__MACH__) || defined (__WIN32__) || defined(__EMSCRIPTEN__) || defined(ESP_NONOS) || defined(ARDUINO)
+#elif defined (__nuttx__) || defined (__FreeRTOS__) || defined (__MACH__) ||   \
+      defined (__WIN32__) || defined (__EMSCRIPTEN__) ||                       \
+      defined (ESP_NONOS) || defined (ARDUINO) || defined (ESP32)
     #include <stdint.h>
 
     struct can_frame

--- a/include/freertos/can_ioctl.h
+++ b/include/freertos/can_ioctl.h
@@ -35,7 +35,11 @@
 #define _FREERTOS_CAN_IOCTL_H_
 
 #include <stdint.h>
+#ifdef ESP32
+#include "stropts.h"
+#else
 #include "freertos/stropts.h"
+#endif
 
 #if defined (__cplusplus)
 extern "C" {

--- a/src/freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx
+++ b/src/freertos_drivers/esp32/Esp32HardwareCanAdapter.hxx
@@ -107,6 +107,8 @@ public:
     /// Enables the ESP32 CAN driver
     virtual void enable()
     {
+        LOG(WARNING,
+            "Esp32HardwareCan has been deprecated, please use Esp32Twai.");
         ESP_ERROR_CHECK(can_start());
         LOG(VERBOSE, "ESP32-CAN driver enabled");
     }

--- a/src/freertos_drivers/esp32/Esp32Twai.cxx
+++ b/src/freertos_drivers/esp32/Esp32Twai.cxx
@@ -1,0 +1,667 @@
+/** \copyright
+ * Copyright (c) 2020, Mike Dunston
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file Esp32Twai.hxx
+ *
+ * TWAI driver implementation for OpenMRN. This leverages a clone the ESP-IDF
+ * HAL API rather than the TWAI driver to allow for faster access to received
+ * frames and support for ESP-IDF v4.0 and above.
+ *
+ * @author Mike Dunston
+ * @date 24 September 2020
+ */
+
+#include "freertos_drivers/esp32/Esp32Twai.hxx"
+
+#ifdef ESP32
+
+#include <driver/gpio.h>
+#include <driver/periph_ctrl.h>
+#include <esp_task.h>
+#include <esp_vfs.h>
+#include <esp_intr_alloc.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+
+#if __has_include(<esp_idf_version.h>)
+#include <esp_idf_version.h>
+#else
+#include <esp_system.h>
+
+#ifndef ESP_IDF_VERSION
+#define ESP_IDF_VERSION 0
+#endif
+
+#ifndef ESP_IDF_VERSION_VAL
+#define ESP_IDF_VERSION_VAL(a,b,c) 1
+#endif
+
+#endif
+
+#include "can_frame.h"
+#include "can_ioctl.h"
+#include "Esp32TwaiHal.hxx"
+#include "executor/Notifiable.hxx"
+#include "freertos_drivers/arduino/DeviceBuffer.hxx"
+#include "nmranet_config.h"
+#include "utils/Atomic.hxx"
+#include "utils/constants.hxx"
+#include "utils/logging.h"
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,0,0)
+/// Data type used internally by ESP-IDF select() calls.
+typedef SemaphoreHandle_t * esp_vfs_select_sem_t;
+#endif // IDF < 4.0
+
+/// Default file descriptor to return in the vfs_open() call.
+///
+/// NOTE: The TWAI driver only supports one file descriptor at this time.
+static constexpr int TWAI_VFS_FD = 0;
+
+/// Interval at which to print the ESP32 TWAI bus status.
+static constexpr TickType_t STATUS_PRINT_INTERVAL = pdMS_TO_TICKS(10000);
+
+/// TWAI peripheral ISR flags.
+///
+/// Since the ISR is written in C/C++ code we can only specify the flag
+/// ESP_INTR_FLAG_LOWMED. We can optionally specify ESP_INTR_FLAG_IRAM but
+/// there are intermittent crashes when the ISR is in IRAM due to flash access
+/// (ie SPIFFS or LittleFS).
+static constexpr int TWAI_ISR_FLAGS = ESP_INTR_FLAG_LOWMED;
+
+// Starting in IDF v4.2 the CAN peripheral was renamed to TWAI.
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4,2,0)
+/// Pin matrix index for the TWAI TX peripheral pin.
+static constexpr uint32_t TWAI_TX_SIGNAL_IDX = TWAI_TX_IDX;
+
+/// Pin matrix index for the TWAI RX peripheral pin.
+static constexpr uint32_t TWAI_RX_SIGNAL_IDX = TWAI_RX_IDX;
+
+/// TWAI peripheral ISR source index.
+static constexpr int TWAI_ISR_SOURCE = ETS_TWAI_INTR_SOURCE;
+
+/// TWAI Peripheral module ID.
+static constexpr periph_module_t TWAI_PERIPHERAL = PERIPH_TWAI_MODULE;
+#else
+/// Pin matrix index for the TWAI TX peripheral pin.
+static constexpr uint32_t TWAI_TX_SIGNAL_IDX = CAN_TX_IDX;
+
+/// Pin matrix index for the TWAI RX peripheral pin.
+static constexpr uint32_t TWAI_RX_SIGNAL_IDX = CAN_RX_IDX;
+
+/// TWAI peripheral ISR source index.
+static constexpr int TWAI_ISR_SOURCE = ETS_CAN_INTR_SOURCE;
+
+/// TWAI Peripheral module ID.
+static constexpr periph_module_t TWAI_PERIPHERAL = PERIPH_CAN_MODULE;
+#endif // ESP_IDF_VERSION > 4.2.0
+
+/// Internal flag used for tracking if the VFS driver has been registered.
+static bool vfs_is_registered = false;
+
+/// Internal flag used for tracking if the low-level TWAI driver has been
+/// configured.
+static bool twai_is_configured = false;
+
+/// TWAI default interrupt enable mask, excludes data overrun (bit[3]) and
+/// brp_div (bit[4]) since these are not supported on all models.
+static constexpr uint32_t TWAI_DEFAULT_INTERRUPTS = 0xE7;
+
+/// TWAI HAL context object.
+static twai_hal_context_t twai_context;
+
+/// Handle for the TWAI ISR.
+static intr_handle_t twai_isr_handle;
+
+/// TWAI TX queue handle.
+static QueueHandle_t twai_tx_queue_handle;
+
+/// TWAI RX queue handle.
+static QueueHandle_t twai_rx_queue_handle;
+
+/// TWAI driver runtime statistics holders.
+typedef struct 
+{
+    /// Number of frames that are pending transmission by the low-level TWAI
+    /// driver.
+    /// NOTE: This saves calling FreeRTOS functions to check @ref twai_tx_queue.
+    uint32_t tx_pending;
+
+    /// Number of frames that have been received by the low-level TWAI driver but
+    /// have not been read from @ref twai_rx_queue.
+    /// NOTE: This saves calling FreeRTOS functions to check @ref twai_rx_queue.
+    uint32_t rx_pending;
+
+    /// Number of frames have been removed from @ref twai_rx_queue and sent to the
+    /// OpenMRN stack.
+    uint32_t rx_processed;
+
+    /// Number of frames frames that could not be sent to @ref twai_rx_queue.
+    uint32_t rx_overrun_count;
+
+    /// Number of frames that were discarded that had too large of a DLC count.
+    uint32_t rx_discard_count;
+
+    /// Number of frames that have been sent to the @ref twai_tx_queue by the
+    /// OpenMRN stack successfully.
+    uint32_t tx_processed;
+
+    /// Number of frames that have been transmitted successfully by the low-level
+    /// TWAI driver.
+    uint32_t tx_success_count;
+
+    /// Number of frames that have been could not be transmitted successfully by
+    /// the low-level TWAI driver.
+    uint32_t tx_failed_count;
+
+    /// Number of arbitration errors that have been observed on the TWAI bus.
+    uint32_t arb_lost_count;
+
+    /// Number of general bus errors that have been observed on the TWAI bus.
+    uint32_t bus_error_count;
+} twai_driver_stats;
+
+/// Runtime statistics for the TWAI driver.
+static twai_driver_stats twai_stats = {};
+
+/// Atomic used to protect @ref twai_stats.
+static Atomic twai_stats_lock;
+
+/// Thread handle for the statistics reporting task.
+static os_thread_t status_thread_handle;
+
+/// Semaphore provided by the VFS layer when select() is invoked on one of the
+/// file descriptors handle by the TWAI VFS adapter.
+static esp_vfs_select_sem_t twai_select_sem;
+
+/// Internal flag indicating that the VFS layer has called
+/// @ref vfs_start_select() and that @ref twai_select_sem should be used if/when
+/// there is a change in @ref twai_tx_queue_handle or @ref twai_rx_queue_handle.
+static volatile uint32_t twai_select_pending;
+
+/// Flushes all frames in @ref twai_tx_queue_handle.
+static inline void twai_flush_tx_queue()
+{
+    AtomicHolder h(&twai_stats_lock);
+    xQueueReset(twai_tx_queue_handle);
+    twai_stats.tx_pending = 0;
+}
+
+/// Flushes all frames in @ref twai_rx_queue_handle.
+static inline void twai_flush_rx_queue()
+{
+    AtomicHolder h(&twai_stats_lock);
+    xQueueReset(twai_rx_queue_handle);
+    twai_stats.rx_pending = 0;
+}
+
+/// VFS adapter for open(path, flags, mode).
+///
+/// @param path is the path to the file being opened.
+/// @param flags are the flags to use for opened file.
+/// @param mode is the mode to use for the opened file.
+///
+/// When this method is invoked it will enable the TWAI driver and start the
+/// periodic timer used for RX/TX of frame data.
+///
+/// @return 0 upon success, -1 upon failure with errno containing the cause.
+static int twai_vfs_open(const char *path, int flags, int mode)
+{
+    // skip past the '/' that is passed in as first character
+    path++;
+
+    LOG(INFO, "[TWAI] Enabling TWAI device:%s", path);
+    twai_flush_tx_queue();
+    twai_flush_rx_queue();
+
+    twai_hal_start(&twai_context, TWAI_MODE_NORMAL);
+    return TWAI_VFS_FD;
+}
+
+/// VFS adapter for close(fd).
+///
+/// @param path is the path to the file being opened.
+/// @param flags are the flags to use for opened file.
+/// @param mode is the mode to use for the opened file.
+///
+/// When this method is invoked it will disable the TWAI driver and stop the
+/// periodic timer used for RX/TX of frame data if it is running.
+///
+/// @return zero upon success, negative value with errno for failure.
+static int twai_vfs_close(int fd)
+{
+    LOG(INFO, "[TWAI] Disabling TWAI fd:%d", fd);
+    twai_flush_tx_queue();
+
+    twai_hal_stop(&twai_context);
+    return 0;
+}
+
+/// VFS interface helper for write()
+///
+/// @param fd is the file descriptor being written to.
+/// @param buf is the buffer containing the data to be written.
+/// @param size is the size of the buffer.
+/// @return number of bytes written or -1 if there is the write would be a
+/// blocking operation.
+static ssize_t twai_vfs_write(int fd, const void *buf, size_t size)
+{
+    DASSERT(fd == TWAI_VFS_FD);
+    ssize_t sent = 0;
+    const struct can_frame *data = (const struct can_frame *)buf;
+    size /= sizeof(struct can_frame);
+    while (size)
+    {
+        if (twai_hal_check_state_flags(&twai_context, TWAI_HAL_STATE_FLAG_BUS_OFF))
+        {
+            twai_hal_start_bus_recovery(&twai_context);
+            twai_flush_tx_queue();
+            break;
+        }
+        else if (!twai_hal_check_state_flags(&twai_context, TWAI_HAL_STATE_FLAG_RUNNING))
+        {
+            break;
+        }
+
+        twai_message_t tx_frame;
+        twai_hal_frame_t hal_frame;
+        bzero(&tx_frame, sizeof(twai_message_t));
+        tx_frame.identifier = data->can_id;
+        tx_frame.extd = data->can_eff;
+        tx_frame.rtr = data->can_rtr;
+        tx_frame.data_length_code = data->can_dlc;
+        memcpy(tx_frame.data, data->data, data->can_dlc);
+        twai_hal_format_frame(&tx_frame, &hal_frame);
+        if (xQueueSend(twai_tx_queue_handle, &hal_frame, 0) == pdTRUE)
+        {
+            {
+                AtomicHolder h(&twai_stats_lock);
+                twai_stats.tx_pending++;
+                twai_stats.tx_processed++;
+            }
+            // If the bus is running and the TX buffer is not occupied we can
+            // start the TX from here.
+            if (twai_hal_check_state_flags(&twai_context, TWAI_HAL_STATE_FLAG_RUNNING) &&
+                !twai_hal_check_state_flags(&twai_context, TWAI_HAL_STATE_FLAG_TX_BUFF_OCCUPIED) &&
+                xQueueReceive(twai_tx_queue_handle, &hal_frame, 0) == pdTRUE)
+            {
+                twai_hal_set_tx_buffer_and_transmit(&twai_context, &hal_frame);
+            }
+            sent++;
+            size--;
+        }
+        else
+        {
+            // No space in the TX queue
+            break;
+        }
+    }
+    if (!sent)
+    {
+        errno = EWOULDBLOCK;
+        return -1;
+    }
+    return sent * sizeof(struct can_frame);
+}
+
+/// VFS interface helper for read()
+///
+/// @param fd is the file descriptor being read from.
+/// @param buf is the buffer to write into.
+/// @param size is the size of the buffer.
+/// @return number of bytes read or -1 if there is the read would be a
+/// blocking operation.
+static ssize_t twai_vfs_read(int fd, void *buf, size_t size)
+{
+    DASSERT(fd == TWAI_VFS_FD);
+
+    ssize_t received = 0;
+    struct can_frame *data = (struct can_frame *)buf;
+    size /= sizeof(struct can_frame);
+    while (size)
+    {
+        twai_hal_frame_t hal_frame;
+        memset(&hal_frame, 0, sizeof(twai_hal_frame_t));
+        if (xQueueReceive(twai_rx_queue_handle, &hal_frame, 0) != pdTRUE)
+        {
+            // no frames available to receive
+            break;
+        }
+        {
+            AtomicHolder h(&twai_stats_lock);
+            twai_stats.rx_pending--;
+            twai_stats.rx_processed++;
+        }
+        twai_message_t rx_frame;
+        twai_hal_parse_frame(&hal_frame, &rx_frame);
+        memcpy(data->data, rx_frame.data, TWAI_FRAME_MAX_DLC);
+        data->can_dlc = rx_frame.data_length_code;
+        data->can_id = rx_frame.identifier;
+        data->can_eff = rx_frame.extd;
+        data->can_rtr = rx_frame.rtr;
+        size--;
+        received++;
+        data++;
+    }
+    if (!received)
+    {
+        errno = EWOULDBLOCK;
+        return -1;
+    }
+
+    return received * sizeof(struct can_frame);
+}
+
+/// VFS interface helper for select()
+///
+/// @param nfds is the number of FDs being checked.
+/// @param readfds is the set of FDs being checked for ready to read.
+/// @param writefds is the set of FDs being checked for ready to write.
+/// @param exceptfds is the set of FDs being checked for exception.
+/// @param sem is the semaphore to use for waking up the select() call.
+/// @param end_select_args is any arguments to pass into vfs_end_select().
+/// @return ESP_OK for success.
+static esp_err_t twai_vfs_start_select(int nfds, fd_set *readfds
+                                     , fd_set *writefds, fd_set *exceptfds
+                                     , esp_vfs_select_sem_t sem
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4,0,0)
+                                     , void **end_select_args
+#endif
+)
+{
+    HASSERT(nfds >= 1);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4,0,0)
+    *end_select_args = nullptr;
+#endif
+    twai_select_sem = sem;
+    twai_select_pending = 1;
+
+    return ESP_OK;
+}
+
+/// VFS interface helper invoked when select() is woken up.
+///
+/// @param end_select_args is any arguments provided in vfs_start_select().
+/// @return ESP_OK for success.
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4,0,0)
+static esp_err_t twai_vfs_end_select(void *end_select_args)
+#else
+static void twai_vfs_end_select()
+#endif
+{
+    twai_select_pending = 0;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4,0,0)
+    return ESP_OK;
+#endif
+}
+
+/// VFS adapter for fcntl(fd, cmd, arg).
+///
+/// @param fd to operate on.
+/// @param cmd to be executed.
+/// @param arg arg to be used for the operation.
+///
+/// This method is currently a NO-OP.
+///
+/// @return zero upon success, negative value with errno for failure.
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4,0,0)
+static int twai_vfs_fcntl(int fd, int cmd, int arg)
+#else
+static int twai_vfs_fcntl(int fd, int cmd, va_list arg)
+#endif
+{
+    DASSERT(fd == TWAI_VFS_FD);
+
+    // NO OP
+
+    return 0;
+}
+
+/// Interrupt routine that processing events raised by the low-level TWAI
+/// driver.
+///
+/// @param arg Unused
+static IRAM_ATTR void twai_isr(void *arg)
+{
+    BaseType_t wakeup = pdFALSE;
+    uint32_t events = twai_hal_decode_interrupt_events(&twai_context);
+    bool is_rx = (events & TWAI_HAL_EVENT_RX_BUFF_FRAME);
+    bool is_tx = (events & TWAI_HAL_EVENT_TX_BUFF_FREE);
+
+    AtomicHolder h(&twai_stats_lock);
+
+    if (is_rx)
+    {
+        uint32_t msg_count = twai_hal_get_rx_msg_count(&twai_context);
+        for (int i = 0; i < msg_count; i++)
+        {
+            twai_hal_frame_t frame;
+            twai_hal_read_rx_buffer_and_clear(&twai_context, &frame);
+            if (frame.dlc > TWAI_FRAME_MAX_DLC)
+            {
+                twai_stats.rx_discard_count++;
+            }
+            else if (xQueueSendFromISR(twai_rx_queue_handle, &frame, &wakeup) == pdTRUE)
+            {
+                twai_stats.rx_pending++;
+            }
+            else
+            {
+                twai_stats.rx_overrun_count++;
+            }
+        }
+    }
+
+    if (is_tx)
+    {
+        twai_stats.tx_pending--;
+        if (twai_hal_check_last_tx_successful(&twai_context))
+        {
+            twai_stats.tx_success_count++;
+        }
+        else
+        {
+            twai_stats.tx_failed_count++;
+        }
+
+        twai_hal_frame_t tx_frame;
+        if (xQueueReceiveFromISR(twai_tx_queue_handle, &tx_frame, &wakeup) == pdTRUE)
+        {
+            twai_hal_set_tx_buffer_and_transmit(&twai_context, &tx_frame);
+        }
+    }
+
+    if (events & TWAI_HAL_EVENT_BUS_RECOV_CPLT)
+    {
+        twai_hal_start(&twai_context, TWAI_MODE_NORMAL);
+    }
+    if (events & TWAI_HAL_EVENT_BUS_ERR)
+    {
+        twai_stats.bus_error_count++;
+    }
+    if (events & TWAI_HAL_EVENT_ARB_LOST)
+    {
+        twai_stats.arb_lost_count++;
+    }
+
+    if ((is_rx || is_tx) && twai_select_pending)
+    {
+        esp_vfs_select_triggered_isr(twai_select_sem, &wakeup);
+    }
+
+
+// In IDF v4.3 the portYIELD_FROM_ISR macro was extended to take the value of
+// the wakeup flag and if true will yield as expected otherwise it is mostly a
+// no-op.
+#if ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(4,2,0)
+    if (wakeup == pdTRUE)
+    {
+        portYIELD_FROM_ISR();
+    }
+#else
+    portYIELD_FROM_ISR(wakeup);
+#endif // ESP_IDF_VERSION > 4.2.0
+}
+
+/// Periodic TWAI statistics reporting task.
+///
+/// @param param (unused)
+static void *report_stats(void *param)
+{
+    while (twai_is_configured)
+    {
+        // local copy of the stats for reporting.
+        twai_driver_stats stats;
+        {
+            AtomicHolder h(&twai_stats_lock);
+            stats = twai_stats;
+        }
+
+        LOG(INFO
+          , "[TWAI] RX:%d (pending:%d,overrun:%d,discard:%d)"
+            " TX:%d (pending:%d,suc:%d,fail:%d)"
+            " bus (arb-err:%d,err:%d,state:%s)"
+          , stats.rx_processed, stats.rx_pending, stats.rx_overrun_count
+          , stats.rx_discard_count, stats.tx_processed, stats.tx_pending
+          , stats.tx_success_count, stats.tx_failed_count
+          , stats.arb_lost_count, stats.bus_error_count
+          , twai_hal_check_state_flags(&twai_context, TWAI_HAL_STATE_FLAG_RUNNING) ? "Running"
+          : twai_hal_check_state_flags(&twai_context, TWAI_HAL_STATE_FLAG_RECOVERING) ? "Recovering"
+          : twai_hal_check_state_flags(&twai_context, TWAI_HAL_STATE_FLAG_ERR_WARN) ? "Err-Warn"
+          : twai_hal_check_state_flags(&twai_context, TWAI_HAL_STATE_FLAG_ERR_PASSIVE) ? "Err-Pasv"
+          : "Bus Off");
+
+        // delay until the next reporting interval, this is being used instead
+        // of vTaskDelay to allow early wake up in the case of shutdown of the
+        // TWAI driver.
+        ulTaskNotifyTake(pdTRUE, STATUS_PRINT_INTERVAL);
+    }
+    return nullptr;
+}
+
+static inline void configure_twai_gpio(gpio_num_t tx, gpio_num_t rx)
+{
+    LOG(VERBOSE, "[TWAI] Configuring TWAI TX pin: %d", tx);
+    gpio_set_pull_mode(tx, GPIO_FLOATING);
+    gpio_matrix_out(tx, TWAI_TX_SIGNAL_IDX, false, false);
+    gpio_pad_select_gpio(tx);
+
+    LOG(VERBOSE, "[TWAI] Configuring TWAI RX pin: %d", rx);
+    gpio_set_pull_mode(rx, GPIO_FLOATING);
+    gpio_set_direction(rx, GPIO_MODE_INPUT);
+    gpio_matrix_in(rx, TWAI_RX_SIGNAL_IDX, false);
+    gpio_pad_select_gpio(rx);
+}
+
+static inline void create_twai_buffers()
+{
+    LOG(VERBOSE, "[TWAI] Creating TWAI TX queue: %d"
+      , config_can_tx_buffer_size());
+
+    twai_tx_queue_handle =
+        xQueueCreate(config_can_tx_buffer_size(), sizeof(twai_hal_frame_t));
+    HASSERT(twai_tx_queue_handle != nullptr);
+
+    LOG(VERBOSE, "[TWAI] Creating TWAI RX queue: %d"
+      , config_can_rx_buffer_size());
+    twai_rx_queue_handle =
+        xQueueCreate(config_can_rx_buffer_size(), sizeof(twai_hal_frame_t));
+    HASSERT(twai_rx_queue_handle != nullptr);
+}
+
+static inline void initialize_twai()
+{
+    periph_module_reset(TWAI_PERIPHERAL);
+    periph_module_enable(TWAI_PERIPHERAL);
+    HASSERT(twai_hal_init(&twai_context));
+    twai_timing_config_t timingCfg = TWAI_TIMING_CONFIG_125KBITS();
+    twai_filter_config_t filterCfg = TWAI_FILTER_CONFIG_ACCEPT_ALL();
+    LOG(VERBOSE, "[TWAI] Initiailizing TWAI peripheral");
+    twai_hal_configure(&twai_context, &timingCfg, &filterCfg
+                     , TWAI_DEFAULT_INTERRUPTS, 0);
+    LOG(VERBOSE, "[TWAI] Allocating TWAI ISR");
+    ESP_ERROR_CHECK(
+        esp_intr_alloc(TWAI_ISR_SOURCE, TWAI_ISR_FLAGS, twai_isr, NULL
+                     , &twai_isr_handle));
+}
+
+// Constructor.
+Esp32Twai::Esp32Twai(const char *vfsPath, int rxPin, int txPin, bool report)
+    : vfsPath_(vfsPath), rxPin_((gpio_num_t)rxPin), txPin_((gpio_num_t)txPin)
+    , reportStats_(report)
+{
+    HASSERT(GPIO_IS_VALID_GPIO(rxPin));
+    HASSERT(GPIO_IS_VALID_OUTPUT_GPIO(txPin));
+}
+
+// Destructor.
+Esp32Twai::~Esp32Twai()
+{
+    if (vfs_is_registered)
+    {
+        ESP_ERROR_CHECK(esp_vfs_unregister(vfsPath_));
+    }
+
+    if (twai_is_configured)
+    {
+        ESP_ERROR_CHECK(esp_intr_free(twai_isr_handle));
+        twai_hal_deinit(&twai_context);
+        twai_is_configured = false;
+        xTaskNotifyGive(status_thread_handle);
+        vQueueDelete(twai_tx_queue_handle);
+        vQueueDelete(twai_rx_queue_handle);
+    }
+}
+
+// Initializes the VFS adapter and TWAI driver
+void Esp32Twai::hw_init()
+{
+    esp_vfs_t vfs;
+    memset(&vfs, 0, sizeof(esp_vfs_t));
+    vfs.write = twai_vfs_write;
+    vfs.read = twai_vfs_read;
+    vfs.open = twai_vfs_open;
+    vfs.close = twai_vfs_close;
+    vfs.fcntl = twai_vfs_fcntl;
+    vfs.start_select = twai_vfs_start_select;
+    vfs.end_select = twai_vfs_end_select;
+    vfs.flags = ESP_VFS_FLAG_DEFAULT;
+    ESP_ERROR_CHECK(esp_vfs_register(vfsPath_, &vfs, this));
+    vfs_is_registered = true;
+
+    configure_twai_gpio(txPin_, rxPin_);
+    create_twai_buffers();
+    initialize_twai();
+
+    twai_is_configured = true;
+    if (reportStats_)
+    {
+        os_thread_create(&status_thread_handle, "TWAI-STATS", 0, 0,
+                         report_stats, nullptr);
+    }
+}
+
+#endif // ESP32

--- a/src/freertos_drivers/esp32/Esp32Twai.hxx
+++ b/src/freertos_drivers/esp32/Esp32Twai.hxx
@@ -1,0 +1,89 @@
+/** \copyright
+ * Copyright (c) 2020, Mike Dunston
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file Esp32Twai.hxx
+ *
+ * TWAI driver implementation for OpenMRN. This leverages the ESP-IDF HAL API
+ * rather than the TWAI driver to allow 
+ *
+ * @author Mike Dunston
+ * @date 24 September 2020
+ */
+
+#ifndef _FREERTOS_DRIVERS_ESP32_ESP32TWAI_HXX_
+#define _FREERTOS_DRIVERS_ESP32_ESP32TWAI_HXX_
+
+// Only define the Esp32Twai interface if we are compiling for a supported
+// platform.
+#ifdef ESP32
+
+#include <driver/gpio.h>
+
+#include "utils/macros.h"
+
+namespace openmrn_arduino
+{
+
+class Esp32Twai
+{
+public:
+    /// Constructor.
+    ///
+    /// @param vfsPath is the VFS path to register the TWAI driver to.
+    /// @param rxPin is the pin connected to the external transceiver RX pin.
+    /// @param txPin is the pin connected to the external transceiver TX pin.
+    Esp32Twai(const char *vfsPath, int rxPin, int txPin, bool report = true);
+
+    /// Destructor.
+    ///
+    /// Cleans up resources allocated by the TWAI driver.
+    ~Esp32Twai();
+
+    /// Initializes the VFS adapter and TWAI driver
+    void hw_init();
+private:
+    DISALLOW_COPY_AND_ASSIGN(Esp32Twai);
+
+    /// VFS Mount point.
+    const char *vfsPath_;
+
+    /// GPIO pin connected to the external transceiver RX pin.
+    const gpio_num_t rxPin_;
+
+    /// GPIO pin connected to the external transceiver TX pin.
+    const gpio_num_t txPin_;
+
+    /// Flag to indicate that TWAI statistics should be periodically reported.
+    const bool reportStats_;
+};
+
+} // namespace openmrn_arduino
+
+using openmrn_arduino::Esp32Twai;
+
+#endif // ESP32
+
+#endif // _FREERTOS_DRIVERS_ESP32_ESP32TWAI_HXX_

--- a/src/freertos_drivers/esp32/Esp32TwaiHal.hxx
+++ b/src/freertos_drivers/esp32/Esp32TwaiHal.hxx
@@ -1,0 +1,1452 @@
+// Copyright 2015-2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "sdkconfig.h"
+
+#if __has_include(<esp_idf_version.h>)
+#include <esp_idf_version.h>
+#else
+#include <esp_system.h>
+
+#ifndef ESP_IDF_VERSION
+#define ESP_IDF_VERSION 0
+#endif
+
+#ifndef ESP_IDF_VERSION_VAL
+#define ESP_IDF_VERSION_VAL(a,b,c) 1
+#endif
+#endif
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,0,0)
+#include <soc/can_struct.h>
+typedef can_dev_t ESP32_CAN_DEV_TYPE;
+#define TWAI_BRP_MIN                         2
+#define TWAI_BRP_MAX                         128
+#define TWAI_BRP_MAX_ECO                     256
+#define TWAI_BRP_DIV_THRESH                  128
+#define TWAI_SUPPORT_MULTI_ADDRESS_LAYOUT    1
+#elif ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(4,1,0)
+#include <soc/can_periph.h>
+typedef can_dev_t ESP32_CAN_DEV_TYPE;
+#define TWAI_BRP_MIN                         2
+#define TWAI_BRP_MAX                         128
+#define TWAI_BRP_MAX_ECO                     256
+#define TWAI_BRP_DIV_THRESH                  128
+#define TWAI_SUPPORT_MULTI_ADDRESS_LAYOUT    1
+#else
+#include <soc/twai_periph.h>
+typedef twai_dev_t ESP32_CAN_DEV_TYPE;
+#endif
+
+/**
+ * @brief   TWAI Constants
+ */
+#define TWAI_EXTD_ID_MASK               0x1FFFFFFF  /**< Bit mask for 29 bit Extended Frame Format ID */
+#define TWAI_STD_ID_MASK                0x7FF       /**< Bit mask for 11 bit Standard Frame Format ID */
+#define TWAI_FRAME_MAX_DLC              8           /**< Max data bytes allowed in TWAI */
+#define TWAI_FRAME_EXTD_ID_LEN_BYTES    4           /**< EFF ID requires 4 bytes (29bit) */
+#define TWAI_FRAME_STD_ID_LEN_BYTES     2           /**< SFF ID requires 2 bytes (11bit) */
+#define TWAI_ERR_PASS_THRESH            128         /**< Error counter threshold for error passive */
+
+/** @cond */    //Doxy command to hide preprocessor definitions from docs
+/**
+ * @brief   TWAI Message flags
+ *
+ * The message flags are used to indicate the type of message transmitted/received.
+ * Some flags also specify the type of transmission.
+ */
+#define TWAI_MSG_FLAG_NONE              0x00        /**< No message flags (Standard Frame Format) */
+#define TWAI_MSG_FLAG_EXTD              0x01        /**< Extended Frame Format (29bit ID) */
+#define TWAI_MSG_FLAG_RTR               0x02        /**< Message is a Remote Frame */
+#define TWAI_MSG_FLAG_SS                0x04        /**< Transmit as a Single Shot Transmission. Unused for received. */
+#define TWAI_MSG_FLAG_SELF              0x08        /**< Transmit as a Self Reception Request. Unused for received. */
+#define TWAI_MSG_FLAG_DLC_NON_COMP      0x10        /**< Message's Data length code is larger than 8. This will break compliance with TWAI */
+
+/**
+ * @brief Initializer macros for timing configuration structure
+ *
+ * The following initializer macros offer commonly found bit rates. These macros
+ * place the sample point at 80% or 67% of a bit time.
+ *
+ * @note These timing values are based on the assumption APB clock is at 80MHz
+ * @note The available bit rates are dependent on the chip target and revision.
+ */
+#if (TWAI_BRP_MAX > 256)
+#define TWAI_TIMING_CONFIG_1KBITS()     {.brp = 4000, .tseg_1 = 15, .tseg_2 = 8, .sjw = 3, .triple_sampling = false}
+#define TWAI_TIMING_CONFIG_5KBITS()     {.brp = 800, .tseg_1 = 15, .tseg_2 = 8, .sjw = 3, .triple_sampling = false}
+#define TWAI_TIMING_CONFIG_10KBITS()    {.brp = 400, .tseg_1 = 15, .tseg_2 = 8, .sjw = 3, .triple_sampling = false}
+#endif
+#if (TWAI_BRP_MAX > 128) || (CONFIG_ESP32_REV_MIN >= 2)
+#define TWAI_TIMING_CONFIG_12_5KBITS()  {.brp = 256, .tseg_1 = 16, .tseg_2 = 8, .sjw = 3, .triple_sampling = false}
+#define TWAI_TIMING_CONFIG_16KBITS()    {.brp = 200, .tseg_1 = 16, .tseg_2 = 8, .sjw = 3, .triple_sampling = false}
+#define TWAI_TIMING_CONFIG_20KBITS()    {.brp = 200, .tseg_1 = 15, .tseg_2 = 4, .sjw = 3, .triple_sampling = false}
+#endif
+#define TWAI_TIMING_CONFIG_25KBITS()    {.brp = 128, .tseg_1 = 16, .tseg_2 = 8, .sjw = 3, .triple_sampling = false}
+#define TWAI_TIMING_CONFIG_50KBITS()    {.brp = 80, .tseg_1 = 15, .tseg_2 = 4, .sjw = 3, .triple_sampling = false}
+#define TWAI_TIMING_CONFIG_100KBITS()   {.brp = 40, .tseg_1 = 15, .tseg_2 = 4, .sjw = 3, .triple_sampling = false}
+#define TWAI_TIMING_CONFIG_125KBITS()   {.brp = 32, .tseg_1 = 15, .tseg_2 = 4, .sjw = 3, .triple_sampling = false}
+#define TWAI_TIMING_CONFIG_250KBITS()   {.brp = 16, .tseg_1 = 15, .tseg_2 = 4, .sjw = 3, .triple_sampling = false}
+#define TWAI_TIMING_CONFIG_500KBITS()   {.brp = 8, .tseg_1 = 15, .tseg_2 = 4, .sjw = 3, .triple_sampling = false}
+#define TWAI_TIMING_CONFIG_800KBITS()   {.brp = 4, .tseg_1 = 16, .tseg_2 = 8, .sjw = 3, .triple_sampling = false}
+#define TWAI_TIMING_CONFIG_1MBITS()     {.brp = 4, .tseg_1 = 15, .tseg_2 = 4, .sjw = 3, .triple_sampling = false}
+
+/**
+ * @brief   Initializer macro for filter configuration to accept all IDs
+ */
+#define TWAI_FILTER_CONFIG_ACCEPT_ALL() {.acceptance_code = 0, .acceptance_mask = 0xFFFFFFFF, .single_filter = true}
+/** @endcond */
+
+/**
+ * @brief   TWAI Controller operating modes
+ */
+typedef enum
+{
+    TWAI_MODE_NORMAL,               /**< Normal operating mode where TWAI controller can send/receive/acknowledge messages */
+    TWAI_MODE_NO_ACK,               /**< Transmission does not require acknowledgment. Use this mode for self testing */
+    TWAI_MODE_LISTEN_ONLY,          /**< The TWAI controller will not influence the bus (No transmissions or acknowledgments) but can receive messages */
+} twai_mode_t;
+
+/**
+ * @brief   Structure to store a TWAI message
+ *
+ * @note    The flags member is deprecated
+ */
+typedef struct
+{
+    union
+    {
+        struct
+        {
+            //The order of these bits must match deprecated message flags for compatibility reasons
+            uint32_t extd: 1;           /**< Extended Frame Format (29bit ID) */
+            uint32_t rtr: 1;            /**< Message is a Remote Frame */
+            uint32_t ss: 1;             /**< Transmit as a Single Shot Transmission. Unused for received. */
+            uint32_t self: 1;           /**< Transmit as a Self Reception Request. Unused for received. */
+            uint32_t dlc_non_comp: 1;   /**< Message's Data length code is larger than 8. This will break compliance with ISO 11898-1 */
+            uint32_t reserved: 27;      /**< Reserved bits */
+        };
+        //Todo: Deprecate flags
+        uint32_t flags;                 /**< Deprecated: Alternate way to set bits using message flags */
+    };
+    uint32_t identifier;                /**< 11 or 29 bit identifier */
+    uint8_t data_length_code;           /**< Data length code */
+    uint8_t data[TWAI_FRAME_MAX_DLC];    /**< Data bytes (not relevant in RTR frame) */
+} twai_message_t;
+
+/**
+ * @brief   Structure for bit timing configuration of the TWAI driver
+ *
+ * @note    Macro initializers are available for this structure
+ */
+typedef struct
+{
+    uint32_t brp;                   /**< Baudrate prescaler (i.e., APB clock divider). Any even number from 2 to 128 for ESP32, 2 to 32768 for ESP32S2.
+                                         For ESP32 Rev 2 or later, multiples of 4 from 132 to 256 are also supported */
+    uint8_t tseg_1;                 /**< Timing segment 1 (Number of time quanta, between 1 to 16) */
+    uint8_t tseg_2;                 /**< Timing segment 2 (Number of time quanta, 1 to 8) */
+    uint8_t sjw;                    /**< Synchronization Jump Width (Max time quanta jump for synchronize from 1 to 4) */
+    bool triple_sampling;           /**< Enables triple sampling when the TWAI controller samples a bit */
+} twai_timing_config_t;
+
+/**
+ * @brief   Structure for acceptance filter configuration of the TWAI driver (see documentation)
+ *
+ * @note    Macro initializers are available for this structure
+ */
+typedef struct
+{
+    uint32_t acceptance_code;       /**< 32-bit acceptance code */
+    uint32_t acceptance_mask;       /**< 32-bit acceptance mask */
+    bool single_filter;             /**< Use Single Filter Mode (see documentation) */
+} twai_filter_config_t;
+
+
+/* ------------------------- Defines and Typedefs --------------------------- */
+
+#define TWAI_LL_STATUS_RBS      (0x1 << 0)      //Receive Buffer Status
+#define TWAI_LL_STATUS_DOS      (0x1 << 1)      //Data Overrun Status
+#define TWAI_LL_STATUS_TBS      (0x1 << 2)      //Transmit Buffer Status
+#define TWAI_LL_STATUS_TCS      (0x1 << 3)      //Transmission Complete Status
+#define TWAI_LL_STATUS_RS       (0x1 << 4)      //Receive Status
+#define TWAI_LL_STATUS_TS       (0x1 << 5)      //Transmit Status
+#define TWAI_LL_STATUS_ES       (0x1 << 6)      //Error Status
+#define TWAI_LL_STATUS_BS       (0x1 << 7)      //Bus Status
+
+#define TWAI_LL_INTR_RI         (0x1 << 0)      //Receive Interrupt
+#define TWAI_LL_INTR_TI         (0x1 << 1)      //Transmit Interrupt
+#define TWAI_LL_INTR_EI         (0x1 << 2)      //Error Interrupt
+//Data overrun interrupt not supported in SW due to HW peculiarities
+#define TWAI_LL_INTR_EPI        (0x1 << 5)      //Error Passive Interrupt
+#define TWAI_LL_INTR_ALI        (0x1 << 6)      //Arbitration Lost Interrupt
+#define TWAI_LL_INTR_BEI        (0x1 << 7)      //Bus Error Interrupt
+
+/*
+ * The following frame structure has an NEARLY identical bit field layout to
+ * each byte of the TX buffer. This allows for formatting and parsing frames to
+ * be done outside of time critical regions (i.e., ISRs). All the ISR needs to
+ * do is to copy byte by byte to/from the TX/RX buffer. The two reserved bits in
+ * TX buffer are used in the frame structure to store the self_reception and
+ * single_shot flags which in turn indicate the type of transmission to execute.
+ */
+typedef union
+{
+    struct
+    {
+        struct
+        {
+            uint8_t dlc: 4;             //Data length code (0 to 8) of the frame
+            uint8_t self_reception: 1;  //This frame should be transmitted using self reception command
+            uint8_t single_shot: 1;     //This frame should be transmitted using single shot command
+            uint8_t rtr: 1;             //This frame is a remote transmission request
+            uint8_t frame_format: 1;    //Format of the frame (1 = extended, 0 = standard)
+        };
+        union
+        {
+            struct
+            {
+                uint8_t id[2];          //11 bit standard frame identifier
+                uint8_t data[8];        //Data bytes (0 to 8)
+                uint8_t reserved8[2];
+            } standard;
+            struct
+            {
+                uint8_t id[4];          //29 bit extended frame identifier
+                uint8_t data[8];        //Data bytes (0 to 8)
+            } extended;
+        };
+    };
+    uint8_t bytes[13];
+} __attribute__((packed)) twai_ll_frame_buffer_t;
+
+_Static_assert(sizeof(twai_ll_frame_buffer_t) == 13, "TX/RX buffer type should be 13 bytes");
+
+/* ---------------------------- Mode Register ------------------------------- */
+
+/**
+ * @brief   Enter reset mode
+ *
+ * When in reset mode, the TWAI controller is effectively disconnected from the
+ * TWAI bus and will not participate in any bus activates. Reset mode is required
+ * in order to write the majority of configuration registers.
+ *
+ * @param hw Start address of the TWAI registers
+ *
+ * @note Reset mode is automatically entered on BUS OFF condition
+ */
+static inline void twai_ll_enter_reset_mode(ESP32_CAN_DEV_TYPE *hw)
+{
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    hw->mode_reg.reset = 1;
+#else
+    hw->mode_reg.rm = 1;
+#endif // ESP_IDF_VERSION
+}
+
+/**
+ * @brief   Exit reset mode
+ *
+ * When not in reset mode, the TWAI controller will take part in bus activities
+ * (e.g., send/receive/acknowledge messages and error frames) depending on the
+ * operating mode.
+ *
+ * @param hw Start address of the TWAI registers
+ *
+ * @note Reset mode must be exit to initiate BUS OFF recovery
+ */
+static inline void twai_ll_exit_reset_mode(ESP32_CAN_DEV_TYPE *hw)
+{
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    hw->mode_reg.reset = 0;
+#else
+    hw->mode_reg.rm = 0;
+#endif // ESP_IDF_VERSION
+}
+
+/**
+ * @brief   Check if in reset mode
+ * @param hw Start address of the TWAI registers
+ * @return true if in reset mode
+ */
+static inline bool twai_ll_is_in_reset_mode(ESP32_CAN_DEV_TYPE *hw)
+{
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    return hw->mode_reg.reset;
+#else
+    return hw->mode_reg.rm;
+#endif
+}
+
+/**
+ * @brief   Set operating mode of TWAI controller
+ *
+ * @param hw Start address of the TWAI registers
+ * @param mode Operating mode
+ *
+ * @note Must be called in reset mode
+ */
+static inline void twai_ll_set_mode(ESP32_CAN_DEV_TYPE *hw, twai_mode_t mode)
+{
+    if (mode == TWAI_MODE_NORMAL)
+    {
+        // Normal Operating mode
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+        hw->mode_reg.listen_only = 0;
+        hw->mode_reg.self_test = 0;
+#else
+        hw->mode_reg.lom = 0;
+        hw->mode_reg.stm = 0;
+#endif // ESP_IDF_VERSION
+    }
+    else if (mode == TWAI_MODE_NO_ACK)
+    {
+        // Self Test Mode (No Ack)
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+        hw->mode_reg.listen_only = 0;
+        hw->mode_reg.self_test = 1;
+#else
+        hw->mode_reg.lom = 0;
+        hw->mode_reg.stm = 1;
+#endif // ESP_IDF_VERSION
+    }
+    else if (mode == TWAI_MODE_LISTEN_ONLY)
+    {
+        // Listen Only Mode
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+        hw->mode_reg.listen_only = 1;
+        hw->mode_reg.self_test = 0;
+#else
+        hw->mode_reg.lom = 1;
+        hw->mode_reg.stm = 0;
+#endif // ESP_IDF_VERSION
+    }
+}
+
+/* --------------------------- Command Register ----------------------------- */
+
+/**
+ * @brief   Set TX command
+ *
+ * Setting the TX command will cause the TWAI controller to attempt to transmit
+ * the frame stored in the TX buffer. The TX buffer will be occupied (i.e.,
+ * locked) until TX completes.
+ *
+ * @param hw Start address of the TWAI registers
+ *
+ * @note Transmit commands should be called last (i.e., after handling buffer
+ *       release and clear data overrun) in order to prevent the other commands
+ *       overwriting this latched TX bit with 0.
+ */
+static inline void twai_ll_set_cmd_tx(ESP32_CAN_DEV_TYPE *hw)
+{
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    hw->command_reg.tx_req = 1;
+#else
+    hw->command_reg.tr = 1;
+#endif // ESP_IDF_VERSION
+}
+
+/**
+ * @brief   Set single shot TX command
+ *
+ * Similar to setting TX command, but the TWAI controller will not automatically
+ * retry transmission upon an error (e.g., due to an acknowledgement error).
+ *
+ * @param hw Start address of the TWAI registers
+ *
+ * @note Transmit commands should be called last (i.e., after handling buffer
+ *       release and clear data overrun) in order to prevent the other commands
+ *       overwriting this latched TX bit with 0.
+ */
+static inline void twai_ll_set_cmd_tx_single_shot(ESP32_CAN_DEV_TYPE *hw)
+{
+    hw->command_reg.val = 0x03;     //Writing to TR and AT simultaneously
+}
+
+/**
+ * @brief   Aborts TX
+ *
+ * Frames awaiting TX will be aborted. Frames already being TX are not aborted.
+ * Transmission Complete Status bit is automatically set to 1.
+ * Similar to setting TX command, but the TWAI controller will not automatically
+ * retry transmission upon an error (e.g., due to acknowledge error).
+ *
+ * @param hw Start address of the TWAI registers
+ *
+ * @note Transmit commands should be called last (i.e., after handling buffer
+ *       release and clear data overrun) in order to prevent the other commands
+ *       overwriting this latched TX bit with 0.
+ */
+static inline void twai_ll_set_cmd_abort_tx(ESP32_CAN_DEV_TYPE *hw)
+{
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    hw->command_reg.abort_tx = 1;
+#else
+    hw->command_reg.at = 1;
+#endif // ESP_IDF_VERSION
+}
+
+/**
+ * @brief   Release RX buffer
+ *
+ * Rotates RX buffer to the next frame in the RX FIFO.
+ *
+ * @param hw Start address of the TWAI registers
+ */
+static inline void twai_ll_set_cmd_release_rx_buffer(ESP32_CAN_DEV_TYPE *hw)
+{
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    hw->command_reg.release_rx_buff = 1;
+#else
+    hw->command_reg.rrb = 1;
+#endif // ESP_IDF_VERSION
+}
+
+/**
+ * @brief   Clear data overrun
+ *
+ * Clears the data overrun status bit
+ *
+ * @param hw Start address of the TWAI registers
+ */
+static inline void twai_ll_set_cmd_clear_data_overrun(ESP32_CAN_DEV_TYPE *hw)
+{
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    hw->command_reg.clear_data_overrun = 1;
+#else
+    hw->command_reg.cdo = 1;
+#endif // ESP_IDF_VERSION
+}
+
+/**
+ * @brief   Set self reception single shot command
+ *
+ * Similar to setting TX command, but the TWAI controller also simultaneously
+ * receive the transmitted frame and is generally used for self testing
+ * purposes. The TWAI controller will not ACK the received message, so consider
+ * using the NO_ACK operating mode.
+ *
+ * @param hw Start address of the TWAI registers
+ *
+ * @note Transmit commands should be called last (i.e., after handling buffer
+ *       release and clear data overrun) in order to prevent the other commands
+ *       overwriting this latched TX bit with 0.
+ */
+static inline void twai_ll_set_cmd_self_rx_request(ESP32_CAN_DEV_TYPE *hw)
+{
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    hw->command_reg.self_rx_req = 1;
+#else
+    hw->command_reg.srr = 1;
+#endif // ESP_IDF_VERSION
+}
+
+/**
+ * @brief   Set self reception request command
+ *
+ * Similar to setting the self reception request, but the TWAI controller will
+ * not automatically retry transmission upon an error (e.g., due to and
+ * acknowledgement error).
+ *
+ * @param hw Start address of the TWAI registers
+ *
+ * @note Transmit commands should be called last (i.e., after handling buffer
+ *       release and clear data overrun) in order to prevent the other commands
+ *       overwriting this latched TX bit with 0.
+ */
+static inline void twai_ll_set_cmd_self_rx_single_shot(ESP32_CAN_DEV_TYPE *hw)
+{
+    hw->command_reg.val = 0x12;
+}
+
+/* --------------------------- Status Register ------------------------------ */
+
+/**
+ * @brief   Get all status bits
+ *
+ * @param hw Start address of the TWAI registers
+ * @return Status bits
+ */
+static inline uint32_t twai_ll_get_status(ESP32_CAN_DEV_TYPE *hw)
+{
+    return hw->status_reg.val;
+}
+
+/**
+ * @brief   Check if RX FIFO overrun status bit is set
+ *
+ * @param hw Start address of the TWAI registers
+ * @return Overrun status bit
+ */
+static inline bool twai_ll_is_fifo_overrun(ESP32_CAN_DEV_TYPE *hw)
+{
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    return hw->status_reg.data_overrun;
+#else
+    return hw->status_reg.dos;
+#endif // ESP_IDF_VERSION
+}
+
+/**
+ * @brief   Check if previously TX was successful
+ *
+ * @param hw Start address of the TWAI registers
+ * @return Whether previous TX was successful
+ */
+static inline bool twai_ll_is_last_tx_successful(ESP32_CAN_DEV_TYPE *hw)
+{
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    return hw->status_reg.tx_complete;
+#else
+    return hw->status_reg.tcs;
+#endif // ESP_IDF_VERSION
+}
+
+/* -------------------------- Interrupt Register ---------------------------- */
+
+/**
+ * @brief   Get currently set interrupts
+ *
+ * Reading the interrupt registers will automatically clear all interrupts
+ * except for the Receive Interrupt.
+ *
+ * @param hw Start address of the TWAI registers
+ * @return Bit mask of set interrupts
+ */
+static inline uint32_t twai_ll_get_and_clear_intrs(ESP32_CAN_DEV_TYPE *hw)
+{
+    return hw->interrupt_reg.val;
+}
+
+/* ----------------------- Interrupt Enable Register ------------------------ */
+
+/**
+ * @brief   Set which interrupts are enabled
+ *
+ * @param hw Start address of the TWAI registers
+ * @param Bit mask of interrupts to enable
+ *
+ * @note Must be called in reset mode
+ */
+static inline void twai_ll_set_enabled_intrs(ESP32_CAN_DEV_TYPE *hw, uint32_t intr_mask)
+{
+#if defined(CONFIG_ESP32_REV_MIN) && CONFIG_ESP32_REV_MIN >= 2
+    //ESP32 Rev 2 or later has brp div field. Need to mask it out
+    hw->interrupt_enable_reg.val = (hw->interrupt_enable_reg.val & 0x10) | intr_mask;
+#else
+    hw->interrupt_enable_reg.val = intr_mask;
+#endif // CONFIG_ESP32_REV_MIN
+}
+
+/* ------------------------ Bus Timing Registers --------------------------- */
+
+/**
+ * @brief   Set bus timing
+ *
+ * @param hw Start address of the TWAI registers
+ * @param brp Baud Rate Prescaler
+ * @param sjw Synchronization Jump Width
+ * @param tseg1 Timing Segment 1
+ * @param tseg2 Timing Segment 2
+ * @param triple_sampling Triple Sampling enable/disable
+ *
+ * @note Must be called in reset mode
+ * @note ESP32 rev 2 or later can support a x2 brp by setting a brp_div bit,
+ *       allowing the brp to go from a maximum of 128 to 256.
+ */
+static inline void twai_ll_set_bus_timing(ESP32_CAN_DEV_TYPE *hw, uint32_t brp, uint32_t sjw, uint32_t tseg1, uint32_t tseg2, bool triple_sampling)
+{
+#if CONFIG_ESP32_REV_MIN >= 2
+    if (brp > TWAI_BRP_DIV_THRESH)
+    {
+        //Need to set brp_div bit
+        hw->interrupt_enable_reg.brp_div = 1;
+        brp /= 2;
+    }
+    else
+    {
+        hw->interrupt_enable_reg.brp_div = 0;
+    }
+#endif // CONFIG_ESP32_REV_MIN
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    hw->bus_timing_0_reg.baud_rate_prescaler = (brp / 2) - 1;
+    hw->bus_timing_0_reg.sync_jump_width = sjw - 1;
+    hw->bus_timing_1_reg.time_seg_1 = tseg1 - 1;
+    hw->bus_timing_1_reg.time_seg_2 = tseg2 - 1;
+    hw->bus_timing_1_reg.sampling = triple_sampling;
+#else
+    hw->bus_timing_0_reg.brp = (brp / 2) - 1;
+    hw->bus_timing_0_reg.sjw = sjw - 1;
+    hw->bus_timing_1_reg.tseg1 = tseg1 - 1;
+    hw->bus_timing_1_reg.tseg2 = tseg2 - 1;
+    hw->bus_timing_1_reg.sam = triple_sampling;
+#endif // ESP_IDF_VERSION
+}
+
+/* ----------------------------- ALC Register ------------------------------- */
+
+/**
+ * @brief   Clear Arbitration Lost Capture Register
+ *
+ * Reading the ALC register rearms the Arbitration Lost Interrupt
+ *
+ * @param hw Start address of the TWAI registers
+ */
+static inline void twai_ll_clear_arb_lost_cap(ESP32_CAN_DEV_TYPE *hw)
+{
+    (void)hw->arbitration_lost_captue_reg.val;
+}
+
+/* ----------------------------- ECC Register ------------------------------- */
+
+/**
+ * @brief   Clear Error Code Capture register
+ *
+ * Reading the ECC register rearms the Bus Error Interrupt
+ *
+ * @param hw Start address of the TWAI registers
+ */
+static inline void twai_ll_clear_err_code_cap(ESP32_CAN_DEV_TYPE *hw)
+{
+    (void)hw->error_code_capture_reg.val;
+}
+
+/* ----------------------------- EWL Register ------------------------------- */
+
+/**
+ * @brief   Set Error Warning Limit
+ *
+ * @param hw Start address of the TWAI registers
+ * @param ewl Error Warning Limit
+ *
+ * @note Must be called in reset mode
+ */
+static inline void twai_ll_set_err_warn_lim(ESP32_CAN_DEV_TYPE *hw, uint32_t ewl)
+{
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    hw->error_warning_limit_reg.byte = ewl;
+#else
+    hw->error_warning_limit_reg.ewl = ewl;
+#endif // ESP_IDF_VERSION
+}
+
+/**
+ * @brief   Get Error Warning Limit
+ *
+ * @param hw Start address of the TWAI registers
+ * @return Error Warning Limit
+ */
+static inline uint32_t twai_ll_get_err_warn_lim(ESP32_CAN_DEV_TYPE *hw)
+{
+    return hw->error_warning_limit_reg.val;
+}
+
+/* ------------------------ RX Error Count Register ------------------------- */
+
+/**
+ * @brief   Get RX Error Counter
+ *
+ * @param hw Start address of the TWAI registers
+ * @return REC value
+ *
+ * @note REC is not frozen in reset mode. Listen only mode will freeze it. A BUS
+ *       OFF condition automatically sets the REC to 0.
+ */
+static inline uint32_t twai_ll_get_rec(ESP32_CAN_DEV_TYPE *hw)
+{
+    return hw->rx_error_counter_reg.val;
+}
+
+/**
+ * @brief   Set RX Error Counter
+ *
+ * @param hw Start address of the TWAI registers
+ * @param rec REC value
+ *
+ * @note Must be called in reset mode
+ */
+static inline void twai_ll_set_rec(ESP32_CAN_DEV_TYPE *hw, uint32_t rec)
+{
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    hw->rx_error_counter_reg.byte = rec;
+#else
+    hw->rx_error_counter_reg.rxerr = rec;
+#endif // ESP_IDF_VERSION
+}
+
+/* ------------------------ TX Error Count Register ------------------------- */
+
+/**
+ * @brief   Get TX Error Counter
+ *
+ * @param hw Start address of the TWAI registers
+ * @return TEC value
+ *
+ * @note A BUS OFF condition will automatically set this to 128
+ */
+static inline uint32_t twai_ll_get_tec(ESP32_CAN_DEV_TYPE *hw)
+{
+    return hw->tx_error_counter_reg.val;
+}
+
+/**
+ * @brief   Set TX Error Counter
+ *
+ * @param hw Start address of the TWAI registers
+ * @param tec TEC value
+ *
+ * @note Must be called in reset mode
+ */
+static inline void twai_ll_set_tec(ESP32_CAN_DEV_TYPE *hw, uint32_t tec)
+{
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    hw->tx_error_counter_reg.byte = tec;
+#else
+    hw->tx_error_counter_reg.txerr = tec;
+#endif // ESP_IDF_VERSION
+}
+
+/* ---------------------- Acceptance Filter Registers ----------------------- */
+
+/**
+ * @brief   Set Acceptance Filter
+ * @param hw Start address of the TWAI registers
+ * @param code Acceptance Code
+ * @param mask Acceptance Mask
+ * @param single_filter Whether to enable single filter mode
+ *
+ * @note Must be called in reset mode
+ */
+static inline void twai_ll_set_acc_filter(ESP32_CAN_DEV_TYPE* hw, uint32_t code, uint32_t mask, bool single_filter)
+{
+    uint32_t code_swapped = __builtin_bswap32(code);
+    uint32_t mask_swapped = __builtin_bswap32(mask);
+    for (int i = 0; i < 4; i++)
+    {
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+        hw->acceptance_filter.code_reg[i].byte = ((code_swapped >> (i * 8)) & 0xFF);
+        hw->acceptance_filter.mask_reg[i].byte = ((mask_swapped >> (i * 8)) & 0xFF);
+#else
+        hw->acceptance_filter.acr[i].byte = ((code_swapped >> (i * 8)) & 0xFF);
+        hw->acceptance_filter.amr[i].byte = ((mask_swapped >> (i * 8)) & 0xFF);
+#endif // ESP_IDF_VERSION
+    }
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    hw->mode_reg.acceptance_filter = single_filter;
+#else
+    hw->mode_reg.afm = single_filter;
+#endif // ESP_IDF_VERSION
+}
+
+/* ------------------------- TX/RX Buffer Registers ------------------------- */
+
+/**
+ * @brief   Copy a formatted TWAI frame into TX buffer for transmission
+ *
+ * @param hw Start address of the TWAI registers
+ * @param tx_frame Pointer to formatted frame
+ *
+ * @note Call twai_ll_format_frame_buffer() to format a frame
+ */
+static inline void twai_ll_set_tx_buffer(ESP32_CAN_DEV_TYPE *hw, twai_ll_frame_buffer_t *tx_frame)
+{
+    // Copy formatted frame into TX buffer
+    for (int i = 0; i < 13; i++)
+    {
+        hw->tx_rx_buffer[i].val = tx_frame->bytes[i];
+    }
+}
+
+/**
+ * @brief   Copy a received frame from the RX buffer for parsing
+ *
+ * @param hw Start address of the TWAI registers
+ * @param rx_frame Pointer to store formatted frame
+ *
+ * @note Call twai_ll_prase_frame_buffer() to parse the formatted frame
+ */
+static inline void twai_ll_get_rx_buffer(ESP32_CAN_DEV_TYPE *hw, twai_ll_frame_buffer_t *rx_frame)
+{
+    // Copy RX buffer registers into frame
+    for (int i = 0; i < 13; i++)
+    {
+        rx_frame->bytes[i] =  hw->tx_rx_buffer[i].byte;
+    }
+}
+
+/**
+ * @brief   Format contents of a TWAI frame into layout of TX Buffer
+ *
+ * This function encodes a message into a frame structure. The frame structure
+ * has an identical layout to the TX buffer, allowing the frame structure to be
+ * directly copied into TX buffer.
+ *
+ * @param[in] 11bit or 29bit ID
+ * @param[in] dlc Data length code
+ * @param[in] data Pointer to an 8 byte array containing data. NULL if no data
+ * @param[in] format Type of TWAI frame
+ * @param[in] single_shot Frame will not be retransmitted on failure
+ * @param[in] self_rx Frame will also be simultaneously received
+ * @param[out] tx_frame Pointer to store formatted frame
+ */
+static inline void twai_ll_format_frame_buffer(uint32_t id, uint8_t dlc, const uint8_t *data,
+                                              uint32_t flags, twai_ll_frame_buffer_t *tx_frame)
+{
+    bool is_extd = flags & TWAI_MSG_FLAG_EXTD;
+    bool is_rtr = flags & TWAI_MSG_FLAG_RTR;
+
+    //Set frame information
+    tx_frame->dlc = dlc;
+    tx_frame->frame_format = is_extd;
+    tx_frame->rtr = is_rtr;
+    tx_frame->self_reception = (flags & TWAI_MSG_FLAG_SELF) ? 1 : 0;
+    tx_frame->single_shot = (flags & TWAI_MSG_FLAG_SS) ? 1 : 0;
+
+    // Set ID. The ID registers are big endian and left aligned, therefore a
+    // bswap will be required
+    if (is_extd)
+    {
+        uint32_t id_temp = __builtin_bswap32((id & TWAI_EXTD_ID_MASK) << 3);
+        for (int i = 0; i < 4; i++)
+        {
+            tx_frame->extended.id[i] = (id_temp >> (8 * i)) & 0xFF;
+        }
+    }
+    else
+    {
+        uint32_t id_temp =  __builtin_bswap16((id & TWAI_STD_ID_MASK) << 5);
+        for (int i = 0; i < 2; i++)
+        {
+            tx_frame->standard.id[i] = (id_temp >> (8 * i)) & 0xFF;
+        }
+    }
+
+    uint8_t *data_buffer = (is_extd) ? tx_frame->extended.data : tx_frame->standard.data;
+    if (!is_rtr)
+    {
+        //Only copy data if the frame is a data frame (i.e not RTR)
+        for (int i = 0; (i < dlc) && (i < TWAI_FRAME_MAX_DLC); i++)
+        {
+            data_buffer[i] = data[i];
+        }
+    }
+}
+
+/**
+ * @brief   Parse formatted TWAI frame (RX Buffer Layout) into its constituent contents
+ *
+ * @param[in] rx_frame Pointer to formatted frame
+ * @param[out] id 11 or 29bit ID
+ * @param[out] dlc Data length code
+ * @param[out] data Data. Left over bytes set to 0.
+ * @param[out] format Type of TWAI frame
+ */
+static inline void twai_ll_prase_frame_buffer(twai_ll_frame_buffer_t *rx_frame, uint32_t *id, uint8_t *dlc,
+                                             uint8_t *data, uint32_t *flags)
+{
+    //Copy frame information
+    *dlc = rx_frame->dlc;
+    uint32_t flags_temp = 0;
+    flags_temp |= (rx_frame->frame_format) ? TWAI_MSG_FLAG_EXTD : 0;
+    flags_temp |= (rx_frame->rtr) ? TWAI_MSG_FLAG_RTR : 0;
+    flags_temp |= (rx_frame->dlc > TWAI_FRAME_MAX_DLC) ? TWAI_MSG_FLAG_DLC_NON_COMP : 0;
+    *flags = flags_temp;
+
+    //Copy ID. The ID registers are big endian and left aligned, therefore a bswap will be required
+    if (rx_frame->frame_format)
+    {
+        uint32_t id_temp = 0;
+        for (int i = 0; i < 4; i++)
+        {
+            id_temp |= rx_frame->extended.id[i] << (8 * i);
+        }
+        id_temp = __builtin_bswap32(id_temp) >> 3;  //((byte[i] << 8*(3-i)) >> 3)
+        *id = id_temp & TWAI_EXTD_ID_MASK;
+    }
+    else
+    {
+        uint32_t id_temp = 0;
+        for (int i = 0; i < 2; i++)
+        {
+            id_temp |= rx_frame->standard.id[i] << (8 * i);
+        }
+        id_temp = __builtin_bswap16(id_temp) >> 5;  //((byte[i] << 8*(1-i)) >> 5)
+        *id = id_temp & TWAI_STD_ID_MASK;
+    }
+
+    uint8_t *data_buffer = (rx_frame->frame_format) ? rx_frame->extended.data : rx_frame->standard.data;
+    //Only copy data if the frame is a data frame (i.e. not a remote frame)
+    int data_length = (rx_frame->rtr) ? 0 : ((rx_frame->dlc > TWAI_FRAME_MAX_DLC) ? TWAI_FRAME_MAX_DLC : rx_frame->dlc);
+    for (int i = 0; i < data_length; i++)
+    {
+        data[i] = data_buffer[i];
+    }
+    //Set remaining bytes of data to 0
+    for (int i = data_length; i < TWAI_FRAME_MAX_DLC; i++)
+    {
+        data[i] = 0;
+    }
+}
+
+/* ----------------------- RX Message Count Register ------------------------ */
+
+/**
+ * @brief   Get RX Message Counter
+ *
+ * @param hw Start address of the TWAI registers
+ * @return RX Message Counter
+ */
+static inline uint32_t twai_ll_get_rx_msg_count(ESP32_CAN_DEV_TYPE *hw)
+{
+    return hw->rx_message_counter_reg.val;
+}
+
+/* ------------------------- Clock Divider Register ------------------------- */
+
+/**
+ * @brief   Set CLKOUT Divider and enable/disable
+ *
+ * Configure CLKOUT. CLKOUT is a pre-scaled version of APB CLK. Divider can be
+ * 1, or any even number from 2 to 14. Set the divider to 0 to disable CLKOUT.
+ *
+ * @param hw Start address of the TWAI registers
+ * @param divider Divider for CLKOUT. Set to 0 to disable CLKOUT
+ */
+static inline void twai_ll_set_clkout(ESP32_CAN_DEV_TYPE *hw, uint32_t divider)
+{
+#if !CONFIG_IDF_TARGET_ESP32S2
+    if (divider >= 2 && divider <= 14)
+    {
+#else
+    if (divider >= 2 && divider <= 490)
+    {
+#endif // CONFIG_IDF_TARGET_ESP32S2
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+        hw->clock_divider_reg.clock_off = 0;
+        hw->clock_divider_reg.clock_divider = (divider / 2) - 1;
+#else
+        hw->clock_divider_reg.co = 0;
+        hw->clock_divider_reg.cd = (divider / 2) - 1;
+#endif // ESP_IDF_VERSION
+    }
+    else if (divider == 1)
+    {
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+        hw->clock_divider_reg.clock_off = 0;
+        hw->clock_divider_reg.clock_divider = 7;
+#else
+        hw->clock_divider_reg.co = 0;
+#if !CONFIG_IDF_TARGET_ESP32S2
+        //Setting the divider reg to max value (7) means a divider of 1
+        hw->clock_divider_reg.cd = 7;
+#else
+        //Setting the divider reg to max value (255) means a divider of 1
+        hw->clock_divider_reg.cd = 255;
+#endif // CONFIG_IDF_TARGET_ESP32S2
+#endif // ESP_IDF_VERSION
+    }
+    else
+    {
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+        hw->clock_divider_reg.clock_off = 1;
+        hw->clock_divider_reg.clock_divider = 0;
+#else
+        hw->clock_divider_reg.co = 1;
+        hw->clock_divider_reg.cd = 0;
+#endif // ESP_IDF_VERSION
+    }
+}
+
+#if !CONFIG_IDF_TARGET_ESP32S2
+/**
+ * @brief   Set register address mapping to extended mode
+ *
+ * Extended mode register address mapping consists of more registers and extra
+ * features.
+ *
+ * @param hw Start address of the TWAI registers
+ *
+ * @note Must be called before setting any configuration
+ * @note Must be called in reset mode
+ */
+static inline void twai_ll_enable_extended_reg_layout(ESP32_CAN_DEV_TYPE *hw)
+{
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    hw->clock_divider_reg.can_mode = 1;
+#else
+    hw->clock_divider_reg.cm = 1;
+#endif // ESP_IDF_VERSION
+}
+#endif // !ESP32-S2
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/* ------------------------- Defines and Typedefs --------------------------- */
+
+#define TWAI_HAL_SET_FLAG(var, flag)            ((var) |= (flag))
+#define TWAI_HAL_RESET_FLAG(var, flag)          ((var) &= ~(flag))
+
+//HAL state flags
+#define TWAI_HAL_STATE_FLAG_RUNNING             (1 << 0)    //Controller is active (not in reset mode)
+#define TWAI_HAL_STATE_FLAG_RECOVERING          (1 << 1)    //Bus is undergoing bus recovery
+#define TWAI_HAL_STATE_FLAG_ERR_WARN            (1 << 2)    //TEC or REC is >= error warning limit
+#define TWAI_HAL_STATE_FLAG_ERR_PASSIVE         (1 << 3)    //TEC or REC is >= 128
+#define TWAI_HAL_STATE_FLAG_BUS_OFF             (1 << 4)    //Bus-off due to TEC >= 256
+#define TWAI_HAL_STATE_FLAG_TX_BUFF_OCCUPIED    (1 << 5)    //Transmit buffer is occupied
+
+//Error active interrupt related
+#define TWAI_HAL_EVENT_BUS_OFF                  (1 << 0)
+#define TWAI_HAL_EVENT_BUS_RECOV_CPLT           (1 << 1)
+#define TWAI_HAL_EVENT_BUS_RECOV_PROGRESS       (1 << 2)
+#define TWAI_HAL_EVENT_ABOVE_EWL                (1 << 3)
+#define TWAI_HAL_EVENT_BELOW_EWL                (1 << 4)
+#define TWAI_HAL_EVENT_ERROR_PASSIVE            (1 << 5)
+#define TWAI_HAL_EVENT_ERROR_ACTIVE             (1 << 6)
+#define TWAI_HAL_EVENT_BUS_ERR                  (1 << 7)
+#define TWAI_HAL_EVENT_ARB_LOST                 (1 << 8)
+#define TWAI_HAL_EVENT_RX_BUFF_FRAME            (1 << 9)
+#define TWAI_HAL_EVENT_TX_BUFF_FREE             (1 << 10)
+
+typedef struct
+{
+    ESP32_CAN_DEV_TYPE *dev;
+    uint32_t state_flags;
+} twai_hal_context_t;
+
+typedef twai_ll_frame_buffer_t twai_hal_frame_t;
+
+/* ---------------------------- Init and Config ----------------------------- */
+
+//Default values written to various registers on initialization
+#define TWAI_HAL_INIT_TEC    0
+#define TWAI_HAL_INIT_REC    0
+#define TWAI_HAL_INIT_EWL    96
+
+/**
+ * @brief Initialize TWAI peripheral and HAL context
+ *
+ * Sets HAL context, puts TWAI peripheral into reset mode, then sets some
+ * registers with default values.
+ *
+ * @param hal_ctx Context of the HAL layer
+ * @return True if successfully initialized, false otherwise.
+ */
+static inline bool twai_hal_init(twai_hal_context_t *hal_ctx)
+{
+    //Initialize HAL context
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,1,0)
+    hal_ctx->dev = (ESP32_CAN_DEV_TYPE*)&CAN;
+#else
+    hal_ctx->dev = (ESP32_CAN_DEV_TYPE*)&TWAI;
+#endif // ESP_IDF_VERSION
+    hal_ctx->state_flags = 0;
+    //Initialize TWAI controller, and set default values to registers
+    twai_ll_enter_reset_mode(hal_ctx->dev);
+    if (!twai_ll_is_in_reset_mode(hal_ctx->dev))
+    {
+        // Must enter reset mode to write to config registers
+        return false;
+    }
+#if !CONFIG_IDF_TARGET_ESP32S2
+    // Changes the address layout of the registers
+    twai_ll_enable_extended_reg_layout(hal_ctx->dev);
+#endif
+    // Freeze REC by changing to LOM mode
+    twai_ll_set_mode(hal_ctx->dev, TWAI_MODE_LISTEN_ONLY);
+    // Both TEC and REC should start at 0
+    twai_ll_set_tec(hal_ctx->dev, TWAI_HAL_INIT_TEC);
+    twai_ll_set_rec(hal_ctx->dev, TWAI_HAL_INIT_REC);
+    // Set default value of for EWL
+    twai_ll_set_err_warn_lim(hal_ctx->dev, TWAI_HAL_INIT_EWL);
+    return true;
+}
+
+/**
+ * @brief Deinitialize the TWAI peripheral and HAL context
+ *
+ * Clears any unhandled interrupts and unsets HAL context
+ *
+ * @param hal_ctx Context of the HAL layer
+ */
+static inline void twai_hal_deinit(twai_hal_context_t *hal_ctx)
+{
+    //Clear any pending registers
+    (void) twai_ll_get_and_clear_intrs(hal_ctx->dev);
+    twai_ll_set_enabled_intrs(hal_ctx->dev, 0);
+    twai_ll_clear_arb_lost_cap(hal_ctx->dev);
+    twai_ll_clear_err_code_cap(hal_ctx->dev);
+    hal_ctx->dev = NULL;
+}
+
+/**
+ * @brief Configure the TWAI peripheral
+ *
+ * @param hal_ctx Context of the HAL layer
+ * @param t_config Pointer to timing configuration structure
+ * @param f_config Pointer to filter configuration structure
+ * @param intr_mask Mask of interrupts to enable
+ * @param clkout_divider Clock divider value for CLKOUT. Set to -1 to disable CLKOUT
+ */
+static inline void twai_hal_configure(twai_hal_context_t *hal_ctx,
+    const twai_timing_config_t *t_config, const twai_filter_config_t *f_config,
+    uint32_t intr_mask, uint32_t clkout_divider)
+{
+    //Configure bus timing, acceptance filter, CLKOUT, and interrupts
+    twai_ll_set_bus_timing(hal_ctx->dev, t_config->brp, t_config->sjw,
+                           t_config->tseg_1, t_config->tseg_2,
+                           t_config->triple_sampling);
+    twai_ll_set_acc_filter(hal_ctx->dev, f_config->acceptance_code,
+                           f_config->acceptance_mask, f_config->single_filter);
+    twai_ll_set_clkout(hal_ctx->dev, clkout_divider);
+    twai_ll_set_enabled_intrs(hal_ctx->dev, intr_mask);
+    // Clear any latched interrupts
+    (void) twai_ll_get_and_clear_intrs(hal_ctx->dev);
+}
+
+/* -------------------------------- Actions -------------------------------- */
+
+/**
+ * @brief Start the TWAI peripheral
+ *
+ * Start the TWAI peripheral by configuring its operating mode, then exiting
+ * reset mode so that the TWAI peripheral can participate in bus activities.
+ *
+ * @param hal_ctx Context of the HAL layer
+ * @param mode Operating mode
+ */
+static inline void twai_hal_start(twai_hal_context_t *hal_ctx, twai_mode_t mode)
+{
+    // Set operating mode
+    twai_ll_set_mode(hal_ctx->dev, mode);
+    // Clear any latched interrupts
+    (void) twai_ll_get_and_clear_intrs(hal_ctx->dev);
+    TWAI_HAL_SET_FLAG(hal_ctx->state_flags, TWAI_HAL_STATE_FLAG_RUNNING);
+    twai_ll_exit_reset_mode(hal_ctx->dev); 
+}
+
+/**
+ * @brief Stop the TWAI peripheral
+ *
+ * Stop the TWAI peripheral by entering reset mode to stop any bus activity, then
+ * setting the operating mode to Listen Only so that REC is frozen.
+ *
+ * @param hal_ctx Context of the HAL layer
+ */
+static inline void twai_hal_stop(twai_hal_context_t *hal_ctx)
+{
+    twai_ll_enter_reset_mode(hal_ctx->dev);
+    (void) twai_ll_get_and_clear_intrs(hal_ctx->dev);
+    // Freeze REC by changing to LOM mode
+    twai_ll_set_mode(hal_ctx->dev, TWAI_MODE_LISTEN_ONLY);
+    // Any TX is immediately halted on entering reset mode
+    TWAI_HAL_RESET_FLAG(hal_ctx->state_flags,
+                        TWAI_HAL_STATE_FLAG_TX_BUFF_OCCUPIED);
+    TWAI_HAL_RESET_FLAG(hal_ctx->state_flags, TWAI_HAL_STATE_FLAG_RUNNING);
+}
+
+/**
+ * @brief Start bus recovery
+ *
+ * @param hal_ctx Context of the HAL layer
+ */
+static inline void twai_hal_start_bus_recovery(twai_hal_context_t *hal_ctx)
+{
+    TWAI_HAL_SET_FLAG(hal_ctx->state_flags, TWAI_HAL_STATE_FLAG_RECOVERING);
+    twai_ll_exit_reset_mode(hal_ctx->dev);
+}
+
+/**
+ * @brief Get the value of the TX Error Counter
+ *
+ * @param hal_ctx Context of the HAL layer
+ * @return TX Error Counter Value
+ */
+static inline uint32_t twai_hal_get_tec(twai_hal_context_t *hal_ctx)
+{
+    return twai_ll_get_tec((hal_ctx)->dev);
+}
+
+/**
+ * @brief Get the value of the RX Error Counter
+ *
+ * @param hal_ctx Context of the HAL layer
+ * @return RX Error Counter Value
+ */
+static inline uint32_t twai_hal_get_rec(twai_hal_context_t *hal_ctx)
+{
+    return twai_ll_get_rec((hal_ctx)->dev);
+}
+
+/**
+ * @brief Get the RX message count register
+ *
+ * @param hal_ctx Context of the HAL layer
+ * @return RX message count
+ */
+static inline uint32_t twai_hal_get_rx_msg_count(twai_hal_context_t *hal_ctx)
+{
+    return twai_ll_get_rx_msg_count((hal_ctx)->dev);
+}
+
+/**
+ * @brief Check if the last transmitted frame was successful
+ *
+ * @param hal_ctx Context of the HAL layer
+ * @return True if successful
+ */
+static inline bool twai_hal_check_last_tx_successful(
+    twai_hal_context_t *hal_ctx)
+{
+    return twai_ll_is_last_tx_successful((hal_ctx)->dev);
+}
+
+/**
+ * @brief Check if certain HAL state flags are set
+ *
+ * The HAL will maintain a record of the controller's state via a set of flags.
+ * These flags are automatically maintained (i.e., set and reset) inside various
+ * HAL function calls. This function checks if certain flags are currently set.
+ *
+ * @param hal_ctx Context of the HAL layer
+ * @param check_flags Bit mask of flags to check
+ * @return True if one or more of the flags in check_flags are set
+ */
+
+static inline bool twai_hal_check_state_flags(twai_hal_context_t *hal_ctx,
+                                              uint32_t check_flags)
+{
+    return hal_ctx->state_flags & check_flags;
+}
+
+/* ----------------------------- Event Handling ---------------------------- */
+
+/**
+ * @brief Decode current events that triggered an interrupt
+ *
+ * This function should be the called at the beginning of an ISR. This
+ * function will do the following:
+ * - Read and clear interrupts
+ * - Decode current events that triggered an interrupt
+ * - Respond to low latency interrupt events
+ *      - Bus off: Change to LOM to free TEC/REC
+ *      - Recovery complete: Enter reset mode
+ *      - Clear ECC and ALC
+ * - Update state flags based on events that have occurred.
+ *
+ * @param hal_ctx Context of the HAL layer
+ * @return Bit mask of events that have occurred
+ */
+static inline uint32_t twai_hal_decode_interrupt_events(
+    twai_hal_context_t *hal_ctx)
+{
+    uint32_t events = 0;
+    //Read interrupt, status
+    uint32_t interrupts = twai_ll_get_and_clear_intrs(hal_ctx->dev);
+    uint32_t status = twai_ll_get_status(hal_ctx->dev);
+    uint32_t tec = twai_ll_get_tec(hal_ctx->dev);
+    uint32_t rec = twai_ll_get_rec(hal_ctx->dev);
+
+    //Error Warning Interrupt set whenever Error or Bus Status bit changes
+    if (interrupts & TWAI_LL_INTR_EI)
+    {
+        if (status & TWAI_LL_STATUS_BS)
+        {
+            //Currently in BUS OFF state
+            if (status & TWAI_LL_STATUS_ES)
+            {
+                // EWL is exceeded, thus must have entered BUS OFF
+
+                // Set to listen only to freeze tec and rec
+                twai_ll_set_mode(hal_ctx->dev, TWAI_MODE_LISTEN_ONLY);
+                events |= TWAI_HAL_EVENT_BUS_OFF;
+                TWAI_HAL_SET_FLAG(hal_ctx->state_flags,
+                                  TWAI_HAL_STATE_FLAG_BUS_OFF);
+                TWAI_HAL_RESET_FLAG(hal_ctx->state_flags,
+                                    TWAI_HAL_STATE_FLAG_RUNNING);
+                // Any TX would have been halted by entering bus off. Reset
+                // it's flag
+                TWAI_HAL_RESET_FLAG(hal_ctx->state_flags,
+                                    TWAI_HAL_STATE_FLAG_TX_BUFF_OCCUPIED);
+            }
+            else
+            {
+                //Below EWL. Therefore TEC is counting down in bus recovery
+                events |= TWAI_HAL_EVENT_BUS_RECOV_PROGRESS;
+            }
+        }
+        else
+        {
+            //Not in BUS OFF
+            if (status & TWAI_LL_STATUS_ES)
+            {
+                // Just Exceeded EWL
+                events |= TWAI_HAL_EVENT_ABOVE_EWL;  
+                TWAI_HAL_SET_FLAG(hal_ctx->state_flags,
+                                  TWAI_HAL_STATE_FLAG_ERR_WARN);
+            } else if (hal_ctx->state_flags & TWAI_HAL_STATE_FLAG_RECOVERING)
+            {
+                // Previously undergoing bus recovery. Thus means bus recovery
+                // complete
+                twai_ll_enter_reset_mode(hal_ctx->dev);
+                // Enter reset mode to stop the peripheral
+                events |= TWAI_HAL_EVENT_BUS_RECOV_CPLT;
+                TWAI_HAL_RESET_FLAG(hal_ctx->state_flags,
+                                    TWAI_HAL_STATE_FLAG_RECOVERING);
+                TWAI_HAL_RESET_FLAG(hal_ctx->state_flags,
+                                    TWAI_HAL_STATE_FLAG_BUS_OFF);
+            }
+            else
+            {
+                // Just went below EWL
+                events |= TWAI_HAL_EVENT_BELOW_EWL;
+                TWAI_HAL_RESET_FLAG(hal_ctx->state_flags,
+                                    TWAI_HAL_STATE_FLAG_ERR_WARN);
+            }
+        }
+    }
+    // Receive Interrupt set whenever RX FIFO  is not empty
+    if (interrupts & TWAI_LL_INTR_RI)
+    {
+        events |= TWAI_HAL_EVENT_RX_BUFF_FRAME;
+    }
+    // Transmit interrupt set whenever TX buffer becomes free
+    if (interrupts & TWAI_LL_INTR_TI)
+    {
+        events |= TWAI_HAL_EVENT_TX_BUFF_FREE;
+        TWAI_HAL_RESET_FLAG(hal_ctx->state_flags,
+                            TWAI_HAL_STATE_FLAG_TX_BUFF_OCCUPIED);
+    }
+    // Error Passive Interrupt on transition from error active to passive or
+    // vice versa
+    if (interrupts & TWAI_LL_INTR_EPI)
+    {
+        if (tec >= TWAI_ERR_PASS_THRESH || rec >= TWAI_ERR_PASS_THRESH)
+        {
+            events |= TWAI_HAL_EVENT_ERROR_PASSIVE;
+            TWAI_HAL_SET_FLAG(hal_ctx->state_flags,
+                              TWAI_HAL_STATE_FLAG_ERR_PASSIVE);
+        }
+        else
+        {
+            events |= TWAI_HAL_EVENT_ERROR_ACTIVE;
+            TWAI_HAL_RESET_FLAG(hal_ctx->state_flags,
+                                TWAI_HAL_STATE_FLAG_ERR_PASSIVE);
+        }
+    }
+    // Bus error interrupt triggered on a bus error (e.g. bit, ACK, stuff etc)
+    if (interrupts & TWAI_LL_INTR_BEI)
+    {
+        twai_ll_clear_err_code_cap(hal_ctx->dev);
+        events |= TWAI_HAL_EVENT_BUS_ERR;
+    }
+    // Arbitration Lost Interrupt triggered on losing arbitration
+    if (interrupts & TWAI_LL_INTR_ALI)
+    {
+        twai_ll_clear_arb_lost_cap(hal_ctx->dev);
+        events |= TWAI_HAL_EVENT_ARB_LOST;
+    }
+    return events;
+}
+
+/* ------------------------------- TX and RX -------------------------------- */
+
+/**
+ * @brief Format a TWAI Frame
+ *
+ * This function takes a TWAI message structure (containing ID, DLC, data, and
+ * flags) and formats it to match the layout of the TX frame buffer.
+ *
+ * @param message Pointer to TWAI message
+ * @param frame Pointer to empty frame structure
+ */
+static inline void twai_hal_format_frame(const twai_message_t *message,
+                                         twai_hal_frame_t *frame)
+{
+    //Direct call to ll function
+    twai_ll_format_frame_buffer(message->identifier, message->data_length_code,
+                                message->data, message->flags, frame);
+}
+
+/**
+ * @brief Parse a TWAI Frame
+ *
+ * This function takes a TWAI frame (in the format of the RX frame buffer) and
+ * parses it to a TWAI message (containing ID, DLC, data and flags).
+ *
+ * @param frame Pointer to frame structure
+ * @param message Pointer to empty message structure
+ */
+static inline void twai_hal_parse_frame(twai_hal_frame_t *frame,
+                                        twai_message_t *message)
+{
+    //Direct call to ll function
+    twai_ll_prase_frame_buffer(frame, &message->identifier,
+                               &message->data_length_code, message->data,
+                               &message->flags);
+}
+
+/**
+ * @brief Copy a frame into the TX buffer and transmit
+ *
+ * This function copies a formatted TX frame into the TX buffer, and the
+ * transmit by setting the correct transmit command (e.g. normal, single shot,
+ * self RX) in the command register.
+ *
+ * @param hal_ctx Context of the HAL layer
+ * @param tx_frame Pointer to structure containing formatted TX frame
+ */
+static inline void twai_hal_set_tx_buffer_and_transmit(
+    twai_hal_context_t *hal_ctx, twai_hal_frame_t *tx_frame)
+{
+    //Copy frame into tx buffer
+    twai_ll_set_tx_buffer(hal_ctx->dev, tx_frame);
+    //Hit the send command
+    if (tx_frame->self_reception)
+    {
+        if (tx_frame->single_shot)
+        {
+            twai_ll_set_cmd_self_rx_single_shot(hal_ctx->dev);
+        }
+        else
+        {
+            twai_ll_set_cmd_self_rx_request(hal_ctx->dev);
+        }
+    }
+    else if (tx_frame->single_shot)
+    {
+        twai_ll_set_cmd_tx_single_shot(hal_ctx->dev);
+    }
+    else
+    {
+        twai_ll_set_cmd_tx(hal_ctx->dev);
+    }
+    TWAI_HAL_SET_FLAG(hal_ctx->state_flags,
+                      TWAI_HAL_STATE_FLAG_TX_BUFF_OCCUPIED);
+}
+
+/**
+ * @brief Copy a frame from the RX buffer and release
+ *
+ * This function copies a frame from the RX buffer, then release the buffer (so
+ * that it loads the next frame in the RX FIFO).
+ *
+ * @param hal_ctx Context of the HAL layer
+ * @param rx_frame Pointer to structure to store RX frame
+ */
+static inline void twai_hal_read_rx_buffer_and_clear(
+    twai_hal_context_t *hal_ctx, twai_hal_frame_t *rx_frame)
+{
+    twai_ll_get_rx_buffer(hal_ctx->dev, rx_frame);
+    twai_ll_set_cmd_release_rx_buffer(hal_ctx->dev);
+}

--- a/src/openlcb/SimpleStack.hxx
+++ b/src/openlcb/SimpleStack.hxx
@@ -54,12 +54,13 @@
 #include "openlcb/SimpleNodeInfo.hxx"
 #include "openlcb/TractionTrain.hxx"
 #include "openlcb/TrainInterface.hxx"
+#include "openmrn_features.h"
 #include "utils/ActivityLed.hxx"
 #include "utils/GcTcpHub.hxx"
 #include "utils/GridConnectHub.hxx"
 #include "utils/HubDevice.hxx"
 #include "utils/HubDeviceNonBlock.hxx"
-#ifdef __FreeRTOS__
+#ifdef OPENMRN_FEATURE_EXECUTOR_SELECT
 #include "utils/HubDeviceSelect.hxx"
 #endif
 
@@ -338,7 +339,9 @@ public:
         auto *port = new HubDeviceNonBlock<CanHubFlow>(can_hub(), device);
         additionalComponents_.emplace_back(port);
     }
+#endif // __FreeRTOS__
 
+#ifdef OPENMRN_FEATURE_EXECUTOR_SELECT
     /// Adds a CAN bus port with select-based asynchronous driver API.
     void add_can_port_select(const char *device)
     {
@@ -354,7 +357,7 @@ public:
         auto *port = new HubDeviceSelect<CanHubFlow>(can_hub(), fd, on_error);
         additionalComponents_.emplace_back(port);
     }
-#endif
+#endif // OPENMRN_FEATURE_EXECUTOR_SELECT
 
     /// Adds a gridconnect port to the CAN bus.
     void add_gridconnect_port(const char *path, Notifiable *on_exit = nullptr);

--- a/src/os/OSSelectWakeup.cxx
+++ b/src/os/OSSelectWakeup.cxx
@@ -122,6 +122,11 @@ static pthread_once_t vfs_init_once = PTHREAD_ONCE_INIT;
 static pthread_key_t select_wakeup_key;
 static int wakeup_fd;
 
+// ESP-IDF v4+ made breaking changes to the VFS layer and in doing so it is not
+// required (or advised) to interact with the LwIP stack via the below
+// functions. For previous versions of ESP-IDF it is necessary to use these
+// functions to allow waking up the ESP32 from a select() call due to bugs in
+// the VFS layer.
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,0,0)
 extern "C"
 {

--- a/src/os/OSSelectWakeup.hxx
+++ b/src/os/OSSelectWakeup.hxx
@@ -54,6 +54,15 @@
 #include <sys/select.h>
 #endif
 
+#ifdef ESP32
+#ifndef ESP_IDF_VERSION
+#define ESP_IDF_VERSION 0
+#endif
+#ifndef ESP_IDF_VERSION_VAL
+#define ESP_IDF_VERSION_VAL(a,b,c) 1
+#endif
+#endif
+
 /// Signal handler that does nothing. @param sig ignored.
 void empty_signal_handler(int sig);
 
@@ -190,16 +199,30 @@ private:
     void esp_wakeup();
     void esp_wakeup_from_isr();
 public:
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,0,0)
     void esp_start_select(void* signal_sem);
     void esp_end_select();
+#else
+    void esp_start_select(esp_vfs_select_sem_t signal_sem, void **args);
+    esp_err_t esp_end_select(void *args);
+#endif // IDF v4+
 
 private:
     /// FD for waking up select in ESP32 VFS implementation.
     int vfsFd_{-1};
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,0,0)
     /// Semaphore for waking up LWIP select.
     void* lwipSem_{nullptr};
+
     /// Semaphore for waking up ESP32 select.
     void* espSem_{nullptr};
+#else
+    /// Semaphore provided by the ESP32 VFS layer to use for waking up the
+    /// ESP32 early from the select() call.
+    esp_vfs_select_sem_t espSem_{false, nullptr};
+#endif // IDF v4+
+
     /// true if we have already woken up select. protected by Atomic *this.
     bool woken_{true};
 #endif

--- a/src/os/OSSelectWakeup.hxx
+++ b/src/os/OSSelectWakeup.hxx
@@ -55,13 +55,17 @@
 #endif
 
 #ifdef ESP32
+#include <esp_vfs.h>
+
 #ifndef ESP_IDF_VERSION
 #define ESP_IDF_VERSION 0
 #endif
+
 #ifndef ESP_IDF_VERSION_VAL
 #define ESP_IDF_VERSION_VAL(a,b,c) 1
 #endif
-#endif
+
+#endif // ESP32
 
 /// Signal handler that does nothing. @param sig ignored.
 void empty_signal_handler(int sig);


### PR DESCRIPTION
The existing `Esp32HardwareCan` code depends on using tasks to poll the ESP-IDF CAN (renamed to TWAI in ESP-IDF v4.2) which is not optimal. This code replicates the ESP-IDF v4.2 TWAI driver and has been augmented to support ESP-IDF v3.2 and above.

In my testing I've seen between 900-950 frames per second without dropping frames, this was done using Esp32CanLoadTest on the esp32 and load_test on Linux using an LCC-Buffer.

@RobertPHeller If you can please test this in your setup when you get a chance it would be appreciated. The current set of ESP32 PRs can be applied concurrently with this one and I'd suggest apply this one last.