### PR TITLE
WIP: ESP32-S2 support

### DIFF
--- a/src/freertos_drivers/common/CpuLoad.cxx
+++ b/src/freertos_drivers/common/CpuLoad.cxx
@@ -39,7 +39,12 @@
 #include "os/os.h"
 #include "freertos_includes.h"
 
-extern "C" {
+#ifdef ESP32
+#include "sdkconfig.h"
+#endif
+
+extern "C"
+{
 
 /// The bits to shift to get multiples of 1.0
 static constexpr uint32_t SHIFT_ONE = 24;
@@ -108,7 +113,8 @@ void CpuLoad::record_value(bool busy, uintptr_t key)
     }
 }
 
-uint8_t CpuLoad::get_load() {
+uint8_t CpuLoad::get_load()
+{
     return (avg_ * 100) >> SHIFT_ONE;
 }
 
@@ -116,20 +122,27 @@ void cpuload_tick(unsigned irq)
 {
     if (!Singleton<CpuLoad>::exists())
         return;
-#ifdef ESP32
+// On the ESP32 it is necessary to use a slightly different approach for
+// recording CPU usage metrics since there may be additional CPU cores.
+// NOTE: The ESP32-S2 is a single-core SoC and defines the FREERTOS_UNICORE
+// flag which we can use here to switch to the standard algorithm.
+#if defined(CONFIG_IDF_TARGET) && !defined(CONFIG_FREERTOS_UNICORE)
     if (irq != 0)
     {
         Singleton<CpuLoad>::instance()->record_value(true, (uintptr_t)irq);
     }
-    else // assumes openmrn task is pinned to core 0
+    else
     {
-        auto hdl = xTaskGetCurrentTaskHandleForCPU(0);
-        bool is_idle = xTaskGetIdleTaskHandleForCPU(0) == hdl;
+        // Record the first CPU core (PRO_CPU). NOTE: This assumes that OpenMRN
+        // is running on this core.
+        auto hdl = xTaskGetCurrentTaskHandleForCPU(PRO_CPU_NUM);
+        bool is_idle = xTaskGetIdleTaskHandleForCPU(PRO_CPU_NUM) == hdl;
         Singleton<CpuLoad>::instance()->record_value(!is_idle, (uintptr_t)hdl);
     }
-    // always records CPU 1 task.
-    auto hdl = xTaskGetCurrentTaskHandleForCPU(1);
-    bool is_idle = xTaskGetIdleTaskHandleForCPU(1) == hdl;
+    // Record the second CPU core (APP_CPU). NOTE: this is where application
+    // code typically runs.
+    auto hdl = xTaskGetCurrentTaskHandleForCPU(APP_CPU_NUM);
+    bool is_idle = xTaskGetIdleTaskHandleForCPU(APP_CPU_NUM) == hdl;
     Singleton<CpuLoad>::instance()->record_value(!is_idle, (uintptr_t)hdl);
 #else
     if (irq != 0)

--- a/src/freertos_drivers/common/CpuLoad.hxx
+++ b/src/freertos_drivers/common/CpuLoad.hxx
@@ -46,7 +46,8 @@
 #include "utils/StringPrintf.hxx"
 #include "freertos_includes.h"
 
-extern "C" {
+extern "C"
+{
     /// Call this function repeatedly from a hardware timer to feed the CPUload
     /// class.
     /// @param irq should be zero if parent is the main context, otherwise the
@@ -65,7 +66,8 @@ extern "C" {
 ///
 /// . retrieve CPU load when desired from the object of this class or via
 ///   Singleton<CpuLoad>::instance().
-class CpuLoad : public Singleton<CpuLoad> {
+class CpuLoad : public Singleton<CpuLoad>
+{
 public:
     CpuLoad() {}
 
@@ -83,22 +85,26 @@ public:
 
     /// Return the maximum consecutive count that busy was measured, clipped to
     /// 255.
-    uint8_t get_max_consecutive() {
+    uint8_t get_max_consecutive()
+    {
         return maxConsecutive_;
     }
 
     /// Reset the maximum consecutive busy count.
-    void clear_max_consecutive() {
+    void clear_max_consecutive()
+    {
         maxConsecutive_ = 0;
     }
 
     /// Returns the peak count over 16 ticks.
-    uint8_t get_peak_over_16_counts() {
+    uint8_t get_peak_over_16_counts()
+    {
         return peakOver16Counts_;
     }
 
     /// Reset the peak count over 16 ticks.
-    void clear_peak_over_16_counts() {
+    void clear_peak_over_16_counts()
+    {
         peakOver16Counts_ = 0;
     }
 

--- a/src/freertos_drivers/common/libatomic.c
+++ b/src/freertos_drivers/common/libatomic.c
@@ -35,6 +35,13 @@
 
 #include <stdint.h>
 
+#ifdef ESP32
+#include "sdkconfig.h"
+#include <soc/cpu.h>
+#include <soc/soc_memory_layout.h>
+#include <xtensa/xtruntime.h>
+#endif
+
 #if defined(STM32F0xx) || (!defined(ARDUINO) && !defined(ESP32))
 // On Cortex-M0 the only way to do atomic operation is to disable interrupts.
 
@@ -78,6 +85,31 @@ uint8_t __atomic_fetch_and_1(uint8_t *ptr, uint8_t val, int memorder)
     ACQ_LOCK();
     uint8_t ret = *ptr;
     *ptr = ret & val;
+    REL_LOCK();
+    return ret;
+}
+
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+// The ESP32-S2 GCC does not include an implementation for __atomic_exchange_1
+// at this time. The version below has been replicated from above with asm code
+// adjusted for the ESP32S2.
+
+/// Disables interrupts and saves the interrupt enable flag in a register.
+#define ACQ_LOCK()                                                             \
+    uint32_t _pastlock;                                                        \
+    __asm__ __volatile__ ("rsil %0, " XTSTR(XCHAL_EXCM_LEVEL) "\n"             \
+                          : "=r"(_pastlock));
+
+/// Restores the interrupte enable flag from a register.
+#define REL_LOCK() __asm__ __volatile__ ("memw \n"                             \
+                                         "wsr %0, ps\n"                        \
+                                        :: "r"(_pastlock));
+
+uint8_t __atomic_exchange_1(uint8_t *ptr, uint8_t val, int memorder)
+{
+    ACQ_LOCK();
+    uint8_t ret = *ptr;
+    *ptr = val;
     REL_LOCK();
     return ret;
 }

--- a/src/os/os.c
+++ b/src/os/os.c
@@ -427,8 +427,6 @@ int __attribute__((weak)) os_thread_create_helper(os_thread_t *thread,
                                 priority,
                                 (StackType_t *)stack_malloc(stack_size),
                                 (StaticTask_t *) malloc(sizeof(StaticTask_t)));
-    task_new->task = *thread;
-    task_new->name = (char*)pcTaskGetTaskName(*thread);
 #elif (configSUPPORT_DYNAMIC_ALLOCATION == 1)
     xTaskCreate(os_thread_start, (const char *const)name,
                 stack_size/sizeof(portSTACK_TYPE), priv, priority, thread);
@@ -624,6 +622,18 @@ long long os_get_time_monotonic(void)
     time = system_get_rtc_time();
     time *= clockmul;
     time >>= 2;
+#elif defined(CONFIG_IDF_TARGET)
+    // esp_timer_get_time() returns the number of microseconds since boot. The
+    // returned value is casted to int64_t whereas the underlying API is using
+    // uint64_t. This API is also used in arduino-esp32 via micros() which
+    // truncates the value to uint32_t (unsigned long).
+    //
+    // Using esp_timer_get_time() instead of clock_gettime() in ESP-IDF is
+    // preferred due to FRC vs RTC configuration options. FRC is the default
+    // option and is available on all ESP32 modules, esp_timer_get_time() is
+    // also used by arduino-esp32 for micros() even though it is truncated to
+    // unsigned long (uint32_t).
+    time = USEC_TO_NSEC(esp_timer_get_time());
 #else
     struct timespec ts;
 #if defined (__nuttx__)

--- a/src/os/stack_malloc.c
+++ b/src/os/stack_malloc.c
@@ -32,7 +32,9 @@
  */
 #include <stdlib.h>
 
-#if defined(__FreeRTOS__)
+#include "openmrn_features.h"
+
+#if OPENMRN_FEATURE_THREAD_FREERTOS
 const void *__attribute__((weak)) stack_malloc(unsigned long length);
 
 const void *stack_malloc(unsigned long length)
@@ -44,7 +46,7 @@ const void *stack_malloc(unsigned long length)
     void *volatile v = malloc(length);
     return v;
 }
-#endif
+#endif // OPENMRN_FEATURE_THREAD_FREERTOS
 
 void *buffer_malloc(size_t length) __attribute__((weak));
 

--- a/src/utils/AutoSyncFileFlow.hxx
+++ b/src/utils/AutoSyncFileFlow.hxx
@@ -37,6 +37,7 @@
 
 #include "executor/Service.hxx"
 #include "executor/StateFlow.hxx"
+#include "utils/StringPrintf.hxx"
 
 /// Simple state flow to configure automatic calls to fsync on a single file
 /// handle at regular intervals.

--- a/src/utils/StringPrintf.cxx
+++ b/src/utils/StringPrintf.cxx
@@ -36,7 +36,7 @@
 
 std::string StringPrintf(const char *format, ...)
 {
-#ifdef __FreeRTOS__
+#if defined(__FreeRTOS__) || defined(ESP32)
     static const int kBufSize = 64;
 #else
     static const int kBufSize = 1000;

--- a/src/utils/macros.h
+++ b/src/utils/macros.h
@@ -89,13 +89,18 @@ extern const char* g_death_file;
 
 #define DIE(MSG) abort()
 
-#elif defined(ESP_NONOS) || defined(ARDUINO)
+#elif defined(ESP_NONOS) || defined(ARDUINO) || defined(CONFIG_IDF_TARGET)
 
 #include <stdio.h>
 #include <assert.h>
 
+/// Checks that the value of expression x is true, else terminates the current
+/// process.
+/// @param x is the assertion expression that should evaluate to true.
 #define HASSERT(x) do { if (!(x)) { printf("Assertion failed in file " __FILE__ " line %d: assert(%s)\n", __LINE__, #x); g_death_file = __FILE__; g_death_lineno = __LINE__; assert(0); abort();} } while(0)
 
+/// Unconditionally terminates the current process with a message.
+/// @param MSG is the message to print as cause of death.
 #define DIE(MSG) do { printf("Crashed in file " __FILE__ " line %d: " MSG "\n", __LINE__); assert(0); abort(); } while(0)
 
 #else
@@ -104,6 +109,9 @@ extern const char* g_death_file;
 #include <stdio.h>
 
 #ifdef NDEBUG
+/// Checks that the value of expression x is true, else terminates the current
+/// process.
+/// @param x is the assertion expression that should evaluate to true.
 #define HASSERT(x) do { if (!(x)) { fprintf(stderr, "Assertion failed in file " __FILE__ " line %d: assert(" #x ")\n", __LINE__); g_death_file = __FILE__; g_death_lineno = __LINE__; abort();} } while(0)
 #else
 /// Checks that the value of expression x is true, else terminates the current
@@ -188,15 +196,15 @@ extern const char* g_death_file;
 #define C_STATIC_ASSERT(expr, name) \
     typedef unsigned char __attribute__((unused)) __static_assert_##name[expr ? 0 : -1]
 
-#if !defined(ESP_NONOS) && !defined(ESP32)
+#ifdef ARDUINO_ARCH_ESP32
+#include <esp8266-compat.h>
+#elif !defined(ESP_NONOS)
 /// Declares (on the ESP8266) that the current function is not executed too
 /// often and should be placed in the SPI flash.
 #define ICACHE_FLASH_ATTR
 /// Declares (on the ESP8266) that the current function is executed
 /// often and should be placed in the instruction RAM.
 #define ICACHE_RAM_ATTR
-#elif defined(ESP32)
-#include <esp8266-compat.h>
 #endif
 
 /// Retrieve a parent pointer from a member class variable. UNSAFE.

--- a/src/utils/stdio_logging.h
+++ b/src/utils/stdio_logging.h
@@ -6,7 +6,8 @@
 extern "C" {
 #endif
 
-#if defined(__linux__) || defined(__MACH__) || defined(__EMSCRIPTEN__)
+#if defined(__linux__) || defined(__MACH__) || defined(__EMSCRIPTEN__) || \
+    defined(ESP32)
 #define LOGWEAK __attribute__((weak))
 #else
 #define LOGWEAK


### PR DESCRIPTION
This requires other ESP32 PRs to be merged before this is usable.

The ESP32 S2 (and eventually S3) SoC have dependencies on ESP-IDF v4.2 or later which is planned for arduino-esp32 v2.0.0. Moving up to ESP-IDF v4.x will require a number of changes in `OSSelectWakeup.cxx/hxx` and `Esp32WiFiManager.cxx/hxx` which I've made but need to clean up before pushing to this PR.