### PR TITLE
Adds a method to send out a global alias mapping enquiry to the bus.

### DIFF
--- a/src/openlcb/CanDefs.hxx
+++ b/src/openlcb/CanDefs.hxx
@@ -121,12 +121,12 @@ struct CanDefs {
         HIGH_PRIORITY   = 0, /**< high priority CAN message */
         NORMAL_PRIORITY = 1  /**< normal priority CAN message */
     };
-    
+
     enum ControlField
     {
         RID_FRAME = 0x0700, /**< Reserve ID Frame */
         AMD_FRAME = 0x0701, /**< Alias Map Definition frame */
-        AME_FRAME = 0x0702, /**< Alias Mapping Inquery */
+        AME_FRAME = 0x0702, /**< Alias Mapping Enquiry */
         AMR_FRAME = 0x0703  /**< Alias Map Reset */
     };
 

--- a/src/openlcb/IfCan.cxx
+++ b/src/openlcb/IfCan.cxx
@@ -718,13 +718,18 @@ void IfCan::send_global_alias_enquiry(Node *source)
         LOG_ERROR("Tried to send global AME witout a local alias.");
         return;
     }
-    auto *b = frame_write_flow()->alloc();
-    CanDefs::control_init(*b->data(), send_alias, CanDefs::AME_FRAME, 0);
-    // Sends it out
-    frame_write_flow()->send(b->ref());
-    // Sends a local loopback of it so that we also respond with all the
-    // definitions.
-    frame_dispatcher()->send((Buffer<CanMessageData> *)b);
+    {
+        auto *b = frame_write_flow()->alloc();
+        CanDefs::control_init(*b->data(), send_alias, CanDefs::AME_FRAME, 0);
+        // Sends it out
+        frame_write_flow()->send(b);
+    }
+    {
+        // Sends another to the local node, but not using the local alias.
+        auto *b = frame_dispatcher()->alloc();
+        CanDefs::control_init(*b->data(), 0, CanDefs::AME_FRAME, 0);
+        frame_dispatcher()->send(b);
+    }
 }
 
 void IfCan::add_addressed_message_support()

--- a/src/openlcb/IfCan.cxx
+++ b/src/openlcb/IfCan.cxx
@@ -709,13 +709,13 @@ void IfCan::send_global_alias_enquiry(Node *source)
 {
     if (!source->is_initialized())
     {
-        LOG_ERROR("Tried to send global AME from not initialzied node.");
+        LOG_ERROR("Tried to send global AME from not initialized node.");
         return;
     }
     NodeAlias send_alias = local_aliases()->lookup(source->node_id());
     if (!send_alias)
     {
-        LOG_ERROR("Tried to send global AME witout a local alias.");
+        LOG_ERROR("Tried to send global AME without a local alias.");
         return;
     }
     {

--- a/src/openlcb/IfCan.cxxtest
+++ b/src/openlcb/IfCan.cxxtest
@@ -137,6 +137,27 @@ TEST_F(AsyncIfTest, AMESupport)
     wait();
 }
 
+TEST_F(AsyncNodeTest, GlobalAMESupport)
+{
+    EXPECT_TRUE(node_->is_initialized());
+    RX({
+        ifCan_->local_aliases()->add(UINT64_C(0x050101011877), 0x729U);
+        ifCan_->remote_aliases()->add(UINT64_C(0x050101011811), 0x111U);
+        EXPECT_EQ(
+            0x111u, ifCan_->remote_aliases()->lookup(UINT64_C(0x050101011811)));
+    });
+    // The enquiry is sent out...
+    expect_packet(":X1070222AN;");
+    // ...along with all local aliases...
+    expect_packet(":X1070122AN02010D000003;");
+    expect_packet(":X10701729N050101011877;");
+    RX(ifCan_->send_global_alias_enquiry(node_));
+    wait();
+    // and the remote cache was cleared.
+    RX(EXPECT_EQ(
+        0u, ifCan_->remote_aliases()->lookup(UINT64_C(0x050101011811))));
+}
+
 TEST_F(AsyncNodeTest, NodeIdLookupLocal)
 {
     NodeIdLookupFlow lflow(ifCan_.get());

--- a/src/openlcb/IfCan.cxxtest
+++ b/src/openlcb/IfCan.cxxtest
@@ -156,6 +156,9 @@ TEST_F(AsyncNodeTest, GlobalAMESupport)
     // and the remote cache was cleared.
     RX(EXPECT_EQ(
         0u, ifCan_->remote_aliases()->lookup(UINT64_C(0x050101011811))));
+    // Checks regression: we did not lose the local node alias.
+    RX(EXPECT_EQ(
+           0x22Au, ifCan_->local_aliases()->lookup(node_->node_id())));
 }
 
 TEST_F(AsyncNodeTest, NodeIdLookupLocal)

--- a/src/openlcb/IfCan.hxx
+++ b/src/openlcb/IfCan.hxx
@@ -115,6 +115,15 @@ public:
     /// Sets the alias allocator for this If. Takes ownership of pointer.
     void set_alias_allocator(AliasAllocator *a);
 
+    /// Sends a global alias enquiry packet. This will also clear the remote
+    /// alias cache (in this node and in all other OpenMRN-based nodes on the
+    /// bus) and let it re-populate from the responses coming back. This call
+    /// should be used very sparingly because of the effect it has on the
+    /// entire bus.
+    /// @param source a local node to use for sending this message out. Must be
+    /// already initialized.
+    void send_global_alias_enquiry(Node *source);
+
     void add_owned_flow(Executable *e) override;
 
     bool matching_node(NodeHandle expected, NodeHandle actual) override;


### PR DESCRIPTION
Updates the global AME handler to clear the remote alias cache. This cache
will be re-populated from the responses coming back from the bus after the
AME frame.