### PR TITLE
Fix incorrect global AME replies.

### DIFF
--- a/src/openlcb/IfCan.cxx
+++ b/src/openlcb/IfCan.cxx
@@ -382,8 +382,9 @@ private:
     {
         while (nextIndex_ < if_can()->local_aliases()->size())
         {
-            if (if_can()->local_aliases()->retrieve(
-                    nextIndex_, nullptr, nullptr))
+            NodeID n;
+            if (if_can()->local_aliases()->retrieve(nextIndex_, &n, nullptr) &&
+                ((n >> (5 * 8)) != 0))
             {
                 return allocate_and_call(
                     if_can()->frame_write_flow(), STATE(fill_response));

--- a/src/openlcb/IfCan.cxxtest
+++ b/src/openlcb/IfCan.cxxtest
@@ -123,9 +123,13 @@ TEST_F(AsyncIfTest, RemoteAliasLearned)
     });
 }
 
-TEST_F(AsyncIfTest, AMESupport)
+TEST_F(AsyncIfTest, AMEReceiveSupport)
 {
+    // Example virtual node.
     RX(ifCan_->local_aliases()->add(UINT64_C(0x050101011877), 0x729U));
+    // This is a reserved but unused alias which should not get AMD frames as
+    // replies for AME.
+    RX(ifCan_->alias_allocator()->add_allocated_alias(0x567u));
     send_packet_and_expect_response(":X10702643N050101011877;",
                                     ":X10701729N050101011877;");
     wait();
@@ -137,12 +141,13 @@ TEST_F(AsyncIfTest, AMESupport)
     wait();
 }
 
-TEST_F(AsyncNodeTest, GlobalAMESupport)
+TEST_F(AsyncNodeTest, GlobalAMESendSupport)
 {
     EXPECT_TRUE(node_->is_initialized());
     RX({
         ifCan_->local_aliases()->add(UINT64_C(0x050101011877), 0x729U);
         ifCan_->remote_aliases()->add(UINT64_C(0x050101011811), 0x111U);
+        ifCan_->alias_allocator()->add_allocated_alias(0x567u);
         EXPECT_EQ(
             0x111u, ifCan_->remote_aliases()->lookup(UINT64_C(0x050101011811)));
     });


### PR DESCRIPTION
Fixes a bug where a global AME request was also getting replies for reserved
but unallocated aliases. These carry an invalid node ID from the local alias
cache and should not be sent to the bus.

Adds reserved aliases to the test cases and to test that no additional packets
show up.