### PR TITLE
Support eeprom update notification.

### DIFF
--- a/boards/ti-ek-tm4c123gxl-launchpad/HwInit.cxx
+++ b/boards/ti-ek-tm4c123gxl-launchpad/HwInit.cxx
@@ -110,6 +110,15 @@ StoredBitSet* g_gpio_stored_bit_set = nullptr;
 constexpr unsigned EEPROM_BIT_COUNT = 84;
 constexpr unsigned EEPROM_BITS_PER_CELL = 28;
 
+/// This variable will be set to 1 when a write arrives to the eeprom.
+uint8_t eeprom_updated = 0;
+
+// Overridesthe default behavior to keep track of eeprom writes.
+void EEPROMEmulation::updated_notification()
+{
+    eeprom_updated = 1;
+}
+
 extern "C" {
 void hw_set_to_safe(void);
 

--- a/src/freertos_drivers/common/EEPROMEmulation.cxx
+++ b/src/freertos_drivers/common/EEPROMEmulation.cxx
@@ -194,6 +194,8 @@ void EEPROMEmulation::write(unsigned int index, const void *buf, size_t len)
     {
         memcpy(shadow_ + shadow_index, shadow_data, shadow_len);
     }
+
+    updated_notification();
 }
 
 /** Write to the EEPROM on a native block boundary.

--- a/src/freertos_drivers/common/EEPROMEmulation.hxx
+++ b/src/freertos_drivers/common/EEPROMEmulation.hxx
@@ -154,6 +154,12 @@ protected:
     static const size_t BLOCK_SIZE;
 
 private:
+    /** This function will be called after every write. The default
+     * implementation is a weak symbol with an empty function. It is intended
+     * to be overridden in the application to get callbacks for eeprom writes
+     * that can trigger a reload. */
+    void updated_notification();
+
     /** Write to the EEPROM.  NOTE!!! This is not necessarily atomic across
      * byte boundaries in the case of power loss.  The user should take this
      * into account as it relates to data integrity of a whole block.

--- a/src/freertos_drivers/common/EEPROMEmulation_weak.cxx
+++ b/src/freertos_drivers/common/EEPROMEmulation_weak.cxx
@@ -37,3 +37,11 @@
 // emulation implementation to prevent GCC from mistakenly optimizing away the
 // constant into a linker reference.
 const bool __attribute__((weak)) EEPROMEmulation::SHADOW_IN_RAM = false;
+
+/// This function will be called after every write. The default
+/// implementation is a weak symbol with an empty function. It is intended
+/// to be overridden in the application to get callbacks for eeprom writes
+/// that can trigger a reload.
+void __attribute__((weak)) EEPROMEmulation::updated_notification()
+{
+}


### PR DESCRIPTION
Adds a weak callback to the eepromemulation driver, triggered
after each write is completed.

Shows with an example how to use this to automatically apply changes
that happened from JMRI configuration UI.