### PR TITLE
Fixes library.a dependencies and other makefile cleanup.

### DIFF
--- a/etc/core_test.mk
+++ b/etc/core_test.mk
@@ -30,13 +30,20 @@ CXXFLAGS += $(INCLUDES)
 
 .SUFFIXES: .o .otest .c .cxx .cxxtest .test .testmd5 .testout
 
-LIBDIR ?= lib
+ifdef LIBDIR
+# we are under prog.mk
+TESTLIBDEPS += $(foreach lib,$(SUBDIRS),lib/lib$(lib).a)
+else
+LIBDIR = lib
+endif
+TESTLIBDEPS += $(foreach lib,$(CORELIBS),$(LIBDIR)/lib$(lib).a)
+
 LDFLAGS      += -L$(LIBDIR)
 
 $(LIBDIR)/timestamp: $(BUILDDIRS)
 
 $(info test deps $(TESTOBJSEXTRA) $(LIBDIR)/timestamp )
-$(TESTBINS): %.test$(EXTENTION) : %.test.o $(TESTOBJSEXTRA) $(LIBDIR)/timestamp $(TESTEXTRADEPS) | $(BUILDDIRS)
+$(TESTBINS): %.test$(EXTENTION) : %.test.o $(TESTOBJSEXTRA) $(LIBDIR)/timestamp lib/timestamp $(TESTLIBDEPS) $(TESTEXTRADEPS) | $(BUILDDIRS)
 	$(LD) -o $@ $(LDFLAGS) -los  $< $(TESTOBJSEXTRA) $(STARTGROUP) $(LINKCORELIBS) $(ENDGROUP) $(SYSLIBRARIES) 
 
 -include $(TESTOBJS:.test.o=.dtest)

--- a/etc/make_utils.mk
+++ b/etc/make_utils.mk
@@ -27,10 +27,14 @@ endef
 ### Helper template to declare a dependency.
 ### Arguments: target_file dependency_file
 ### Example on how to call: Put the following on a standalone line in the Makefile
-### $(foreach lib,$(LIBDIRS),$(eval $(call DEP_helper_template,lib/lib$(lib).a,build-$(lib))))
-define DEP_helper_template
+### $(foreach lib,$(LIBDIRS),$(eval $(call SUBDIR_helper_template,lib/lib$(lib).a,build-$(lib))))
+define SUBDIR_helper_template
 
-$(1): $(2)
+$(1)/lib$(1).a: | build-$(1)
+
+lib/lib$(1).a: $(1)/lib$(1).a
+
+lib/timestamp: lib/lib$(1).a
 
 endef
 

--- a/etc/prog.mk
+++ b/etc/prog.mk
@@ -291,7 +291,6 @@ tests:
 	@echo "***Not building tests at target $(TARGET), because missing: $(TEST_MISSING_DEPS) ***"
 
 else
-ifeq (1,1)
 
 SRCDIR=$(abspath ../../)
 #old code from prog.mk
@@ -303,55 +302,6 @@ SYSLIBRARIES += $(LIBS)
 TESTEXTRADEPS += lib/timestamp
 include $(OPENMRNPATH)/etc/core_test.mk
 
-else
-FULLPATHTESTSRCS ?= $(wildcard $(VPATH)/tests/*_test.cc)
-TESTSRCS = $(notdir $(FULLPATHTESTSRCS)) $(wildcard *_test.cc)
-TESTOBJS := $(TESTSRCS:.cc=.o)
-
-VPATH:=$(VPATH):$(GTESTPATH)/src:$(GTESTSRCPATH):$(GMOCKPATH)/src:$(GMOCKSRCPATH):$(abspath ../../tests)
-INCLUDES += -I$(GTESTPATH)/include -I$(GTESTPATH) -I$(GMOCKPATH)/include -I$(GMOCKPATH)
-
-TEST_OUTPUTS=$(TESTOBJS:.o=.output)
-
-TEST_EXTRA_OBJS += gtest-all.o gmock-all.o
-
-.cc.o:
-	$(CXX) $(CXXFLAGS) $< -o $@
-	$(CXX) -MM $(CXXFLAGS) $< > $*.d
-
-gtest-all.o : %.o : $(GTESTSRCPATH)/src/%.cc
-	$(CXX) $(CXXFLAGS) -I$(GTESTPATH) -I$(GTESTSRCPATH)  $< -o $@
-	$(CXX) -MM $(CXXFLAGS) -I$(GTESTPATH) -I$(GTESTSRCPATH) $< > $*.d
-
-gmock-all.o : %.o : $(GMOCKSRCPATH)/src/%.cc
-	$(CXX) $(CXXFLAGS) -I$(GMOCKPATH) -I$(GMOCKSRCPATH)  $< -o $@
-	$(CXX) -MM $(CXXFLAGS) -I$(GMOCKPATH) -I$(GMOCKSRCPATH) $< > $*.d
-
-#.PHONY: $(TEST_OUTPUTS)
-
-$(TEST_OUTPUTS) : %_test.output : %_test
-	./$*_test --gtest_death_test_style=threadsafe
-	touch $@
-
-$(TESTOBJS:.o=) : %_test : %_test.o $(TEST_EXTRA_OBJS) $(FULLPATHLIBS) $(LIBDIR)/timestamp lib/timestamp
-	$(LD) -o $*_test$(EXTENTION) $*_test.o $(TEST_EXTRA_OBJS) $(OBJEXTRA) $(LDFLAGS)  $(LIBS) $(SYSLIBRARIES) -lstdc++
-
-%_test.o : %_test.cc
-	$(CXX) $(CXXFLAGS:-Werror=) -DTESTING -fpermissive  $< -o $*_test.o
-	$(CXX) -MM $(CXXFLAGS) $< > $*_test.d
-
-#$(TEST_OUTPUTS) : %_test.output : %_test.cc gtest-all.o gtest_main.o
-#	$(CXX) $(CXXFLAGS) $< -o $*_test.o
-#	$(CXX) -MM $(CXXFLAGS) $< > $*_test.d
-#	$(LD) -o $*_test$(EXTENTION) $+ $(OBJEXTRA) $(LDFLAGS) $(LIBS) $(SYSLIBRARIES) -lstdc++
-#	./$*_test
-
-tests : all $(TEST_OUTPUTS)
-
-mksubdirs:
-	[ -d lib ] || mkdir lib
-endif # old testrunner code
-
 endif  # if we are able to run tests
 
-endif
+endif  # if we can build anything -- MISSING_DEPS is empty

--- a/etc/prog.mk
+++ b/etc/prog.mk
@@ -38,8 +38,8 @@ OBJS = $(CXXSRCS:.cxx=.o) $(CPPSRCS:.cpp=.o) $(CSRCS:.c=.o) $(ASMSRCS:.S=.o) \
        $(XMLSRCS:.xml=.o)
 
 LIBDIR = $(OPENMRNPATH)/targets/$(TARGET)/lib
-FULLPATHLIBS = $(wildcard $(LIBDIR)/*.a) $(wildcard lib/*.a)
 LIBDIRS := $(SUBDIRS)
+FULLPATHLIBS = $(wildcard $(LIBDIR)/*.a) $(wildcard lib/*.a) $(foreach lib,$(LIBDIRS),lib/lib$(lib).a) 
 LIBS = $(STARTGROUP) \
        $(foreach lib,$(LIBDIRS),-l$(lib)) \
        $(LINKCORELIBS) \
@@ -53,7 +53,7 @@ all:
 # the directory foo and rebuild stuff that's there. However, the dependency is
 # phrased in a way that if recursing does not change the library (when it's
 # up-to-date) then the .elf linking is not re-done.
-$(foreach lib,$(LIBDIRS),$(eval $(call DEP_helper_template,lib/lib$(lib).a,build-$(lib))))
+$(foreach lib,$(LIBDIRS),$(eval $(call SUBDIR_helper_template,$(lib))))
 
 CDIEXTRA := -I.
 INCLUDES += -I.
@@ -151,7 +151,7 @@ clean: clean_cdi
 .PHONY: clean_cdi
 clean_cdi:
 	rm -f cdi.xmlout cdi.nxml cdi.cxxout compile_cdi
-endif
+endif  # have_config_cdi
 
 # Makes sure the subdirectory builds are done before linking the binary.
 # The targets and variable BUILDDIRS are defined in recurse.mk.
@@ -159,7 +159,7 @@ endif
 
 # This file acts as a guard describing when the last libsomething.a was remade
 # in the application libraries.
-lib/timestamp : FORCE $(BUILDDIRS)
+lib/timestamp : FORCE
 #	 creates the lib directory
 	@[ -d lib ] || mkdir lib
 # in case there are not applibs.


### PR DESCRIPTION
- Removes dead code from prog.mk
- Adds endif comments
- Makes the library subdirectories build in an application target be a direct dependency of the executable.
- updates core_test.mk so that the libsomething.a files are dependencies there as well.
  This should avoid certain cases where a change in a file did not cause a test to be rebuilt.