### PR TITLE
Adds ability to remove an event handler from the callbacks.

### DIFF
--- a/src/openlcb/CallbackEventHandler.hxx
+++ b/src/openlcb/CallbackEventHandler.hxx
@@ -101,7 +101,7 @@ public:
 
     ~CallbackEventHandler()
     {
-        EventRegistry::instance()->unregister_handler(this);
+        remove_all_entries();
     }
 
     /// Registers this event handler for a given event ID in the global event
@@ -119,6 +119,21 @@ public:
     {
         EventRegistry::instance()->register_handler(
             EventRegistryEntry(this, event, entry_bits), 0);
+    }
+
+    /// Removes the registration of every single entry added so far.
+    void remove_all_entries()
+    {
+        EventRegistry::instance()->unregister_handler(this);
+    }
+
+    /// Removes the registration of entries added before with a given user_arg
+    /// value.
+    /// @param user_arg argument to match on.
+    void remove_entry(uint32_t entry_bits)
+    {
+        EventRegistry::instance()->unregister_handler(
+            this, entry_bits, 0xFFFFFFFFu);
     }
 
     /// @return the node pointer for which this handler is exported.

--- a/src/openlcb/EventHandler.hxx
+++ b/src/openlcb/EventHandler.hxx
@@ -272,7 +272,17 @@ public:
     virtual void register_handler(const EventRegistryEntry &entry,
                                   unsigned mask) = 0;
     /// Removes all registered instances of a given event handler pointer.
-    virtual void unregister_handler(EventHandler *handler) = 0;
+    /// @param handler the handler for which to unregister entries
+    /// @param user_arg values of the 32-bit user arg to remove
+    /// @param user_arg_mask 32-bit mask where to verify user_arg being equal
+    virtual void unregister_handler(EventHandler *handler,
+        uint32_t user_arg = 0, uint32_t user_arg_mask = 0) = 0;
+
+    /// Prepares storage for adding many event handlers.
+    /// @param count how many empty slots to reserve.
+    virtual void reserve(size_t count)
+    {
+    }
 
     /// Creates a new event iterator. Caller takes ownership of object.
     virtual EventIterator *create_iterator() = 0;

--- a/src/openlcb/EventHandlerContainer.cxxtest
+++ b/src/openlcb/EventHandlerContainer.cxxtest
@@ -313,7 +313,7 @@ public:
     }
 
     vector<EventHandler *> get_all_matching(uint64_t event,
-                                            uint64_t mask = 1)
+                                            uint64_t mask = 0)
     {
         report_.event = event;
         report_.mask = mask;
@@ -332,9 +332,9 @@ public:
         return reinterpret_cast<EventHandler *>(0x100 + n);
     }
 
-    void add_handler(int n, uint64_t eventid, unsigned mask)
+    void add_handler(int n, uint64_t eventid, unsigned mask, uint32_t arg = 0)
     {
-        handlers_.register_handler(EventRegistryEntry(h(n), eventid), mask);
+        handlers_.register_handler(EventRegistryEntry(h(n), eventid, arg), mask);
     }
 
 protected:
@@ -367,6 +367,26 @@ TEST_F(TreeEventHandlerTest, SingleLookup)
     EXPECT_THAT(get_all_matching(0x3FE, 0), ElementsAre());
 
     EXPECT_THAT(get_all_matching(0x103FF, 0), ElementsAre());
+}
+
+TEST_F(TreeEventHandlerTest, RemoveByMask)
+{
+    handlers_.reserve(3);
+    
+    add_handler(1, 0x3FF, 0, 0xB);
+    add_handler(1, 0x3FE, 0, 7);
+    add_handler(1, 0x3FD, 0, 0xFB);
+    EXPECT_THAT(get_all_matching(0x3F0, 0xF), ElementsAre(h(1),h(1),h(1)));
+    EXPECT_THAT(get_all_matching(0x3FF), ElementsAre(h(1)));
+    EXPECT_THAT(get_all_matching(0x3FE), ElementsAre(h(1)));
+    EXPECT_THAT(get_all_matching(0x3FD), ElementsAre(h(1)));
+
+    handlers_.unregister_handler(h(1), 0xB, 0xF);
+
+    EXPECT_THAT(get_all_matching(0x3F0, 0xF), ElementsAre(h(1)));
+    EXPECT_THAT(get_all_matching(0x3FF), ElementsAre());
+    EXPECT_THAT(get_all_matching(0x3FE), ElementsAre(h(1)));
+    EXPECT_THAT(get_all_matching(0x3FD), ElementsAre());
 }
 
 TEST_F(TreeEventHandlerTest, MultiLookup)

--- a/src/openlcb/EventHandlerContainer.hxx
+++ b/src/openlcb/EventHandlerContainer.hxx
@@ -109,8 +109,9 @@ private:
 
 /// EventRegistry implementation that keeps all event handlers in a vector and
 /// forwards every single call to each event handler.
-class VectorEventHandlers : public EventRegistry, private Atomic {
- public:
+class VectorEventHandlers : public EventRegistry, private Atomic
+{
+public:
     VectorEventHandlers() {}
 
     // Creates a new event iterator. Caller takes ownership of object.
@@ -155,7 +156,7 @@ public:
     void unregister_handler(EventHandler *handler, uint32_t user_arg,
         uint32_t user_arg_mask) OVERRIDE;
     void reserve(size_t count) OVERRIDE;
-    
+
 private:
     class Iterator;
     friend class Iterator;

--- a/src/openlcb/EventHandlerContainer.hxx
+++ b/src/openlcb/EventHandlerContainer.hxx
@@ -153,8 +153,8 @@ public:
     EventIterator* create_iterator() OVERRIDE;
     void register_handler(const EventRegistryEntry &entry,
                           unsigned mask) OVERRIDE;
-    void unregister_handler(EventHandler *handler, uint32_t user_arg,
-        uint32_t user_arg_mask) OVERRIDE;
+    void unregister_handler(EventHandler *handler, uint32_t user_arg = 0,
+        uint32_t user_arg_mask = 0) OVERRIDE;
     void reserve(size_t count) OVERRIDE;
 
 private:

--- a/src/openlcb/EventHandlerContainer.hxx
+++ b/src/openlcb/EventHandlerContainer.hxx
@@ -109,7 +109,7 @@ private:
 
 /// EventRegistry implementation that keeps all event handlers in a vector and
 /// forwards every single call to each event handler.
-class VectorEventHandlers : public EventRegistry {
+class VectorEventHandlers : public EventRegistry, private Atomic {
  public:
     VectorEventHandlers() {}
 
@@ -118,30 +118,24 @@ class VectorEventHandlers : public EventRegistry {
         return new FullContainerIterator<HandlersList>(&handlers_);
     }
 
-  void register_handler(const EventRegistryEntry& entry, unsigned mask) OVERRIDE {
-    // @TODO(balazs.racz): need some kind of locking here.
-    handlers_.push_front(entry);
-    set_dirty();
-  }
-  void unregister_handler(EventHandler *handler) OVERRIDE
-  {
-      // @TODO(balazs.racz): need some kind of locking here.
-      struct HandlerEquals
-      {
-          HandlerEquals(EventHandler *h) : h_(h)
-          {
-          }
-          bool operator()(const EventRegistryEntry &e)
-          {
-              return e.handler == h_;
-          }
-
-      private:
-          EventHandler *h_;
-      } predicate(handler);
-      handlers_.remove_if(predicate);
-      set_dirty();
-  }
+    void register_handler(
+        const EventRegistryEntry &entry, unsigned mask) OVERRIDE
+    {
+        AtomicHolder h(this);
+        handlers_.push_front(entry);
+        set_dirty();
+    }
+    void unregister_handler(EventHandler *handler, uint32_t user_arg = 0,
+        uint32_t user_arg_mask = 0) OVERRIDE
+    {
+        AtomicHolder h(this);
+        handlers_.remove_if([handler, user_arg, user_arg_mask](
+                                const EventRegistryEntry &e) {
+            return e.handler == handler &&
+                ((e.user_arg & user_arg_mask) == (user_arg & user_arg_mask));
+        });
+        set_dirty();
+    }
 
  private:
   typedef std::forward_list<EventRegistryEntry> HandlersList;
@@ -158,8 +152,10 @@ public:
     EventIterator* create_iterator() OVERRIDE;
     void register_handler(const EventRegistryEntry &entry,
                           unsigned mask) OVERRIDE;
-    void unregister_handler(EventHandler* handler) OVERRIDE;
-
+    void unregister_handler(EventHandler *handler, uint32_t user_arg,
+        uint32_t user_arg_mask) OVERRIDE;
+    void reserve(size_t count) OVERRIDE;
+    
 private:
     class Iterator;
     friend class Iterator;


### PR DESCRIPTION
Minor fixes:
- adds ability to unregister event handlers by user_arg value and mask
- fixes todos around missing locking
- removes a crashing branch that makes not a lot of sense