### PR TITLE
limit timer cleanup

### DIFF
--- a/src/utils/LimitTimer.hxx
+++ b/src/utils/LimitTimer.hxx
@@ -36,6 +36,8 @@
 #ifndef _UTILS_LIMITTIMER_HXX_
 #define _UTILS_LIMITTIMER_HXX_
 
+#include <algorithm>
+
 #include "executor/Timer.hxx"
  
 /// This timer takes care of limiting the number of speed updates we send
@@ -52,7 +54,7 @@ public:
                std::function<void()> callback)
         : Timer(ex->active_timers())
         , updateDelayMsec_(update_delay_msec)
-        , bucket_(max_tokens > 127 ? 127 : max_tokens)
+        , bucket_(std::min(static_cast<uint8_t>(127), max_tokens))
         , bucketMax_(max_tokens)
         , needUpdate_(false)
         , callback_(callback)

--- a/src/utils/LimitTimer.hxx
+++ b/src/utils/LimitTimer.hxx
@@ -33,6 +33,9 @@
  * @date 9 January 2021
  */
 
+#ifndef _UTILS_LIMITTIMER_HXX_
+#define _UTILS_LIMITTIMER_HXX_
+
 #include "executor/Timer.hxx"
  
 /// This timer takes care of limiting the number of speed updates we send
@@ -133,3 +136,4 @@ private:
     std::function<void()> callback_;
 };
 
+#endif // _UTILS_LIMITTIMER_HXX_


### PR DESCRIPTION
I missed the include guards, and I wanted to simplify my "min" calculation.