### PR TITLE
Fix os_thread_create_helper for arduino esp32

### DIFF
--- a/src/os/os.c
+++ b/src/os/os.c
@@ -421,17 +421,15 @@ int __attribute__((weak)) os_thread_create_helper(os_thread_t *thread,
                                                   void *priv)
 {
     HASSERT(thread);
-#if (configSUPPORT_STATIC_ALLOCATION == 1)
+#if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+    xTaskCreate(os_thread_start, (const char *const)name,
+                stack_size/sizeof(portSTACK_TYPE), priv, priority, thread);
+#elif (configSUPPORT_STATIC_ALLOCATION == 1)
     *thread = xTaskCreateStatic(os_thread_start, (const char *const)name,
                                 stack_size/sizeof(portSTACK_TYPE), priv,
                                 priority,
                                 (StackType_t *)stack_malloc(stack_size),
                                 (StaticTask_t *) malloc(sizeof(StaticTask_t)));
-    task_new->task = *thread;
-    task_new->name = (char*)pcTaskGetTaskName(*thread);
-#elif (configSUPPORT_DYNAMIC_ALLOCATION == 1)
-    xTaskCreate(os_thread_start, (const char *const)name,
-                stack_size/sizeof(portSTACK_TYPE), priv, priority, thread);
 #else
 #error FREERTOS version v9.0.0 or later required
 #endif


### PR DESCRIPTION
Fix code that runs for task creation when a freertos config that enables static allocation.
The previous code was probably never compiled because it had an undeclared variable.

