### PR TITLE
WiFi manager uplink disable

### DIFF
--- a/arduino/examples/ESP32IOBoard/config.h
+++ b/arduino/examples/ESP32IOBoard/config.h
@@ -56,7 +56,7 @@ using AllProducers = RepeatedGroup<ProducerConfig, NUM_INPUTS>;
 
 /// Modify this value every time the EEPROM needs to be cleared on the node
 /// after an update.
-static constexpr uint16_t CANONICAL_VERSION = 0x1000;
+static constexpr uint16_t CANONICAL_VERSION = 0x1002;
 
 /// Defines the main segment in the configuration CDI. This is laid out at
 /// origin 128 to give space for the ACDI user data at the beginning.

--- a/arduino/examples/ESP32WifiCanBridge/config.h
+++ b/arduino/examples/ESP32WifiCanBridge/config.h
@@ -33,7 +33,7 @@ extern const SimpleNodeStaticValues SNIP_STATIC_DATA = {
 
 /// Modify this value every time the EEPROM needs to be cleared on the node
 /// after an update.
-static constexpr uint16_t CANONICAL_VERSION = 0x1000;
+static constexpr uint16_t CANONICAL_VERSION = 0x1002;
 
 /// Defines the main segment in the configuration CDI. This is laid out at
 /// origin 128 to give space for the ACDI user data at the beginning.

--- a/src/freertos_drivers/esp32/Esp32WiFiConfiguration.hxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiConfiguration.hxx
@@ -69,13 +69,20 @@ public:
     static constexpr const char *HUB_DESC =
         "Configuration settings for an OpenLCB Hub";
 
-    /// Visible name for the hub enable field.
-    static constexpr const char *HUB_ENABLE_NAME = "Enable Hub Mode";
+    /// Visible name for the hub/uplink enable field.
+    static constexpr const char *CONN_MODE_NAME = "Connection Mode";
 
-    /// Visible description for the hub enable field.
-    static constexpr const char *HUB_ENABLE_DESC =
-        "Defines this node as a hub which can accept connections";
+    /// Visible description for the hub/uplink enable field.
+    static constexpr const char *CONN_MODE_DESC =
+        "Defines whether to allow accepting connections (according to the Hub configuration), making a connection (according to the Uplink configuration), or both.";
 
+    /// <map> of possible keys and descriptive values to show to the user for
+    /// the connection_mode fields.
+    static constexpr const char *CONN_MODE_MAP =
+        "<relation><property>1</property><value>Uplink Only</value></relation>"
+        "<relation><property>2</property><value>Hub Only</value></relation>"
+        "<relation><property>3</property><value>Hub+Uplink</value></relation>";
+  
     /// Visible name for the hub_listener_port field.
     static constexpr const char *HUB_LISTENER_PORT_NAME = "Hub Listener Port";
 
@@ -94,11 +101,6 @@ public:
 
 /// CDI Configuration for an @ref Esp32WiFiManager managed hub.
 CDI_GROUP(HubConfiguration);
-/// Allows the node to become a Grid Connect Hub.
-CDI_GROUP_ENTRY(enable, openlcb::Uint8ConfigEntry,
-    Name(Esp32WiFiConfigurationParams::HUB_ENABLE_NAME),
-    Description(Esp32WiFiConfigurationParams::HUB_ENABLE_DESC), Min(0), Max(1),
-    Default(0), MapValues(Esp32WiFiConfigurationParams::BOOLEAN_MAP));
 /// Specifies the port which should be used by the hub.
 CDI_GROUP_ENTRY(port, openlcb::Uint16ConfigEntry,
     Name(Esp32WiFiConfigurationParams::HUB_LISTENER_PORT_NAME),
@@ -120,6 +122,11 @@ CDI_GROUP_ENTRY(sleep, openlcb::Uint8ConfigEntry,
     Name(Esp32WiFiConfigurationParams::WIFI_POWER_SAVE_NAME),
     Description(Esp32WiFiConfigurationParams::WIFI_POWER_SAVE_DESC), Min(0),
     Max(1), Default(0), MapValues(Esp32WiFiConfigurationParams::BOOLEAN_MAP));
+/// Defines configuration of hub or uplink
+CDI_GROUP_ENTRY(connection_mode, openlcb::Uint8ConfigEntry,
+    Name(Esp32WiFiConfigurationParams::CONN_MODE_NAME),
+    Description(Esp32WiFiConfigurationParams::CONN_MODE_DESC), Min(1), Max(3),
+    Default(1), MapValues(Esp32WiFiConfigurationParams::CONN_MODE_MAP));
 /// CDI Configuration to enable this node to be a hub.
 CDI_GROUP_ENTRY(hub, HubConfiguration,
     Name(Esp32WiFiConfigurationParams::HUB_NAME),


### PR DESCRIPTION
Makes the wifi manager operate in one of three modes:
- uplink only
- hub+uplink
- hub only

Previously the uplink could not be disabled, which causes massive problems
in a hub-only application.