### PR TITLE
Switches the mdns and uplink connect requests to a separate executor.

### DIFF
--- a/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
@@ -368,6 +368,12 @@ private:
     /// Internal flag for tracking that the mDNS system has been initialized.
     bool mdnsInitialized_{false};
 
+    /// True if we have started the connect executor thread.
+    bool connectExecutorStarted_{false};
+
+    /// Executor to use for the uplink connections.
+    Executor<1> connectExecutor_{NO_THREAD()};
+
     /// Internal holder for mDNS entries which could not be published due to
     /// mDNS not being initialized yet.
     std::map<std::string, uint16_t> mdnsDeferredPublish_;


### PR DESCRIPTION
Using the default executor in this place causes blockage of packet processing.