### PR TITLE
Fixup in the ESP32 arduino examples

### DIFF
--- a/arduino/examples/ESP32CanLoadTest/ESP32CanLoadTest.ino
+++ b/arduino/examples/ESP32CanLoadTest/ESP32CanLoadTest.ino
@@ -69,7 +69,7 @@
 
 /// This is the node id to assign to this device, this must be unique
 /// on the CAN bus.
-static constexpr uint64_t NODE_ID = UINT64_C(0x050101011823);
+static constexpr uint64_t NODE_ID = UINT64_C(0x05010101182b);
 
 #if defined(USE_WIFI)
 // Configuring WiFi accesspoint name and password

--- a/arduino/examples/ESP32CanLoadTest/config.h
+++ b/arduino/examples/ESP32CanLoadTest/config.h
@@ -56,7 +56,7 @@ using AllProducers = RepeatedGroup<ProducerConfig, NUM_INPUTS>;
 
 /// Modify this value every time the EEPROM needs to be cleared on the node
 /// after an update.
-static constexpr uint16_t CANONICAL_VERSION = 0x1000;
+static constexpr uint16_t CANONICAL_VERSION = 0x100b;
 
 /// Defines the main segment in the configuration CDI. This is laid out at
 /// origin 128 to give space for the ACDI user data at the beginning.
@@ -71,14 +71,6 @@ CDI_GROUP_ENTRY(wifi, WiFiConfiguration, Name("WiFi Configuration"));
 #endif
 CDI_GROUP_END();
 
-/// This segment is only needed temporarily until there is program code to set
-/// the ACDI user data version byte.
-CDI_GROUP(VersionSeg, Segment(MemoryConfigDefs::SPACE_CONFIG),
-    Name("Version information"));
-CDI_GROUP_ENTRY(acdi_user_version, Uint8ConfigEntry,
-    Name("ACDI User Data version"), Description("Set to 2 and do not change."));
-CDI_GROUP_END();
-
 /// The main structure of the CDI. ConfigDef is the symbol we use in main.cxx
 /// to refer to the configuration defined here.
 CDI_GROUP(ConfigDef, MainCdi());
@@ -88,11 +80,9 @@ CDI_GROUP_ENTRY(ident, Identification);
 CDI_GROUP_ENTRY(acdi, Acdi);
 /// Adds a segment for changing the values in the ACDI user-defined
 /// space. UserInfoSegment is defined in the system header.
-CDI_GROUP_ENTRY(userinfo, UserInfoSegment);
+CDI_GROUP_ENTRY(userinfo, UserInfoSegment, Name("User Info"));
 /// Adds the main configuration segment.
-CDI_GROUP_ENTRY(seg, IoBoardSegment);
-/// Adds the versioning segment.
-CDI_GROUP_ENTRY(version, VersionSeg);
+CDI_GROUP_ENTRY(seg, IoBoardSegment, Name("Settings"));
 CDI_GROUP_END();
 
 } // namespace openlcb

--- a/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
+++ b/arduino/examples/ESP32IOBoard/ESP32IOBoard.ino
@@ -64,7 +64,7 @@
 
 /// This is the node id to assign to this device, this must be unique
 /// on the CAN bus.
-static constexpr uint64_t NODE_ID = UINT64_C(0x050101011823);
+static constexpr uint64_t NODE_ID = UINT64_C(0x05010101182a);
 
 #if defined(USE_WIFI)
 // Configuring WiFi accesspoint name and password

--- a/arduino/examples/ESP32IOBoard/config.h
+++ b/arduino/examples/ESP32IOBoard/config.h
@@ -56,7 +56,7 @@ using AllProducers = RepeatedGroup<ProducerConfig, NUM_INPUTS>;
 
 /// Modify this value every time the EEPROM needs to be cleared on the node
 /// after an update.
-static constexpr uint16_t CANONICAL_VERSION = 0x1002;
+static constexpr uint16_t CANONICAL_VERSION = 0x100a;
 
 /// Defines the main segment in the configuration CDI. This is laid out at
 /// origin 128 to give space for the ACDI user data at the beginning.
@@ -71,14 +71,6 @@ CDI_GROUP_ENTRY(wifi, WiFiConfiguration, Name("WiFi Configuration"));
 #endif
 CDI_GROUP_END();
 
-/// This segment is only needed temporarily until there is program code to set
-/// the ACDI user data version byte.
-CDI_GROUP(VersionSeg, Segment(MemoryConfigDefs::SPACE_CONFIG),
-    Name("Version information"));
-CDI_GROUP_ENTRY(acdi_user_version, Uint8ConfigEntry,
-    Name("ACDI User Data version"), Description("Set to 2 and do not change."));
-CDI_GROUP_END();
-
 /// The main structure of the CDI. ConfigDef is the symbol we use in main.cxx
 /// to refer to the configuration defined here.
 CDI_GROUP(ConfigDef, MainCdi());
@@ -88,11 +80,9 @@ CDI_GROUP_ENTRY(ident, Identification);
 CDI_GROUP_ENTRY(acdi, Acdi);
 /// Adds a segment for changing the values in the ACDI user-defined
 /// space. UserInfoSegment is defined in the system header.
-CDI_GROUP_ENTRY(userinfo, UserInfoSegment);
+CDI_GROUP_ENTRY(userinfo, UserInfoSegment, Name("User Info"));
 /// Adds the main configuration segment.
-CDI_GROUP_ENTRY(seg, IoBoardSegment);
-/// Adds the versioning segment.
-CDI_GROUP_ENTRY(version, VersionSeg);
+CDI_GROUP_ENTRY(seg, IoBoardSegment, Name("Settings"));
 CDI_GROUP_END();
 
 } // namespace openlcb

--- a/arduino/examples/ESP32SerialBridge/ESP32SerialBridge.ino
+++ b/arduino/examples/ESP32SerialBridge/ESP32SerialBridge.ino
@@ -72,7 +72,7 @@ constexpr gpio_num_t CAN_TX_PIN = GPIO_NUM_5;
 
 /// This is the node id to assign to this device, this must be unique
 /// on the CAN bus.
-static constexpr uint64_t NODE_ID = UINT64_C(0x050101011822);
+static constexpr uint64_t NODE_ID = UINT64_C(0x050101011829);
 
 /// This is the primary entrypoint for the OpenMRN/LCC stack.
 OpenMRN openmrn(NODE_ID);

--- a/arduino/examples/ESP32SerialBridge/config.h
+++ b/arduino/examples/ESP32SerialBridge/config.h
@@ -31,7 +31,7 @@ extern const SimpleNodeStaticValues SNIP_STATIC_DATA = {
 
 /// Modify this value every time the EEPROM needs to be cleared on the node
 /// after an update.
-static constexpr uint16_t CANONICAL_VERSION = 0x1000;
+static constexpr uint16_t CANONICAL_VERSION = 0x1009;
 
 /// Defines the main segment in the configuration CDI. This is laid out at
 /// origin 128 to give space for the ACDI user data at the beginning.
@@ -39,14 +39,6 @@ CDI_GROUP(IoBoardSegment, Segment(MemoryConfigDefs::SPACE_CONFIG), Offset(128));
 /// Each entry declares the name of the current entry, then the type and then
 /// optional arguments list.
 CDI_GROUP_ENTRY(internal_config, InternalConfigData);
-CDI_GROUP_END();
-
-/// This segment is only needed temporarily until there is program code to set
-/// the ACDI user data version byte.
-CDI_GROUP(VersionSeg, Segment(MemoryConfigDefs::SPACE_CONFIG),
-    Name("Version information"));
-CDI_GROUP_ENTRY(acdi_user_version, Uint8ConfigEntry,
-    Name("ACDI User Data version"), Description("Set to 2 and do not change."));
 CDI_GROUP_END();
 
 /// The main structure of the CDI. ConfigDef is the symbol we use in main.cxx
@@ -58,11 +50,9 @@ CDI_GROUP_ENTRY(ident, Identification);
 CDI_GROUP_ENTRY(acdi, Acdi);
 /// Adds a segment for changing the values in the ACDI user-defined
 /// space. UserInfoSegment is defined in the system header.
-CDI_GROUP_ENTRY(userinfo, UserInfoSegment);
+CDI_GROUP_ENTRY(userinfo, UserInfoSegment, Name("User Info"));
 /// Adds the main configuration segment.
-CDI_GROUP_ENTRY(seg, IoBoardSegment);
-/// Adds the versioning segment.
-CDI_GROUP_ENTRY(version, VersionSeg);
+CDI_GROUP_ENTRY(seg, IoBoardSegment, Name("Settings"));
 CDI_GROUP_END();
 
 } // namespace openlcb

--- a/arduino/examples/ESP32WifiCanBridge/ESP32WifiCanBridge.ino
+++ b/arduino/examples/ESP32WifiCanBridge/ESP32WifiCanBridge.ino
@@ -62,7 +62,7 @@ constexpr gpio_num_t CAN_TX_PIN = GPIO_NUM_5;
 
 /// This is the node id to assign to this device, this must be unique
 /// on the CAN bus.
-static constexpr uint64_t NODE_ID = UINT64_C(0x050101011821);
+static constexpr uint64_t NODE_ID = UINT64_C(0x050101011828);
 
 // Configuring WiFi accesspoint name and password
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/arduino/examples/ESP32WifiCanBridge/config.h
+++ b/arduino/examples/ESP32WifiCanBridge/config.h
@@ -33,7 +33,7 @@ extern const SimpleNodeStaticValues SNIP_STATIC_DATA = {
 
 /// Modify this value every time the EEPROM needs to be cleared on the node
 /// after an update.
-static constexpr uint16_t CANONICAL_VERSION = 0x1002;
+static constexpr uint16_t CANONICAL_VERSION = 0x1008;
 
 /// Defines the main segment in the configuration CDI. This is laid out at
 /// origin 128 to give space for the ACDI user data at the beginning.
@@ -42,14 +42,6 @@ CDI_GROUP(IoBoardSegment, Segment(MemoryConfigDefs::SPACE_CONFIG), Offset(128));
 /// optional arguments list.
 CDI_GROUP_ENTRY(internal_config, InternalConfigData);
 CDI_GROUP_ENTRY(wifi, WiFiConfiguration, Name("WiFi Configuration"));
-CDI_GROUP_END();
-
-/// This segment is only needed temporarily until there is program code to set
-/// the ACDI user data version byte.
-CDI_GROUP(VersionSeg, Segment(MemoryConfigDefs::SPACE_CONFIG),
-    Name("Version information"));
-CDI_GROUP_ENTRY(acdi_user_version, Uint8ConfigEntry,
-    Name("ACDI User Data version"), Description("Set to 2 and do not change."));
 CDI_GROUP_END();
 
 /// The main structure of the CDI. ConfigDef is the symbol we use in main.cxx
@@ -61,11 +53,9 @@ CDI_GROUP_ENTRY(ident, Identification);
 CDI_GROUP_ENTRY(acdi, Acdi);
 /// Adds a segment for changing the values in the ACDI user-defined
 /// space. UserInfoSegment is defined in the system header.
-CDI_GROUP_ENTRY(userinfo, UserInfoSegment);
+CDI_GROUP_ENTRY(userinfo, UserInfoSegment, Name("User Info"));
 /// Adds the main configuration segment.
-CDI_GROUP_ENTRY(seg, IoBoardSegment);
-/// Adds the versioning segment.
-CDI_GROUP_ENTRY(version, VersionSeg);
+CDI_GROUP_ENTRY(seg, IoBoardSegment, Name("Settings"));
 CDI_GROUP_END();
 
 } // namespace openlcb


### PR DESCRIPTION
Fixup in the ESP32 arduino examples:
- make sure they all have different Node IDs.
- make sure they all have different canonical versions.
This is useful when the user switches from one example to another to
correctly reset the settings.

Further fixes:
- removes unnecessary "ACDI version number" segment.
- ensures that all segments have a name, which is essential in the new JMRI UI.