### PR TITLE
Update Tiva and CC32xx UART driver.

### DIFF
--- a/include/freertos/tc_ioctl.h
+++ b/include/freertos/tc_ioctl.h
@@ -46,11 +46,17 @@
 #define TCPAREVEN   IO(TERMIOS_IOC_MAGIC, 0xF2)
 #define TCPARONE    IO(TERMIOS_IOC_MAGIC, 0xF3)
 #define TCPARZERO   IO(TERMIOS_IOC_MAGIC, 0xF4)
+/// One stop bit
+#define TCSTOPONE   IO(TERMIOS_IOC_MAGIC, 0xF8) 
+/// Two stop bits
+#define TCSTOPTWO   IO(TERMIOS_IOC_MAGIC, 0xF9)
 
 /// Argument is a Notifiable* pointer. This notifiable will be invoked when all
 /// bytes have completed transferring and the transmit engine is idle.
 #define TCDRAINNOTIFY   IOW(TERMIOS_IOC_MAGIC, 0xE0, 4)
 
+/// Argument is the desired baud rate for the port.
+#define TCBAUDRATE   IOW(TERMIOS_IOC_MAGIC, 0xE1, 4)
 
 #endif // _FREERTOS_TC_IOCTL_H_
 

--- a/src/freertos_drivers/ti/CC32xxUart.hxx
+++ b/src/freertos_drivers/ti/CC32xxUart.hxx
@@ -89,8 +89,8 @@ public:
      */
     void interrupt_handler();
 
-    /** Request an ioctl transaction. Currently the only supported ioctl is
-     * TCSBRK. */
+    /** Request an ioctl transaction. Supported ioctl is TCSBRK, TCDRAINNOTIFY,
+     * and TCPAR* from include/freertos/tc_ioctl.h */
     int ioctl(File *file, unsigned long int key, unsigned long data) override;
 
 private:
@@ -106,19 +106,23 @@ private:
      */
     void send();
 
+    /** Sets the port baud rate and mode from the class variables. */
+    void set_mode();
+    
     /** function pointer to a method that asserts the transmit enable. */
-    TxEnableMethod txEnableAssert;
+    TxEnableMethod txEnableAssert_;
 
     /** function pointer to a method that deasserts the transmit enable. */
-    TxEnableMethod txEnableDeassert;
+    TxEnableMethod txEnableDeassert_;
 
     /** Notifiable to invoke when the transmit engine has finished operation. */
-    Notifiable* txComplete{nullptr};
+    Notifiable* txComplete_{nullptr};
     
-    unsigned long base; /**< base address of this device */
-    unsigned long interrupt; /**< interrupt of this device */
-    bool txPending; /**< transmission currently pending */
-    bool hwFIFO; /**< true if hardware fifo is to be enabled, else false */
+    unsigned long base_; /**< base address of this device */
+    uint32_t interrupt_ : 8; /**< interrupt of this device */
+    uint32_t baud_ : 24; /**< desired baud rate */
+    uint8_t txPending_; /**< transmission currently pending */
+    uint8_t hwFIFO_; /**< true if hardware fifo is to be enabled, else false */
 
     /** Default constructor.
      */

--- a/src/freertos_drivers/ti/CC32xxUart.hxx
+++ b/src/freertos_drivers/ti/CC32xxUart.hxx
@@ -90,7 +90,7 @@ public:
     void interrupt_handler();
 
     /** Request an ioctl transaction. Supported ioctl is TCSBRK, TCDRAINNOTIFY,
-     * and TCPAR* from include/freertos/tc_ioctl.h */
+     * TCSTOP*, TCBAUDRATE and TCPAR* from include/freertos/tc_ioctl.h */
     int ioctl(File *file, unsigned long int key, unsigned long data) override;
 
 private:


### PR DESCRIPTION
- Harmonize features between these two drivers, such as baud rate, mode and fifo settings.
- Adds ioctl for setting baud rate and stop bit configuration
- Packs fields more efficiently.
- Makes all fields use uniform style.