### PR TITLE
Allow Esp32WiFiManager to work with any subclass of SimpleCanStackBase.

### DIFF
--- a/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
@@ -86,7 +86,7 @@
 #endif // defined __has_include
 
 using openlcb::NodeID;
-using openlcb::SimpleCanStack;
+using openlcb::SimpleCanStackBase;
 using openlcb::TcpAutoAddress;
 using openlcb::TcpClientConfig;
 using openlcb::TcpClientDefaultParams;
@@ -304,7 +304,7 @@ private:
 // WiFi connection, mDNS system and the hostname of the ESP32.
 Esp32WiFiManager::Esp32WiFiManager(const char *ssid
                                  , const char *password
-                                 , SimpleCanStack *stack
+                                 , SimpleCanStackBase *stack
                                  , const WiFiConfiguration &cfg
                                  , const char *hostname_prefix
                                  , wifi_mode_t wifi_mode
@@ -357,7 +357,7 @@ Esp32WiFiManager::Esp32WiFiManager(const char *ssid
 // With this constructor being used, it will be the responsibility of the
 // application to manage the WiFi and mDNS systems.
 Esp32WiFiManager::Esp32WiFiManager(
-    SimpleCanStack *stack, const WiFiConfiguration &cfg)
+    SimpleCanStackBase *stack, const WiFiConfiguration &cfg)
     : DefaultConfigUpdateListener()
     , cfg_(cfg)
     , manageWiFi_(false)

--- a/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
+++ b/src/freertos_drivers/esp32/Esp32WiFiManager.hxx
@@ -84,7 +84,7 @@ public:
     /// @param ssid is the WiFi AP to connect to. Must stay alive forever.
     /// @param password is the password for the WiFi AP being connected
     /// to. Must stay alive forever.
-    /// @param stack is the SimpleCanStack for this node. Must stay alive
+    /// @param stack is the SimpleCanStackBase for this node. Must stay alive
     /// forever.
     /// @param cfg is the WiFiConfiguration instance used for this node. This
     /// will be monitored for changes and the WiFi behavior altered
@@ -118,7 +118,7 @@ public:
     /// node uptime.
     Esp32WiFiManager(const char *ssid
                    , const char *password
-                   , openlcb::SimpleCanStack *stack
+                   , openlcb::SimpleCanStackBase *stack
                    , const WiFiConfiguration &cfg
                    , const char *hostname_prefix = "esp32_"
                    , wifi_mode_t wifi_mode = WIFI_MODE_STA
@@ -138,12 +138,12 @@ public:
     /// the application code starts the the WiFi and MDNS systems before
     /// calling OpenMRN::begin().
     ///
-    /// @param stack is the SimpleCanStack for this node.
+    /// @param stack is the SimpleCanStackBase for this node.
     /// @param cfg is the WiFiConfiguration instance used for this node. This
     /// will be monitored for changes and the WiFi behavior altered
     /// accordingly.
     Esp32WiFiManager(
-        openlcb::SimpleCanStack *stack, const WiFiConfiguration &cfg);
+        openlcb::SimpleCanStackBase *stack, const WiFiConfiguration &cfg);
 
     /// Updates the WiFiConfiguration settings used by this node.
     ///
@@ -215,7 +215,7 @@ public:
     /// @param port is the port for the service to be published.
     ///
     /// Note: This will schedule a @ref CallbackExecutable on the @ref Executor
-    /// used by the @ref SimpleCanStack.
+    /// used by the @ref SimpleCanStackBase.
     void mdns_publish(std::string service, uint16_t port);
 
     /// Removes the advertisement of a service via mDNS.
@@ -294,7 +294,7 @@ private:
     const bool manageWiFi_;
 
     /// OpenMRN stack for the Arduino system.
-    openlcb::SimpleCanStack *stack_;
+    openlcb::SimpleCanStackBase *stack_;
 
     /// WiFi operating mode.
     wifi_mode_t wifiMode_{WIFI_MODE_STA};


### PR DESCRIPTION
This allows the WiFi manager to be used in cases such as when a stack type implements a different node type. E.g. SimpleTrainCanStack.