### PR TITLE
Eliminates a copy in the DCC decoder.

### DIFF
--- a/src/dcc/Receiver.hxx
+++ b/src/dcc/Receiver.hxx
@@ -169,7 +169,9 @@ public:
                         clear_packet();
                         pkt_->dlc = 0;
                         pkt_->payload[0] = 0;
-                    } else {
+                    }
+                    else
+                    {
                         havePacket_ = false;
                     }
                     return;

--- a/src/dcc/Receiver.hxx
+++ b/src/dcc/Receiver.hxx
@@ -42,6 +42,7 @@
 
 #include "freertos/can_ioctl.h"
 #include "freertos_drivers/common/SimpleLog.hxx"
+#include "dcc/packet.h"
 
 // If defined, collects samples of timing and state into a ring buffer.
 //#define DCC_DECODER_DEBUG
@@ -89,6 +90,27 @@ public:
         return parseState_;
     }
 
+    /// Sets where to write the decoded DCC data to. If this function is not
+    /// called before a packet preamble starts, the packet will be discarded.
+    /// @param pkt where to store the incoming payload bytes. This packet will
+    /// be reset to an empty packet.
+    void set_packet(DCCPacket *pkt)
+    {
+        pkt_ = pkt;
+        if (pkt_)
+        {
+            clear_packet();
+        }
+    }
+
+    /// Retrieves the last applied DCC packet pointer.
+    /// @return DCC packet, or nullptr if there was no DCC packet pointer
+    /// assigned yet.
+    DCCPacket *pkt()
+    {
+        return pkt_;
+    };
+
     /// Call this function for each time the polarity of the signal changes.
     /// @param value is the number of clock cycles since the last polarity
     /// change.
@@ -110,12 +132,14 @@ public:
                     parseState_ = DCC_PREAMBLE;
                     return;
                 }
-                if (timings_[MM_PREAMBLE].match(value))
+                if (timings_[MM_PREAMBLE].match(value) && pkt_)
                 {
                     parseCount_ = 1 << 2;
-                    ofs_ = 0;
-                    data_[ofs_] = 0;
+                    pkt_->dlc = 0;
+                    pkt_->payload[0] = 0;
+                    pkt_->packet_header.is_marklin = 1;
                     parseState_ = MM_DATA;
+                    havePacket_ = true;
                 }
                 break;
             }
@@ -139,8 +163,15 @@ public:
                 {
                     parseState_ = DCC_DATA;
                     parseCount_ = 1 << 7;
-                    ofs_ = 0;
-                    data_[ofs_] = 0;
+                    if (pkt_)
+                    {
+                        havePacket_ = true;
+                        clear_packet();
+                        pkt_->dlc = 0;
+                        pkt_->payload[0] = 0;
+                    } else {
+                        havePacket_ = false;
+                    }
                     return;
                 }
                 break;
@@ -165,7 +196,10 @@ public:
                 {
                     if (parseCount_)
                     {
-                        data_[ofs_] |= parseCount_;
+                        if (havePacket_)
+                        {
+                            pkt_->payload[pkt_->dlc] |= parseCount_;
+                        }
                         parseCount_ >>= 1;
                         parseState_ = DCC_DATA;
                         return;
@@ -192,9 +226,18 @@ public:
                     else
                     {
                         // end of byte zero bit. Packet is not finished yet.
-                        ofs_++;
-                        HASSERT(ofs_ < sizeof(data_));
-                        data_[ofs_] = 0;
+                        if (havePacket_)
+                        {
+                            pkt_->dlc++;
+                            if (pkt_->dlc >= DCC_PACKET_MAX_PAYLOAD)
+                            {
+                                pkt_ = nullptr;
+                            }
+                            else
+                            {
+                                pkt_->payload[pkt_->dlc] = 0;
+                            }
+                        }
                         parseCount_ = 1 << 7;
                     }
                     parseState_ = DCC_DATA;
@@ -239,16 +282,16 @@ public:
                     parseCount_ >>= 1;
                     if (!parseCount_)
                     {
-                        if (ofs_ == 2)
+                        if (pkt_->dlc == 2)
                         {
                             parseState_ = MM_PACKET_FINISHED;
                             return;
                         }
                         else
                         {
-                            ofs_++;
+                            pkt_->dlc++;
                             parseCount_ = 1 << 7;
-                            data_[ofs_] = 0;
+                            pkt_->payload[pkt_->dlc] = 0;
                         }
                     }
                     parseState_ = MM_DATA;
@@ -260,20 +303,20 @@ public:
             {
                 if (timings_[MM_LONG].match(value))
                 {
-                    data_[ofs_] |= parseCount_;
+                    pkt_->payload[pkt_->dlc] |= parseCount_;
                     parseCount_ >>= 1;
                     if (!parseCount_)
                     {
-                        if (ofs_ == 2)
+                        if (pkt_->dlc == 2)
                         {
                             parseState_ = MM_PACKET_FINISHED;
                             return;
                         }
                         else
                         {
-                            ofs_++;
+                            pkt_->dlc++;
                             parseCount_ = 1 << 7;
-                            data_[ofs_] = 0;
+                            pkt_->payload[pkt_->dlc] = 0;
                         }
                     }
                     parseState_ = MM_DATA;
@@ -293,25 +336,23 @@ public:
             (parseState_ == DCC_DATA_ONE); // one bit comes
     }
 
-    /// Returns the number of payload bytes in the current packet.
-    uint8_t packet_length()
-    {
-        return ofs_ + 1;
-    }
-
-    /// Returns the current packet payload buffer. The buffer gets invalidated
-    /// at the next call to process_data.
-    const uint8_t *packet_data()
-    {
-        return data_;
-    }
-
 private:
+    /// Counter that works through bit patterns.
     uint32_t parseCount_ = 0;
+    /// State machine for parsing.
     State parseState_ = UNKNOWN;
-    // Payload of current packet.
-    uint8_t data_[6];
-    uint8_t ofs_; // offset inside data_;
+    /// True if we have storage in the right time for the current packet.
+    bool havePacket_;
+    /// Storage for the current packet.
+    DCCPacket* pkt_ = nullptr;
+
+    /// Sets the input DCC packet to empty.
+    void clear_packet()
+    {
+        pkt_->header_raw_data = 0;
+        pkt_->dlc = 0;
+        pkt_->feedback_key = 0;
+    }
 
     /// Represents the timing of a half-wave of the digital track signal.
     struct Timing
@@ -377,6 +418,7 @@ public:
         : StateFlowBase(s)
     {
         fd_ = ::open(dev, O_RDONLY | O_NONBLOCK);
+        decoder_.set_packet(&pkt_);
         start_flow(STATE(register_and_sleep));
     }
 
@@ -401,13 +443,11 @@ private:
             decoder_.process_data(value);
             if (decoder_.state() == DccDecoder::DCC_PACKET_FINISHED)
             {
-                dcc_packet_finished(
-                    decoder_.packet_data(), decoder_.packet_length());
+                dcc_packet_finished(pkt_.payload, pkt_.dlc);
             }
             else if (decoder_.state() == DccDecoder::MM_PACKET_FINISHED)
             {
-                mm_packet_finished(
-                    decoder_.packet_data(), decoder_.packet_length());
+                mm_packet_finished(pkt_.payload, pkt_.dlc);
             }
 
             static uint8_t x = 0;
@@ -426,6 +466,8 @@ private:
     uint32_t lastValue_ = 0;
 
 protected:
+    /// Packet buffer.
+    DCCPacket pkt_;
     /// State machine that does the DCC decoding. We have 1 usec per tick, as
     /// these are the numbers we receive from the driver.
     DccDecoder decoder_ {1};

--- a/src/dcc/Receiver.hxx
+++ b/src/dcc/Receiver.hxx
@@ -169,6 +169,7 @@ public:
                         clear_packet();
                         pkt_->dlc = 0;
                         pkt_->payload[0] = 0;
+                        pkt_->packet_header.skip_ec = 1;
                     }
                     else
                     {
@@ -209,6 +210,10 @@ public:
                     else
                     {
                         // end of packet 1 bit.
+                        if (havePacket_)
+                        {
+                            pkt_->dlc++;
+                        }
                         parseState_ = DCC_MAYBE_CUTOUT;
                         return;
                     }
@@ -233,7 +238,7 @@ public:
                             pkt_->dlc++;
                             if (pkt_->dlc >= DCC_PACKET_MAX_PAYLOAD)
                             {
-                                pkt_ = nullptr;
+                                havePacket_ = false;
                             }
                             else
                             {

--- a/src/freertos_drivers/common/DccDecoder.hxx
+++ b/src/freertos_drivers/common/DccDecoder.hxx
@@ -303,13 +303,6 @@ __attribute__((optimize("-O3"))) void DccDecoder<Module>::interrupt_handler()
         {
             prepCutout_ = true;
             Module::dcc_before_cutout_hook();
-            if (decoder_.pkt())
-            {
-                decoder_.pkt()->header_raw_data = 0;
-                decoder_.pkt()->packet_header.skip_ec = 1;
-                nextPacketFilled_ = true;
-            }
-            Module::trigger_os_interrupt();
         }
         // If we are at the second half of the last 1 bit and the
         // value of the input pin is 1, then we cannot recognize when
@@ -324,6 +317,11 @@ __attribute__((optimize("-O3"))) void DccDecoder<Module>::interrupt_handler()
             Module::set_cap_timer_delay_usec(RAILCOM_CUTOUT_PRE);
             inCutout_ = true;
             cutoutState_ = 0;
+            if (decoder_.pkt())
+            {
+                nextPacketFilled_ = true;
+            }
+            Module::trigger_os_interrupt();
         }
         else if (decoder_.state() == dcc::DccDecoder::DCC_CUTOUT)
         {

--- a/src/freertos_drivers/common/DccDecoder.hxx
+++ b/src/freertos_drivers/common/DccDecoder.hxx
@@ -395,11 +395,12 @@ DccDecoder<Module>::rcom_interrupt_handler()
 template <class Module>
 __attribute__((optimize("-O3"))) void DccDecoder<Module>::os_interrupt_handler()
 {
+    unsigned woken = 0;
     if (nextPacketFilled_) {
         inputData_->advance(1);
         nextPacketFilled_ = false;
         inputData_->signal_condition_from_isr();
-
+        woken = 1;
         if (inputData_->space())
         {
             DCCPacket *next;
@@ -417,4 +418,5 @@ __attribute__((optimize("-O3"))) void DccDecoder<Module>::os_interrupt_handler()
         inputData_->data_write_pointer(&next);
         decoder_.set_packet(next);
     }
+    portYIELD_FROM_ISR(woken);
 }

--- a/src/freertos_drivers/common/DccDecoder.hxx
+++ b/src/freertos_drivers/common/DccDecoder.hxx
@@ -396,21 +396,13 @@ template <class Module>
 __attribute__((optimize("-O3"))) void DccDecoder<Module>::os_interrupt_handler()
 {
     unsigned woken = 0;
-    if (nextPacketFilled_) {
+    if (nextPacketFilled_)
+    {
         inputData_->advance(1);
         nextPacketFilled_ = false;
         inputData_->signal_condition_from_isr();
         woken = 1;
-        if (inputData_->space())
-        {
-            DCCPacket *next;
-            inputData_->data_write_pointer(&next);
-            decoder_.set_packet(next);
-        }
-        else
-        {
-            decoder_.set_packet(nullptr);
-        }
+        decoder_.set_packet(nullptr);
     }
     if (!decoder_.pkt() && inputData_->space())
     {


### PR DESCRIPTION
Makes the DCC Decoder fill in the DccPacket structure directly instead of a local buffer which then gets copied.