### PR TITLE
Adds checksum verification to the DccDecode class.

### DIFF
--- a/src/dcc/DccDebug.cxx
+++ b/src/dcc/DccDebug.cxx
@@ -250,7 +250,7 @@ string packet_to_string(const DCCPacket &pkt, bool bin_payload)
     }
     else
     {
-        options += StringPrintf(" [bad dlc, exp %u, actual %u]", ofs, pkt.dlc);
+        options += StringPrintf(" [bad dlc, exp %u, actual %u]", ofs+1, pkt.dlc);
         while (ofs < pkt.dlc)
         {
             options += StringPrintf(" 0x%02x", pkt.payload[ofs++]);

--- a/src/dcc/DccDebug.cxx
+++ b/src/dcc/DccDebug.cxx
@@ -256,6 +256,10 @@ string packet_to_string(const DCCPacket &pkt, bool bin_payload)
             options += StringPrintf(" 0x%02x", pkt.payload[ofs++]);
         }
     }
+    if (pkt.packet_header.csum_error)
+    {
+        options += " [csum err]";
+    }
     return options;
 }
 

--- a/src/dcc/Receiver.hxx
+++ b/src/dcc/Receiver.hxx
@@ -212,7 +212,8 @@ public:
                         // end of packet 1 bit.
                         if (havePacket_)
                         {
-                            if (checkCRC_ && !crcState_.check_ok())
+                            if (checkCRC_ && (pkt_->dlc > 6) &&
+                                !crcState_.check_ok())
                             {
                                 pkt_->packet_header.csum_error = 1;
                             }

--- a/src/dcc/packet.h
+++ b/src/dcc/packet.h
@@ -72,8 +72,8 @@ typedef struct dcc_packet
         /// The packet will be sent 1 + rept_count times to the wire. default:
         /// 0.
         uint8_t rept_count : 2;
-        /// reserved for future use.
-        uint8_t reserved : 1;
+        /// 1 if there was a checksum error in this packet.
+        uint8_t csum_error : 1;
     };
 
     /// Specifies the meaning of the command byte for meta-commands to send.

--- a/src/dcc/packet.h
+++ b/src/dcc/packet.h
@@ -42,7 +42,7 @@ extern "C" {
 #endif
 
 /** Maximum number of payload bytes. */
-#define DCC_PACKET_MAX_PAYLOAD (6)
+#define DCC_PACKET_MAX_PAYLOAD (32)
 /** Send this speed step to emergency-stop the locomotive. */
 #define DCC_PACKET_EMERGENCY_STOP (0xFFFF)
 /** Send this speed step to switch direction of the locomotive. Only used


### PR DESCRIPTION
Adds support to XOR and CRC8 checksum in the DCC decoder class. These are computed during the reception of the individual bytes. The checksum correctness is then returned in a bit in the packet header.

Expands the maximum length of a DCC packet structure from 6 to 32 bytes.