### PR TITLE
Reduce the number of times the config file is opened in SimpleStack

### DIFF
--- a/src/openlcb/ConfigUpdateFlow.cxx
+++ b/src/openlcb/ConfigUpdateFlow.cxx
@@ -42,16 +42,10 @@ namespace openlcb
 
 int ConfigUpdateFlow::open_file(const char *path)
 {
-    if (fd_ >= 0) return fd_;
-    if (!path)
-    {
-        fd_ = -1;
-    }
-    else
-    {
-        fd_ = ::open(path, O_RDWR);
-        HASSERT(fd_ >= 0);
-    }
+    HASSERT(fd_ < 0);
+    HASSERT(path);
+    fd_ = ::open(path, O_RDWR);
+    HASSERT(fd_ >= 0);
     return fd_;
 }
 

--- a/src/openlcb/ConfigUpdateFlow.hxx
+++ b/src/openlcb/ConfigUpdateFlow.hxx
@@ -71,14 +71,22 @@ public:
     {
     }
 
-    /// Must be called once before calling anything else. Returns the file
-    /// descriptor.
+    /// Must be called once (only) before calling anything else. Returns the
+    /// file descriptor.
     int open_file(const char *path);
     /// Asynchronously invokes all update listeners with the config FD.
     void init_flow();
     /// Synchronously invokes all update listeners to factory reset.
     void factory_reset();
 
+    /// @return the file descriptor of the configuration file, or -1 if the
+    /// configuration file has not yet been opened.
+    int get_fd()
+    {
+        return fd_;
+    }
+
+#ifdef GTEST
     void TEST_set_fd(int fd)
     {
         fd_ = fd;
@@ -86,6 +94,7 @@ public:
     bool TEST_is_terminated() {
         return is_terminated();
     }
+#endif // GTEST
 
     void trigger_update() override
     {


### PR DESCRIPTION
Reuse the file descriptor for the config file that was opened by the ConfigUpdateFlow.