### PR TITLE
Tiva 129 updates around emulator

### DIFF
--- a/applications/async_blink/main.cxx
+++ b/applications/async_blink/main.cxx
@@ -63,7 +63,8 @@
 #include "utils/ESPWifiClient.hxx"
 #endif
 
-#if defined (BOARD_LAUNCHPAD_EK) || defined (__linux__)
+#if (defined (TARGET_IS_CC3200) || defined (__linux__) || defined(PART_TM4C1294NCPDT)) && (!defined(NO_CONSOLE))
+#define HAVE_CONSOLE
 #include "console/Console.hxx"
 #endif
 
@@ -206,9 +207,7 @@ openlcb::BitEventConsumer consumer(&logger);
  */
 int appl_main(int argc, char* argv[])
 {
-#if defined (BOARD_LAUNCHPAD_EK)
-    //new Console(stack.executor(), Console::FD_STDIN, Console::FD_STDOUT);
-#elif defined (__linux__)
+#ifdef HAVE_CONSOLE
     new Console(stack.executor(), Console::FD_STDIN, Console::FD_STDOUT, 2121);
 #endif
 

--- a/applications/blink_raw/main.cxx
+++ b/applications/blink_raw/main.cxx
@@ -41,15 +41,6 @@
 
 #include "os/os.h"
 #include "utils/blinker.h"
-#include "console/Console.hxx"
-
-#if (defined (TARGET_IS_CC3200) || defined (__linux__) || defined(PART_TM4C1294NCPDT)) && (!defined(NO_CONSOLE))
-#define HAVE_CONSOLE
-#endif
-
-#ifdef HAVE_CONSOLE
-Executor<1> executor("executor", 0, 2048);
-#endif
 
 /** Entry point to application.
  * @param argc number of command line arguments
@@ -59,9 +50,6 @@ Executor<1> executor("executor", 0, 2048);
 int appl_main(int argc, char *argv[])
 {
     setblink(0);
-#ifdef HAVE_CONSOLE
-    new Console(&executor, Console::FD_STDIN, Console::FD_STDOUT, 2121);
-#endif
     while (1)
     {
         resetblink(1);

--- a/applications/blink_raw/targets/freertos.armv7m.ti-launchpad-tm4c129/Makefile
+++ b/applications/blink_raw/targets/freertos.armv7m.ti-launchpad-tm4c129/Makefile
@@ -32,9 +32,11 @@ BOARD := BOARD_LAUNCHPAD_EK
 endif
 export BOARD
 
-#OPENOCDARGS = -f board/ek-tm4c1294xl.cfg
+OPENOCDARGS = -f board/ek-tm4c1294xl.cfg
 
-OPENOCDARGS = -c 'set TRANSPORT swd' -f interface/xds110.cfg -c 'transport select swd' -c 'set WORKAREASIZE 0x8000' -c 'set CHIPNAME tm4c1294ncpdt' -f target/stellaris.cfg
+#OPENOCDARGS = -c 'set TRANSPORT swd' -f interface/xds110.cfg -c 'transport select swd' -c 'set WORKAREASIZE 0x8000' -c 'set CHIPNAME tm4c1294ncpdt' -f target/stellaris.cfg
+
+#OPENOCDARGS = -f interface/xds110.cfg  -c 'transport select jtag' -c 'set WORKAREASIZE 0x8000' -c 'set CHIPNAME tm4c1294ncpdt' -f target/stellaris.cfg
 
 include $(OPENMRNPATH)/etc/prog.mk
 

--- a/applications/blink_raw/targets/freertos.armv7m.ti-launchpad-tm4c129/Makefile
+++ b/applications/blink_raw/targets/freertos.armv7m.ti-launchpad-tm4c129/Makefile
@@ -32,8 +32,9 @@ BOARD := BOARD_LAUNCHPAD_EK
 endif
 export BOARD
 
-OPENOCDARGS = -f board/ek-tm4c1294xl.cfg
+#OPENOCDARGS = -f board/ek-tm4c1294xl.cfg
 
+OPENOCDARGS = -c 'set TRANSPORT swd' -f interface/xds110.cfg -c 'transport select swd' -c 'set WORKAREASIZE 0x8000' -c 'set CHIPNAME tm4c1294ncpdt' -f target/stellaris.cfg
 
 include $(OPENMRNPATH)/etc/prog.mk
 

--- a/applications/blink_raw/targets/freertos.armv7m.ti-launchpad-tm4c129/Makefile
+++ b/applications/blink_raw/targets/freertos.armv7m.ti-launchpad-tm4c129/Makefile
@@ -34,8 +34,12 @@ export BOARD
 
 OPENOCDARGS = -f board/ek-tm4c1294xl.cfg
 
+# this works for XDS110 with SWD (2 wire)
 #OPENOCDARGS = -c 'set TRANSPORT swd' -f interface/xds110.cfg -c 'transport select swd' -c 'set WORKAREASIZE 0x8000' -c 'set CHIPNAME tm4c1294ncpdt' -f target/stellaris.cfg
 
+#OPENOCDARGS = -f interface/xds110.cfg -c 'set WORKAREASIZE 0x8000' -c 'set CHIPNAME tm4c1294ncpdt' -f target/stellaris.cfg
+
+# this works for XDS110 with JTAG (4 wire)
 #OPENOCDARGS = -f interface/xds110.cfg  -c 'transport select jtag' -c 'set WORKAREASIZE 0x8000' -c 'set CHIPNAME tm4c1294ncpdt' -f target/stellaris.cfg
 
 include $(OPENMRNPATH)/etc/prog.mk

--- a/applications/blink_raw/targets/freertos.armv7m.ti-launchpad-tm4c129/Makefile
+++ b/applications/blink_raw/targets/freertos.armv7m.ti-launchpad-tm4c129/Makefile
@@ -42,7 +42,7 @@ ifeq ($(call find_missing_deps,OPENOCDSCRIPTSPATH OPENOCDPATH),)
 flash: $(EXECUTABLE)$(EXTENTION) $(EXECUTABLE).lst
 	@if ps ax -o comm | grep -q openocd ; then echo openocd already running. quit existing first. ; exit 1 ; fi
 	cp $< last-flashed-$<
-	$(GDB) $< -ex "target remote | $(OPENOCDPATH)/openocd -c \"gdb_port pipe\" --search $(OPENOCDSCRIPTSPATH) $(OPENOCDARGS)" -ex "monitor reset halt" -ex "load" -ex "monitor reset init" -ex "monitor reset run"  -ex "detach" -ex "quit"
+	$(GDB) $< -ex "target remote | $(OPENOCDPATH)/openocd -c \"gdb_port pipe\" --search $(OPENOCDSCRIPTSPATH) $(OPENOCDARGS)" -ex "monitor reset init" -ex "monitor reset run" -ex "load" -ex "monitor reset init" -ex "monitor reset run"  -ex "detach" -ex "quit"
 
 gdb:
 	@if ps ax -o comm | grep -q openocd ; then echo openocd already running. quit existing first. ; exit 1 ; fi

--- a/etc/path.mk
+++ b/etc/path.mk
@@ -553,7 +553,7 @@ SEARCHPATH := \
   /usr/share/openocd/scripts \
 
 
-TRYPATH:=$(call findfirst,target/stellaris_icdi.cfg,$(SEARCHPATH))
+TRYPATH:=$(call findfirst,target/stm32f0x.cfg,$(SEARCHPATH))
 ifneq ($(TRYPATH),)
 OPENOCDSCRIPTSPATH:=$(TRYPATH)
 endif


### PR DESCRIPTION
- Fixes blink_raw application for Tiva 129 by removing the console from blink_raw.
- Adds console the same way to async_blink which is expected to have the higher complexity.
- Fixes flash commands to work with newer openocd releases
- Adds alternative flash commands that work with XDS110
- Fixes search path for openocd scripts to work with newer openocd releases.