### PR TITLE
Allows negative length for EmptyGroup

### DIFF
--- a/src/openlcb/ConfigRenderer.hxx
+++ b/src/openlcb/ConfigRenderer.hxx
@@ -346,19 +346,19 @@ public:
 
     typedef GroupConfigOptions OptionsType;
 
-    constexpr EmptyGroupConfigRenderer(unsigned size)
+    constexpr EmptyGroupConfigRenderer(int size)
         : size_(size)
     {
     }
 
     template <typename... Args> void render_cdi(string *s, Args... args) const
     {
-        *s += StringPrintf("<group offset='%u'/>\n", size_);
+        *s += StringPrintf("<group offset='%d'/>\n", size_);
     }
 
 private:
     /// The number of bytes this group has to skip.
-    unsigned size_;
+    int size_;
 };
 
 /// Helper class for rendering the cdi.xml of groups, segments and the toplevel

--- a/src/openlcb/ConfigRepresentation.cxxtest
+++ b/src/openlcb/ConfigRepresentation.cxxtest
@@ -304,5 +304,32 @@ TEST(Test2GroupTest, Offsets) {
 
 } // namespace test2
 
+namespace test3 {
+
+CDI_GROUP(TestGroup);
+CDI_GROUP_ENTRY(first, Uint8ConfigEntry);
+CDI_GROUP_ENTRY(back, EmptyGroup<-1>);
+CDI_GROUP_ENTRY(second, Uint8ConfigEntry);
+CDI_GROUP_ENTRY(third, Uint16ConfigEntry);
+CDI_GROUP_ENTRY(back2, EmptyGroup<-2>);
+// some comment in here
+CDI_GROUP_ENTRY(fourth, Uint16ConfigEntry);
+CDI_GROUP_ENTRY(back3, EmptyGroup<-2>);
+CDI_GROUP_END();
+
+TEST(Test3GroupTest, NegativeOffsets)
+{
+    TestGroup grp(11);
+    EXPECT_EQ(1u, TestGroup::size());
+    EXPECT_EQ(11u, grp.first().offset());
+    EXPECT_EQ(11u, grp.second().offset());
+    EXPECT_EQ(12u, grp.third().offset());
+    EXPECT_EQ(12u, grp.fourth().offset());
+    EXPECT_EQ(12u, grp.end_offset());
+}
+
+} // namespace test2
+
+
 } // namespace
 } // namespace openlcb

--- a/src/openlcb/ConfigRepresentation.hxx
+++ b/src/openlcb/ConfigRepresentation.hxx
@@ -368,12 +368,12 @@ public:
 /// Defines an empty group with no members, but blocking a certain amount of
 /// space in the rendered configuration.
 ///
-template <unsigned N> class EmptyGroup : public ConfigEntryBase
+template <int N> class EmptyGroup : public ConfigEntryBase
 {
 public:
     using base_type = ConfigEntryBase;
     INHERIT_CONSTEXPR_CONSTRUCTOR(EmptyGroup, base_type)
-    static constexpr unsigned size()
+    static constexpr int size()
     {
         return N;
     }


### PR DESCRIPTION
This enables reverse jumps in the address space.