### PR TITLE
Fix Minor Entry Model Bounded Bug

### DIFF
--- a/src/utils/EntryModel.cxxtest
+++ b/src/utils/EntryModel.cxxtest
@@ -1,0 +1,90 @@
+#include "utils/test_main.hxx"
+#include "utils/EntryModel.hxx"
+
+TEST(EntryModelTest, Create)
+{
+    EntryModel<int64_t, 11> em;
+
+    EXPECT_EQ(0U, em.digits());
+    EXPECT_EQ(0U, em.cursor_index());
+    EXPECT_FALSE(em.has_initial());
+    EXPECT_EQ("", em.parsed(true));
+}
+
+TEST(EntryModelTestBoundedTest, Create)
+{
+    EntryModelBounded<int64_t, 11> em;
+
+    EXPECT_EQ(0U, em.digits());
+    EXPECT_EQ(0U, em.cursor_index());
+    EXPECT_FALSE(em.has_initial());
+    EXPECT_EQ("", em.parsed(true));
+}
+
+TEST(EntryModelTestBoundedTest, InitValue)
+{
+    EntryModelBounded<int64_t, 11> em;
+
+    em.init(2, 10, 24, 1, 28, 0);
+
+    EXPECT_EQ(2U, em.digits());
+    EXPECT_EQ(0U, em.cursor_index());
+    EXPECT_TRUE(em.has_initial());
+    EXPECT_TRUE(em.cursor_visible());
+    EXPECT_EQ("24", em.parsed());
+
+    em.putc_inc('2');
+    EXPECT_EQ(2U, em.digits());
+    EXPECT_EQ(1U, em.cursor_index());
+    EXPECT_FALSE(em.has_initial());
+    EXPECT_TRUE(em.cursor_visible());
+    EXPECT_EQ("2", em.parsed());
+
+    em.putc_inc('2');
+    EXPECT_EQ(2U, em.digits());
+    EXPECT_EQ(2U, em.cursor_index());
+    EXPECT_FALSE(em.has_initial());
+    EXPECT_FALSE(em.cursor_visible());
+    EXPECT_EQ("22", em.parsed());
+
+    em.putc_inc('2');
+    EXPECT_EQ(2U, em.digits());
+    EXPECT_EQ(0U, em.cursor_index());
+    EXPECT_FALSE(em.has_initial());
+    EXPECT_TRUE(em.cursor_visible());
+    EXPECT_EQ("", em.parsed());
+}
+
+TEST(EntryModelTestBoundedTest, InitValueMoreThanMaxDigits)
+{
+    EntryModelBounded<int64_t, 11> em;
+
+    em.init(2, 10, 240, 1, 28, 0);
+
+    EXPECT_EQ(2U, em.digits());
+    EXPECT_EQ(0U, em.cursor_index());
+    EXPECT_TRUE(em.has_initial());
+    EXPECT_TRUE(em.cursor_visible());
+    EXPECT_EQ("240", em.parsed());
+
+    em.putc_inc('2');
+    EXPECT_EQ(2U, em.digits());
+    EXPECT_EQ(1U, em.cursor_index());
+    EXPECT_FALSE(em.has_initial());
+    EXPECT_TRUE(em.cursor_visible());
+    EXPECT_EQ("2", em.parsed());
+
+    em.putc_inc('2');
+    EXPECT_EQ(2U, em.digits());
+    EXPECT_EQ(2U, em.cursor_index());
+    EXPECT_FALSE(em.has_initial());
+    EXPECT_FALSE(em.cursor_visible());
+    EXPECT_EQ("22", em.parsed());
+
+    em.putc_inc('2');
+    EXPECT_EQ(2U, em.digits());
+    EXPECT_EQ(0U, em.cursor_index());
+    EXPECT_FALSE(em.has_initial());
+    EXPECT_TRUE(em.cursor_visible());
+    EXPECT_EQ("", em.parsed());
+}

--- a/src/utils/EntryModel.hxx
+++ b/src/utils/EntryModel.hxx
@@ -407,14 +407,18 @@ private:
     /// Clamp the value at the min or max.
     void clamp()
     {
-        volatile T value = EntryModel<T, N>::get_value();
-        if (value < min_)
+        if (EntryModel<T, N>::cursor_index() != 0 &&
+            !EntryModel<T, N>::has_initial())
         {
-            EntryModel<T, N>::set_value(min_);
-        }
-        else if (value > max_)
-        {
-            EntryModel<T, N>::set_value(max_);
+            volatile T value = EntryModel<T, N>::get_value();
+            if (value < min_)
+            {
+                EntryModel<T, N>::set_value(min_);
+            }
+            else if (value > max_)
+            {
+                EntryModel<T, N>::set_value(max_);
+            }
         }
     }
 


### PR DESCRIPTION
This issue occurs when using EntryModel::putc_inc(). Once wrapping around pas the "max digits", the entry value should be blank. However, the clamping was not handling the wrap around case and setting the value to min or max rather than leaving it blank or "empty".