### PR TITLE
Fix the order in which libraries are linked when building tests.

### DIFF
--- a/etc/core_test.mk
+++ b/etc/core_test.mk
@@ -44,7 +44,7 @@ $(LIBDIR)/timestamp: $(BUILDDIRS)
 
 $(info test deps $(TESTOBJSEXTRA) $(LIBDIR)/timestamp )
 $(TESTBINS): %.test$(EXTENTION) : %.test.o $(TESTOBJSEXTRA) $(LIBDIR)/timestamp lib/timestamp $(TESTLIBDEPS) $(TESTEXTRADEPS) | $(BUILDDIRS)
-	$(LD) -o $@ $(LDFLAGS) -los  $< $(TESTOBJSEXTRA) $(STARTGROUP) $(LINKCORELIBS) $(ENDGROUP) $(SYSLIBRARIES) 
+	$(LD) -o $@ $(LDFLAGS) -los  $< $(TESTOBJSEXTRA) $(LIBS) $(STARTGROUP) $(LINKCORELIBS) $(ENDGROUP) $(SYSLIBRARIES) 
 
 -include $(TESTOBJS:.test.o=.dtest)
 -include $(TESTOBJSEXTRA:.o=.d)

--- a/etc/prog.mk
+++ b/etc/prog.mk
@@ -307,9 +307,8 @@ SRCDIR=$(abspath ../../)
 #old code from prog.mk
 #$(TEST_EXTRA_OBJS) $(OBJEXTRA) $(LDFLAGS)  $(LIBS) $(SYSLIBRARIES)
 #new code in core_test.mk
-#$(LDFLAGS) -los  $< $(TESTOBJSEXTRA) $(LINKCORELIBS) $(SYSLIBRARIES) 
+#$(LDFLAGS) -los  $< $(TESTOBJSEXTRA) $(LIBS) $(LINKCORELIBS) $(SYSLIBRARIES) 
 #TESTOBJSEXTRA += $(TEST_EXTRA_OBJS)
-SYSLIBRARIES += $(LIBS)
 TESTEXTRADEPS += lib/timestamp
 include $(OPENMRNPATH)/etc/core_test.mk
 


### PR DESCRIPTION
Previously we had the order of {core libs} {sys libs} {app libs}
This had a problem when an app lib was relying on something from a sys library; for example an
app lib using MDNS that is provided by the syslib avahi-client.

Now the order is {app libs} {core libs} {syslibs}.