### PR TITLE
Fixes compilation problems with GCC-10.3 (armgcc-2021-10)

### DIFF
--- a/src/freertos_drivers/common/EEPROMEmulation.hxx
+++ b/src/freertos_drivers/common/EEPROMEmulation.hxx
@@ -153,6 +153,9 @@ protected:
     /** block size in bytes */
     static const size_t BLOCK_SIZE;
 
+    /** Maximum byte size of a single block. */
+    static constexpr unsigned MAX_BLOCK_SIZE = 16;
+
 private:
     /** This function will be called after every write. The default
      * implementation is a weak symbol with an empty function. It is intended

--- a/targets/freertos.armv7m/freertos_drivers/tivadriverlib/Makefile
+++ b/targets/freertos.armv7m/freertos_drivers/tivadriverlib/Makefile
@@ -7,3 +7,4 @@ CFLAGS += -Dcodered
 
 include $(OPENMRNPATH)/etc/lib.mk
 
+emac.o : CFLAGS += -Wno-address-of-packed-member


### PR DESCRIPTION
- new GCC does not like variable arrays on the stack where the size of the array is not known.
  For EEPROMEMu we define a constant maximum byte size of these arrays.
- There is a warning emitted for the tivaware source code, this is disabled with a targeted flag change.