### PR TITLE
Adds binary release script.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,4 +57,4 @@ release-bin:
 	rm -rf $(RELDIR)/*
 	mkdir -p $(RELDIR)
 	+$(MAKE) -C . release-bin-all
-	cd $(RELDIR); zip -9r ../release-$(RELNAME).zip .
+	cd $(RELDIR); zip -9r ../applications.$(RELNAME).zip .

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ release-clean:
 
 RELNAME=$(shell uname -sm | tr ' A-Z' '.a-z')
 RELDIR=$(OPENMRNPATH)/bin/release/staging-$(RELNAME)
+JSRELDIR=$(OPENMRNPATH)/bin/release/staging-js
 
 include $(OPENMRNPATH)/etc/release.mk
 
@@ -53,8 +54,21 @@ $(call RELEASE_BIN_template,memconfig_utils,applications/memconfig_utils/targets
 $(call RELEASE_BIN_template,bootloader_client,applications/bootloader_client/targets/linux.x86)
 $(call RELEASE_BIN_template,send_datagram,applications/send_datagram/targets/linux.x86)
 
+$(call RELEASE_JS_template,openmrn-bootloader-client,applications/bootloader_client/targets/js.emscripten)
+$(call RELEASE_JS_template,openmrn-hub,applications/js_hub/targets/js.emscripten)
+
 release-bin:
 	rm -rf $(RELDIR)/*
 	mkdir -p $(RELDIR)
 	+$(MAKE) -C . release-bin-all
-	cd $(RELDIR); zip -9r ../applications.$(RELNAME).zip .
+	cp LICENSE.md $(RELDIR)/LICENSE.txt
+	cd $(RELDIR); zip -9r ../applications.$(RELNAME).zip . 
+
+release-js:
+	rm -rf $(JSRELDIR)/*
+	mkdir -p $(JSRELDIR)
+	+$(MAKE) -C . release-js-all
+	cp LICENSE.md $(JSRELDIR)/win/LICENSE.txt
+	cp LICENSE.md $(JSRELDIR)/macos/LICENSE.txt
+	cd $(JSRELDIR)/win; zip -9r ../../applications.win.zip .
+	cd $(JSRELDIR)/macos; zip -9r ../../applications.macos.zip .

--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,23 @@ js-tests:
 	$(MAKE) -C targets/js.emscripten run-tests
 
 alltests: tests llvm-tests
+
+release-clean:
+	$(MAKE) -C targets/linux.x86 clean
+
+RELNAME=$(shell uname -sm | tr ' A-Z' '.a-z')
+RELDIR=$(OPENMRNPATH)/bin/release/staging-$(RELNAME)
+
+include $(OPENMRNPATH)/etc/release.mk
+
+# These are the applications that are packaged into the binary release.
+$(call RELEASE_BIN_template,hub,applications/hub/targets/linux.x86)
+$(call RELEASE_BIN_template,memconfig_utils,applications/memconfig_utils/targets/linux.x86)
+$(call RELEASE_BIN_template,bootloader_client,applications/bootloader_client/targets/linux.x86)
+$(call RELEASE_BIN_template,send_datagram,applications/send_datagram/targets/linux.x86)
+
+release-bin:
+	rm -rf $(RELDIR)/*
+	mkdir -p $(RELDIR)
+	+$(MAKE) -C . release-bin-all
+	cd $(RELDIR); zip -9r ../release-$(RELNAME).zip .

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,6 +34,20 @@ The following is out of scope of this documentation:
   
   `sudo npm install -g pkg`
   
+## Release numbering
+
+Release numbers are marked as major.minor.patch, such as `v2.10.1`.
+
+- Major release numbers are incremented once per year (2020 is 0, 2021 is 1,
+  2022 is 2, ...).
+
+- Minor release numbers are 10, 20, 30, 40 for given quarters, then incremented
+  by one if there are multiple releases built within a quarter.
+
+- Patch release numbers start at 1, and are only incremented if the same
+  release needs to be re-built with a patch.
+
+  
 ## How to build
 
 All of the make commands here need to be run in the openmrn directory

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,71 @@
+# Release process
+
+This document details how releases need to be built and published for OpenMRN.
+
+## Purpose and content of releases
+
+Releases fulfill two purposes:
+
+- Precompiled binaries are made available for download. This is important for
+  those that do not have facilities or the experience to compile OpenMRN
+  applications from source.
+  
+- (At a later point) a packaged library is made available with include headers
+  and `*.a` files that enable importing OpenMRN into a different compilation
+  environment, such as various IDEs for embedded development.
+  
+The following is out of scope of this documentation:
+
+- Releases for OpenMRNLite (Arduino compatible library) are documented in the
+  [arduino/RELEASE.md](arduino/RELEASE.md) file.
+
+## Requirements for building releases
+
+- You need to be able to compile OpenMRN binaries. You need a linux host (or
+  VM). The necessary packages have to be installed:
+  
+  - beyond standard `g++` you will need `sudo apt-get install
+    libavahi-client-dev`
+    
+- You need both a linux.x86_64 and a raspberry pi host.
+
+- On the linux host you should install node.js, npm, emscripten, and the
+  packager:
+  
+  `sudo npm install -g pkg`
+  
+## How to build
+
+All of the make commands here need to be run in the openmrn directory
+(toplevel).
+
+1. Start with a clean checkout. Run `make release-clean`.
+
+2. On the linux.x86_64 host, run
+
+   `make -j5 release-bin`
+   
+3. Copy `openmrn/bin/release/applications.linux.x86_64.zip` as one of the
+   artifacts.
+   
+3. On the raspberry pi host, do the same:
+
+   `make release-clean`
+   
+   `make -j4 release-bin`
+   
+4. Copy `openmrn/bin/release/applications.linux.armv7l.zip` as one of the
+   artifacts. Rename it to `applications.linux.armv7l-raspberry-pi.zip`
+   
+5. On the linux.x86_64 host, build the javascript binaries. Run
+   
+   `make -j5 release-js`
+   
+6. Copy `openmrn/bin/release/applications.win.zip` and
+   `openmrn/bin/release/applications.macos.zip`.
+   
+7. On the OpenMRN GitHub project, select Releases, create a new release, select
+   create a new tag in the form of `release-v2.10.1`. Upload the release
+   artifacts that you collected.
+   
+8. Publish the release.

--- a/applications/js_hub/targets/js.emscripten/Makefile
+++ b/applications/js_hub/targets/js.emscripten/Makefile
@@ -1,3 +1,15 @@
 -include ../../config.mk
 include $(OPENMRNPATH)/etc/prog.mk
-LDFLAGS += --bind -s DEMANGLE_SUPPORT=1
+LDFLAGS += --bind -s DEMANGLE_SUPPORT=1 -s WASM=0
+
+# How to prepare for releasing this:
+# as administrator do
+# npm install -g pkg
+# then you can call make release
+release:
+	pkg -C Brotli .
+
+clean: clean-wasm
+
+clean-wasm:
+	rm -f $(EXECUTABLE).{wasm,wast}

--- a/applications/js_hub/targets/js.emscripten/package.json
+++ b/applications/js_hub/targets/js.emscripten/package.json
@@ -1,9 +1,15 @@
 {
-  "name": "openmrn-js-hub",
+  "name": "openmrn-hub",
   "version": "0.9.1",
   "dependencies": {
     "websocket": "*",
     "ecstatic": "*",
     "serialport": "*"
+  },
+  "bin": "js_hub.js",
+  "pkg": {
+      "assets": [
+          "./node_modules/@serialport/bindings/build/Release/bindings.node"
+      ]
   }
 }

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,1 +1,2 @@
 !pic32_change_lma.exe
+release

--- a/etc/release.mk
+++ b/etc/release.mk
@@ -1,0 +1,29 @@
+# Helper makefile for building releases of OpenMRN.
+
+
+### Call this template for each binary application that should be built for a
+### release. The call site should be in the toplevel makefile.
+###
+### Arguments: app-name target-path
+###
+### example: $(call RELEASE_BIN_template,hub,applications/hub/targets/linux.x86)
+define RELEASE_BIN_template_helper
+
+release-bin-all: $(RELDIR)/$(1)
+
+$(RELDIR)/$(1): $(2)/$(1)
+	strip -o $$@ $$<
+
+$(2)/$(1):
+	$(MAKE) -C $(2)
+
+release-clean: release-clean-$(1)
+
+release-clean-$(1):
+	$(MAKE) -C $(2) clean rclean
+
+endef
+
+define RELEASE_BIN_template
+$(eval $(call RELEASE_BIN_template_helper,$(1),$(2)))
+endef

--- a/etc/release.mk
+++ b/etc/release.mk
@@ -27,3 +27,37 @@ endef
 define RELEASE_BIN_template
 $(eval $(call RELEASE_BIN_template_helper,$(1),$(2)))
 endef
+
+
+### Call this template for each JS application that should be built for a
+### release. The call site should be in the toplevel makefile.
+###
+### Arguments: app-name target-path
+###
+### example: $(call RELEASE_JS_template,openmrn-bootloader-client,applications/bootloader_client/targets/js.emscripten)
+define RELEASE_JS_template_helper
+
+release-js-all: $(JSRELDIR)/win/$(1)-win.exe
+
+$(JSRELDIR)/win/$(1)-win.exe: $(2)/$(1)-win.exe
+	mkdir -p $(JSRELDIR)/win $(JSRELDIR)/macos
+	cp $(2)/$(1)-win.exe $(JSRELDIR)/win/$(1)-win.exe
+	cp $(2)/$(1)-macos $(JSRELDIR)/macos/$(1)-macos
+
+$(2)/$(1)-win.exe:
+	+$(MAKE) -C $(2)
+	+$(MAKE) -C $(2) release
+
+release-clean: release-clean-$(1)
+
+release-clean-$(1):
+	$(MAKE) -C $(2) clean rclean
+	rm -rf $(2)/$(1)-win.exe $(2)/$(1)-macos $(2)/$(1)-linux
+
+endef
+
+define RELEASE_JS_template
+$(eval $(call RELEASE_JS_template_helper,$(1),$(2)))
+endef
+
+


### PR DESCRIPTION
Adds script (in the makefile) to compile a binary release for OpenMRN.
The binary release contains the standalone applications that are useful
outside of OpenMRN. Currently this list is as follows:
- hub
- bootloader_client
- memconfig_utils
- send_datagram

The binary release script compiles these applications using the host g++ compiler, and packages it as a zip file.

Also added is a release-js script which compiles two applications using node.js package for win.exe and macos binaries.
These are:
- js_hub
- bootloader_client