### PR TITLE
Fixes sequence problem when more than one CDI file gets rendered.

### DIFF
--- a/src/openlcb/CompileCdiMain.cxx
+++ b/src/openlcb/CompileCdiMain.cxx
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
 )");
     }
 
-    render_all_cdi<10>();
+    render_all_cdi<20>();
     /*    render_all_cdi<9>();
         render_all_cdi<8>();
         render_all_cdi<7>();

--- a/src/openlcb/CompileCdiMain.cxx
+++ b/src/openlcb/CompileCdiMain.cxx
@@ -63,16 +63,8 @@ int main(int argc, char *argv[])
 )");
     }
 
+    // Internally calls all smaller numbered instances all the way down to 1.
     render_all_cdi<20>();
-    /*    render_all_cdi<9>();
-        render_all_cdi<8>();
-        render_all_cdi<7>();
-        render_all_cdi<6>();
-        render_all_cdi<5>();
-        render_all_cdi<4>();
-        render_all_cdi<3>();
-        render_all_cdi<2>();
-        render_all_cdi<1>();*/
 
     std::vector<unsigned> event_offsets;
     openlcb::ConfigDef def(0);

--- a/src/openlcb/ConfigRepresentation.hxx
+++ b/src/openlcb/ConfigRepresentation.hxx
@@ -502,11 +502,11 @@ template <> inline void render_all_cdi<0>()
  * @param N is a unique integer between 2 and 10 for the invocation.
  */
 #define RENDER_CDI(NS, TYPE, NAME, N)                                          \
-    template <> inline void render_all_cdi<N>()                                \
+    template <> inline void render_all_cdi<2 * N>()                            \
     {                                                                          \
         NS::TYPE def(0);                                                       \
         render_cdi_helper(def, #NS, NAME);                                     \
-        render_all_cdi<N - 1>();                                               \
+        render_all_cdi<2 * N - 1>();                                           \
     }
 
 #endif // _OPENLCB_CONFIGREPRESENTATION_HXX_


### PR DESCRIPTION
Due to specific rules on partial template specializations, the C++ compiler would emit an error
depending on which order the RENDER_CDI invocatoins were listed in the source file
of config.hxx, incliuding being sensitive to different order of #include lines.

This is fixed by allowing only every second integer to be partially specialized.

No change in the application sources is needed.