### PR TITLE
Switches GcPacketPrinter to use stderr.

### DIFF
--- a/src/utils/GridConnectHub.cxx
+++ b/src/utils/GridConnectHub.cxx
@@ -357,15 +357,15 @@ struct GcPacketPrinter::Impl : public CanHubPortInterface
             gettimeofday(&tv, nullptr);
             struct tm t;
             localtime_r(&tv.tv_sec, &t);
-            printf("%04d-%02d-%02d %02d:%02d:%02d:%06ld [%p] ",
+            fprintf(stderr, "%04d-%02d-%02d %02d:%02d:%02d:%06ld [%p] ",
                 t.tm_year + 1900, t.tm_mon + 1, t.tm_mday, t.tm_hour, t.tm_min,
                 t.tm_sec, (long)tv.tv_usec, message->data()->skipMember_);
 #endif
         }
-        printf("%s", str);
+        fprintf(stderr, "%s", str);
         if (config_gc_generate_newlines() != 1)
         {
-            printf("\n");
+            fprintf(stderr, "\n");
         }
     }
 


### PR DESCRIPTION
This object is used by the hub under linux to print the packets.
Unfortunately stdout is running in buffered mode typically, which makes it impossible
to run hub processes in the background and still get a log of data.