### PR TITLE
Fixes Tiva GPIO and build.

### DIFF
--- a/src/freertos_drivers/sources
+++ b/src/freertos_drivers/sources
@@ -69,7 +69,12 @@ CXXSRCS += c++_operators.cxx
 endif
 
 ifeq ($(TARGET),bare.armv7m)
-SUBDIRS += cc32xxsdk ti_grlib stm32cubel431xx stm32cubel432xx 
+SUBDIRS += cc32xxsdk ti_grlib stm32cubel431xx stm32cubel432xx
+
+ifdef BUILDTIVAWARE
+SUBDIRS += tivadriverlib tivausblib
+endif
+
 endif
 
 ifeq ($(TARGET),bare.armv6m)


### PR DESCRIPTION
The TivaGPIO implementation was missing a volatile qualification
on the input read function.

- Refactors the three similar GPIO classes to remove duplicate code.
- Adds necessary volatile qualification using the standard TivaWare syntax.

Misc:
- Fixes a build problem when using tivaware in bare.armv7m target.