### PR TITLE
Updates the CAN bit timing parameters of the TivaCAN driver.

### DIFF
--- a/src/freertos_drivers/ti/TivaCan.cxx
+++ b/src/freertos_drivers/ti/TivaCan.cxx
@@ -104,7 +104,7 @@ TivaCan::TivaCan(const char *name, unsigned long base, uint32_t interrupt)
         .ui32SJW = 4,
         .ui32QuantumPrescaler = cm3_cpu_clock_hz / ftq
     };
-    MAP_CANBitTimingSet(CAN0_BASE, &clk_params);
+    MAP_CANBitTimingSet(base, &clk_params);
     MAP_CANIntEnable(base, CAN_INT_MASTER | CAN_INT_ERROR | CAN_INT_STATUS);
 
     tCANMsgObject can_message;


### PR DESCRIPTION
This takes over the recommended parameters from the OpenLCB documentation:
16 TQ, 7 PropSeg, 4 Phase1, 4Phase2, 4SJW.
This allows for 0.98% clock tolerance.