### PR TITLE
Fixes bug in FlashFile O_TRUNC handling.

### DIFF
--- a/src/freertos_drivers/common/FlashFile.hxx
+++ b/src/freertos_drivers/common/FlashFile.hxx
@@ -82,7 +82,7 @@ public:
     /// Overrides behavior of open for O_TRUNC.
     int open(File *file, const char *path, int flags, int mode) override
     {
-        if ((mode & O_WRONLY) && (flags & O_TRUNC))
+        if (flags & O_TRUNC)
         {
             // erase entire file.
             flash_->erase(flashStart_, size_);

--- a/src/freertos_drivers/common/FlashFile.hxx
+++ b/src/freertos_drivers/common/FlashFile.hxx
@@ -82,7 +82,7 @@ public:
     /// Overrides behavior of open for O_TRUNC.
     int open(File *file, const char *path, int flags, int mode) override
     {
-        if (flags & O_TRUNC)
+        if ((flags & O_TRUNC) && ((flags & O_ACCMODE) != O_RDONLY))
         {
             // erase entire file.
             flash_->erase(flashStart_, size_);


### PR DESCRIPTION
There was a bug in how we interpreted the O_TRUNC in FlashFile::open. We were looking for O_WRONLY in the mode bits but O_WRONLY is actually part of the flags bits.