### PR TITLE
Simplifies traction node OpenLCB addresses for DCC locomotives.

### DIFF
--- a/src/openlcb/TractionConsist.cxxtest
+++ b/src/openlcb/TractionConsist.cxxtest
@@ -7,12 +7,12 @@
 namespace openlcb
 {
 
-static constexpr NodeID nodeIdLead = 0x060100000000 | 1370;
-static constexpr NodeID nodeIdC1 = 0x060100000000 | 1371;
-static constexpr NodeID nodeIdC2 = 0x060100000000 | 1372;
-static constexpr NodeID nodeIdC3 = 0x060100000000 | 1373;
-static constexpr NodeID nodeIdC4 = 0x060100000000 | 1374;
-static constexpr NodeID nodeIdC5 = 0x060100000000 | 1375;
+static constexpr NodeID nodeIdLead = 0x06010000C000 | 1370;
+static constexpr NodeID nodeIdC1 = 0x06010000C000 | 1371;
+static constexpr NodeID nodeIdC2 = 0x06010000C000 | 1372;
+static constexpr NodeID nodeIdC3 = 0x06010000C000 | 1373;
+static constexpr NodeID nodeIdC4 = 0x06010000C000 | 1374;
+static constexpr NodeID nodeIdC5 = 0x06010000C000 | 1375;
 
 class TrainNodeWithMockPolicy : public TrainNodeForProxy
 {

--- a/src/openlcb/TractionCvSpace.cxx
+++ b/src/openlcb/TractionCvSpace.cxx
@@ -282,7 +282,7 @@ StateFlowBase::Action TractionCvSpace::fill_read1_packet()
      * between long and short addresses */
     if (dccAddress_ >= 0x80)
     {
-        b->data()->add_dcc_address(dcc::DccLongAddress(dccAddress_));
+        b->data()->add_dcc_address(dcc::DccLongAddress(dccAddress_ & 0x3FFF));
     }
     else
     {
@@ -389,7 +389,7 @@ StateFlowBase::Action TractionCvSpace::fill_write1_packet()
      * between long and short addresses */
     if (dccAddress_ >= 0x80)
     {
-        b->data()->add_dcc_address(dcc::DccLongAddress(dccAddress_));
+        b->data()->add_dcc_address(dcc::DccLongAddress(dccAddress_ & 0x3FFF));
     }
     else
     {

--- a/src/openlcb/TractionCvSpace.cxxtest
+++ b/src/openlcb/TractionCvSpace.cxxtest
@@ -20,9 +20,9 @@ protected:
     TractionCvTestBase()
     {
         run_x([this]() {
-            ifCan_->local_aliases()->add(0x0601000000AFULL, 0x272U);
+            ifCan_->local_aliases()->add(0x06010000C0AFULL, 0x272U);
         });
-        expect_packet(":X19100272N0601000000AF;");
+        expect_packet(":X19100272N06010000C0AF;");
     }
 
     ~TractionCvTestBase()
@@ -37,7 +37,7 @@ protected:
     enum
     {
         TRAIN_NODE_ALIAS = 0x272,
-        TRAIN_NODE_ID = 0x0601000000AF
+        TRAIN_NODE_ID = 0x06010000C0AF
     };
 
     TractionCvTest()

--- a/src/openlcb/TractionDefs.hxx
+++ b/src/openlcb/TractionDefs.hxx
@@ -77,6 +77,8 @@ struct TractionDefs {
     static const uint64_t NODE_ID_DC_BLOCK = 0x060000000000ULL;
     /// Node ID space allocated for DCC locomotives.
     static const uint64_t NODE_ID_DCC = 0x060100000000ULL;
+    /// Long addresses should OR this selector to {\link NODE_ID_DCC }.
+    static const uint16_t DCC_LONG_SELECTOR = 0xC000;
     /// Node ID space allocated for TMCC protocol.
     static const uint64_t NODE_ID_TMCC = 0x060200000000ULL;
     /// Node ID space allocated for the Marklin-Motorola protocol.
@@ -216,7 +218,7 @@ struct TractionDefs {
             case dcc::TrainAddressType::DCC_SHORT_ADDRESS:
                 return NODE_ID_DCC | addr;
             case dcc::TrainAddressType::DCC_LONG_ADDRESS:
-                return NODE_ID_DCC | 0xC000 | addr;
+                return NODE_ID_DCC | DCC_LONG_SELECTOR | addr;
             case dcc::TrainAddressType::MM:
                 return NODE_ID_MARKLIN_MOTOROLA | addr;
             default:
@@ -242,7 +244,8 @@ struct TractionDefs {
         if ((id & NODE_ID_MASK) == NODE_ID_DCC)
         {
             *addr = (id & 0x3FFF);
-            if (((id & 0xC000) == 0xC000) || (*addr >= 128u))
+            if (((id & DCC_LONG_SELECTOR) == DCC_LONG_SELECTOR) ||
+                (*addr >= 128u))
             {
                 // overlapping long address
                 *type = dcc::TrainAddressType::DCC_LONG_ADDRESS;

--- a/src/openlcb/TractionDefs.hxx
+++ b/src/openlcb/TractionDefs.hxx
@@ -216,14 +216,7 @@ struct TractionDefs {
             case dcc::TrainAddressType::DCC_SHORT_ADDRESS:
                 return NODE_ID_DCC | addr;
             case dcc::TrainAddressType::DCC_LONG_ADDRESS:
-                if (addr < 128)
-                {
-                    return NODE_ID_DCC | 0xC000 | addr;
-                }
-                else
-                {
-                    return NODE_ID_DCC | addr;
-                }
+                return NODE_ID_DCC | 0xC000 | addr;
             case dcc::TrainAddressType::MM:
                 return NODE_ID_MARKLIN_MOTOROLA | addr;
             default:

--- a/src/openlcb/TractionTestTrain.cxxtest
+++ b/src/openlcb/TractionTestTrain.cxxtest
@@ -45,9 +45,9 @@ protected:
     {
         create_allocated_alias();
         // alias reservation
-        expect_packet(":X1070133AN0601000006C4;");
+        expect_packet(":X1070133AN06010000C6C4;");
         // initialized
-        expect_packet(":X1910033AN0601000006C4;");
+        expect_packet(":X1910033AN06010000C6C4;");
         trainNode_.reset(new TrainNodeForProxy(&trainService_, &trainImpl_));
         wait();
     }

--- a/src/openlcb/TractionThrottle.cxxtest
+++ b/src/openlcb/TractionThrottle.cxxtest
@@ -7,7 +7,7 @@
 namespace openlcb
 {
 
-static constexpr NodeID TRAIN_NODE_ID = 0x060100000000 | 1372;
+static constexpr NodeID TRAIN_NODE_ID = 0x06010000C000 | 1372;
 
 class ThrottleTest : public AsyncNodeTest
 {

--- a/src/openlcb/TractionTrain.cxxtest
+++ b/src/openlcb/TractionTrain.cxxtest
@@ -101,9 +101,9 @@ protected:
             .Times(AtLeast(0))
             .WillRepeatedly(Return(dcc::TrainAddressType::DCC_LONG_ADDRESS));
         // alias reservation
-        expect_packet(":X1070133AN060100003456;");
+        expect_packet(":X1070133AN06010000F456;");
         // initialized
-        expect_packet(":X1910033AN060100003456;");
+        expect_packet(":X1910033AN06010000F456;");
         trainNode_.reset(new TrainNodeForProxy(&trainService_, &m1_));
         wait();
     }
@@ -112,7 +112,7 @@ protected:
         wait();
     }
 
-    static const NodeID kTrainNodeID = 0x060100003456U;
+    static const NodeID kTrainNodeID = 0x06010000F456U;
     std::unique_ptr<TrainNode> trainNode_;
 };
 


### PR DESCRIPTION
Currently we have functions that use an encoding that is more complicated than necessary.
The encoding is not fixed in the standard in any way, so it's rather arbitrary what we put here.

After this PR we have the following encoding:
node_id = 0x060100000000 | address | (is_long ? 0xC000 : 0);