### PR TITLE
Adds debug log to the common DccDecoder class.

### DIFF
--- a/src/freertos_drivers/common/SimpleLog.hxx
+++ b/src/freertos_drivers/common/SimpleLog.hxx
@@ -64,24 +64,22 @@ private:
 /// Actual class that keeps 8 log entries of one byte each.
 typedef SimpleLog<uint64_t> LogBuffer;
 
-
 /// Alternative for hundreds of entries.
-template<class T, int N> class LogRing {
+template <class T, int N> class LogRing
+{
 public:
-    void add(T data) {
-        data_[next_] = data;
-        last_ = data_ + next_;
-        if (next_) {
-            --next_;
-        } else {
-            next_ = N-1;
+    void add(T data)
+    {
+        data_[next_++] = data;
+        if (next_ >= N)
+        {
+            next_ = 0;
         }
     }
-    
+
 private:
     T data_[N];
-    unsigned next_{N};
-    T* last_{data_};
+    unsigned next_ {0};
 };
 
 #endif // _FREERTOS_DRIVERS_COMMON_SIMPLELOG_HXX_


### PR DESCRIPTION
Misc fixes:
- Switches LogRing to assign values forward instead of backward.
  It is confusing and unexpected to look at an array in gdb and
  see the values in the wrong order.