### PR TITLE
Fixes nullptr bug in CallableFlow.

### DIFF
--- a/src/executor/CallableFlow.hxx
+++ b/src/executor/CallableFlow.hxx
@@ -65,7 +65,7 @@ protected:
     
     /// @return the current request we are working on.
     RequestType* request() {
-        return this->message()->data();
+        return this->message() ? this->message()->data() : nullptr;
     }
 
     /// Terminates the flow and returns the request buffer to the caller with


### PR DESCRIPTION
When the flow is idle (no request or request has already been returned)
the request() function should return nullptr, instead of nullptr + 12.