### PR TITLE
Add BroadcastTime Utilities

### DIFF
--- a/src/openlcb/BroadcastTime.cxx
+++ b/src/openlcb/BroadcastTime.cxx
@@ -52,4 +52,28 @@ void BroadcastTime::clear_timezone()
 #endif
 }
 
+extern "C"
+{
+// normally required _GNU_SOURCE
+char *strptime(const char *__restrict, const char *__restrict,
+               struct tm *__restrict);
+}
+
+//
+// BroadcastTimeClient::set_data_year_str
+//
+void BroadcastTime::set_date_year_str(const char *date_year)
+{
+    struct tm tm;
+    if (strptime(date_year, "%b %e, %Y", &tm) != nullptr)
+    {
+        if (tm.tm_year >= (0 - 1900) && tm.tm_year <= (4095 - 1900))
+        {
+            // date valid
+            set_date(tm.tm_mon + 1, tm.tm_mday);
+            set_year(tm.tm_year + 1900);
+        }
+    }
+}
+
 } // namespace openlcb

--- a/src/openlcb/BroadcastTime.cxx
+++ b/src/openlcb/BroadcastTime.cxx
@@ -54,7 +54,7 @@ void BroadcastTime::clear_timezone()
 
 extern "C"
 {
-// normally required _GNU_SOURCE
+// normally requires _GNU_SOURCE
 char *strptime(const char *__restrict, const char *__restrict,
                struct tm *__restrict);
 }

--- a/src/openlcb/BroadcastTime.cxx
+++ b/src/openlcb/BroadcastTime.cxx
@@ -55,8 +55,7 @@ void BroadcastTime::clear_timezone()
 extern "C"
 {
 // normally requires _GNU_SOURCE
-char *strptime(const char *__restrict, const char *__restrict,
-               struct tm *__restrict);
+char *strptime(const char *, const char *, struct tm *);
 }
 
 //

--- a/src/openlcb/BroadcastTime.hxx
+++ b/src/openlcb/BroadcastTime.hxx
@@ -366,6 +366,10 @@ public:
     /// @return true if a time server has been detected, else false
     virtual bool is_server_detected() = 0;
 
+    /// Test if this is a server.
+    /// @return true if a BroadcastTimeServer, else false
+    virtual bool is_server_self() = 0;
+
 protected:
     class SetFlow : public StateFlowBase
     {

--- a/src/openlcb/BroadcastTime.hxx
+++ b/src/openlcb/BroadcastTime.hxx
@@ -155,6 +155,22 @@ public:
         return ::gmtime_r(&now, result);
     }
 
+    /// Get the date (month/day).
+    /// @param month month (1 to 12)
+    /// @param day day of month (1 to 31)
+    /// @return 0 upon success, else -1 on failure
+    int date(int *month, int *day)
+    {
+        struct tm tm;
+        if (gmtime_r(&tm) == nullptr)
+        {
+            return -1;
+        }
+        *month = tm.tm_mon + 1;
+        *day = tm.tm_mday;
+        return 0;
+    }
+
     /// Get the day of the week.
     /// @returns day of the week (0 - 6, Sunday - Saturday) upon success,
     ///          else -1 on failure
@@ -178,6 +194,18 @@ public:
             return -1;
         }
         return tm.tm_yday;
+    }
+
+    /// Get the year.
+    /// @returns year (0 - 4095) upon success, else -1 on failure
+    int year()
+    {
+        struct tm tm;
+        if (gmtime_r(&tm) == nullptr)
+        {
+            return -1;
+        }
+        return tm.tm_year + 1900;
     }
 
     /// Report the clock rate as a 12-bit fixed point number

--- a/src/openlcb/BroadcastTime.hxx
+++ b/src/openlcb/BroadcastTime.hxx
@@ -77,6 +77,10 @@ public:
         new SetFlow(this, SetFlow::Command::SET_YEAR, year);
     }
 
+    /// Set the date and year from a C string.
+    /// @param data_year date and year format in "Mmm dd, yyyy" format
+    void set_date_year_str(const char *date_year);
+
     /// Set Rate. The new rate does not become valid until the update callbacks
     /// are called.
     /// @param rate clock rate ratio as 12 bit sign extended fixed point

--- a/src/openlcb/BroadcastTime.hxx
+++ b/src/openlcb/BroadcastTime.hxx
@@ -51,6 +51,11 @@ class BroadcastTime : public SimpleEventHandler
 public:
     typedef std::vector<std::function<void()>>::size_type UpdateSubscribeHandle;
 
+    /// Destructor.
+    virtual ~BroadcastTime()
+    {
+    }
+
     /// Set the time in seconds since the system Epoch. The new time does not
     /// become valid until the update callbacks are called.
     /// @param hour hour (0 to 23)
@@ -518,10 +523,6 @@ protected:
         time_t time = 0;
         ::gmtime_r(&time, &tm_);
         tm_.tm_isdst = 0;
-    }
-
-    virtual ~BroadcastTime()
-    {
     }
 
     /// Try the possible set event shortcut. This is typically a bypass of the

--- a/src/openlcb/BroadcastTimeAlarm.hxx
+++ b/src/openlcb/BroadcastTimeAlarm.hxx
@@ -165,7 +165,7 @@ protected:
 
 private:
     // Wakeup helper
-    class Wakeup : public Executable
+    class Wakeup : public Executable, protected Atomic
     {
     public:
         /// Constructor.
@@ -179,9 +179,17 @@ private:
         /// Trigger the wakeup to run.
         void trigger()
         {
-            if (!armed)
+            bool add = false;
             {
-                armed = true;
+                AtomicHolder h(this);
+                if (!armed)
+                {
+                    armed = true;
+                    add = true;
+                }
+            }
+            if (add)
+            {
                 alarm_->service()->executor()->add(this);
             }
         }

--- a/src/openlcb/BroadcastTimeAlarm.hxx
+++ b/src/openlcb/BroadcastTimeAlarm.hxx
@@ -172,13 +172,18 @@ private:
         /// @param alarm our parent alarm that we will awaken
         Wakeup(BroadcastTimeAlarm *alarm)
             : alarm_(alarm)
+            , armed(false)
         {
         }
 
         /// Trigger the wakeup to run.
         void trigger()
         {
-            alarm_->service()->executor()->add(this);
+            if (!armed)
+            {
+                armed = true;
+                alarm_->service()->executor()->add(this);
+            }
         }
 
     private:
@@ -186,10 +191,12 @@ private:
         /// on the CPU.
         void run() override
         {
+            armed = false;
             alarm_->wakeup();
         }
 
         BroadcastTimeAlarm *alarm_; ///< our parent alarm we will wakeup
+        bool armed;
     };
 
     /// Setup, or wait to setup alarm.

--- a/src/openlcb/BroadcastTimeClient.hxx
+++ b/src/openlcb/BroadcastTimeClient.hxx
@@ -81,6 +81,13 @@ public:
         return serverDetected_;
     }
 
+    /// Test if this is a server.
+    /// @return true if a BroadcastTimeServer, else false
+    bool is_server_self() override
+    {
+        return false;
+    }
+
     /// Handle requested identification message.
     /// @param entry registry entry for the event range
     /// @param event information about the incoming message

--- a/src/openlcb/BroadcastTimeDefs.cxx
+++ b/src/openlcb/BroadcastTimeDefs.cxx
@@ -37,6 +37,8 @@
 
 #include <string>
 
+#include "utils/format_utils.hxx"
+
 namespace openlcb
 {
 
@@ -87,15 +89,9 @@ std::string BroadcastTimeDefs::rate_quarters_to_string(int16_t rate)
     }
     uint16_t whole = rate >> 2;
     uint16_t frac = rate & 0x3;
-    if (whole >= 100)
-    {
-        result.push_back('0' + (whole / 100));
-    }
-    if (whole >= 10)
-    {
-        result.push_back('0' + ((whole % 100) / 10));
-    }
-    result.push_back('0' + (whole % 10));
+
+    result += integer_to_string(whole);
+
     switch (frac)
     {
         default:

--- a/src/openlcb/BroadcastTimeDefs.cxx
+++ b/src/openlcb/BroadcastTimeDefs.cxx
@@ -37,6 +37,16 @@
 
 #include <string>
 
+namespace openlcb
+{
+
+extern "C"
+{
+// normally requires _GNU_SOURCE
+char *strptime(const char *__restrict, const char *__restrict,
+               struct tm *__restrict);
+}
+
 //
 // BroadcastTimeDefs::time_to_string()
 //
@@ -148,3 +158,4 @@ int16_t BroadcastTimeDefs::string_to_rate_quarters(std::string srate)
     return rate;
 }
 
+} // namespace openlcb

--- a/src/openlcb/BroadcastTimeDefs.cxx
+++ b/src/openlcb/BroadcastTimeDefs.cxx
@@ -1,0 +1,150 @@
+/** @copyright
+ * Copyright (c) 2018, Stuart W. Baker
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file BroadcastTimeDefs.cxx
+ *
+ * Static definitions for implementations of the OpenLCB Broadcast Time
+ * Protocol.
+ *
+ * @author Stuart W. Baker
+ * @date 30 July 2022
+ */
+
+#include "BroadcastTimeDefs.hxx"
+
+#include <string>
+
+//
+// BroadcastTimeDefs::time_to_string()
+//
+std::string BroadcastTimeDefs::time_to_string(int hour, int min)
+{
+    if (hour < 0 || hour > 23)
+    {
+        hour = 0;
+    }
+    if (min < 0 || min > 59)
+    {
+        min = 0;
+    }
+
+    struct tm tm;
+    tm.tm_hour = hour;
+    tm.tm_min = min;
+    char value[6];
+    if (strftime(value, 6, "%R", &tm) != 0)
+    {
+        return value;
+    }
+    else
+    {
+        return "Error";
+    }
+}
+
+//
+// BroadcastTimeDefs::rate_quarters_to_string()
+//
+std::string BroadcastTimeDefs::rate_quarters_to_string(int16_t rate)
+{
+    std::string result;
+    if (rate < 0)
+    {
+        result.push_back('-');
+        rate = -rate;
+    }
+    uint16_t whole = rate >> 2;
+    uint16_t frac = rate & 0x3;
+    if (whole >= 100)
+    {
+        result.push_back('0' + (whole / 100));
+    }
+    if (whole >= 10)
+    {
+        result.push_back('0' + ((whole % 100) / 10));
+    }
+    result.push_back('0' + (whole % 10));
+    switch (frac)
+    {
+        default:
+        case 0:
+            result.append(".00");
+            break;
+        case 1:
+            result.append(".25");
+            break;
+        case 2:
+            result.append(".50");
+            break;
+        case 3:
+            result.append(".75");
+            break;
+    }
+    return result;
+}
+
+//
+// BroadcastTimeDefs::string_to_time()
+//
+bool BroadcastTimeDefs::string_to_time(std::string stime, int *hour, int *min)
+{
+    struct tm tm;
+    if (strptime(stime.c_str(), "%R", &tm) != nullptr)
+    {
+        if (hour)
+        {
+            *hour = tm.tm_hour;
+        }
+        if (min)
+        {
+            *min = tm.tm_min;
+        }
+        return true;
+    }
+    return false;
+}
+
+//
+// BroadcastTimeDefs::string_to_rate_quaraters()
+//
+int16_t BroadcastTimeDefs::string_to_rate_quarters(std::string srate)
+{
+    float rate = std::stof(srate);
+    if (rate < -512)
+    {
+        // set to minimum valid rate
+        rate = -512;
+    }
+    else if (rate > 511.75)
+    {
+        // set to maximum valid rate
+        rate = 511.75;
+    }
+    rate *= 4;
+    rate += rate < 0 ? -0.5 : 0.5;
+    return rate;
+}
+

--- a/src/openlcb/BroadcastTimeDefs.cxx
+++ b/src/openlcb/BroadcastTimeDefs.cxx
@@ -43,8 +43,7 @@ namespace openlcb
 extern "C"
 {
 // normally requires _GNU_SOURCE
-char *strptime(const char *__restrict, const char *__restrict,
-               struct tm *__restrict);
+char *strptime(const char *, const char *, struct tm *);
 }
 
 //
@@ -119,28 +118,30 @@ std::string BroadcastTimeDefs::rate_quarters_to_string(int16_t rate)
 //
 // BroadcastTimeDefs::string_to_time()
 //
-bool BroadcastTimeDefs::string_to_time(std::string stime, int *hour, int *min)
+bool BroadcastTimeDefs::string_to_time(
+    const std::string &stime, int *hour, int *min)
 {
     struct tm tm;
-    if (strptime(stime.c_str(), "%R", &tm) != nullptr)
+    if (strptime(stime.c_str(), "%R", &tm) == nullptr)
     {
-        if (hour)
-        {
-            *hour = tm.tm_hour;
-        }
-        if (min)
-        {
-            *min = tm.tm_min;
-        }
-        return true;
+        return false;
     }
-    return false;
+
+    if (hour)
+    {
+        *hour = tm.tm_hour;
+    }
+    if (min)
+    {
+        *min = tm.tm_min;
+    }
+    return true;
 }
 
 //
 // BroadcastTimeDefs::string_to_rate_quaraters()
 //
-int16_t BroadcastTimeDefs::string_to_rate_quarters(std::string srate)
+int16_t BroadcastTimeDefs::string_to_rate_quarters(const std::string &srate)
 {
     float rate = std::stof(srate);
     if (rate < -512)

--- a/src/openlcb/BroadcastTimeDefs.hxx
+++ b/src/openlcb/BroadcastTimeDefs.hxx
@@ -358,12 +358,12 @@ struct BroadcastTimeDefs
     /// @param hour resulting hour integer (0 to 23)
     /// @param min resulting minute integer (0 to 59)
     /// @return true on success, else false on fault
-    static bool string_to_time(std::string stime, int *hour, int *min);
+    static bool string_to_time(const std::string &stime, int *hour, int *min);
     
     /// Convert a string (float) to rate quarters.
     /// @param srate rate in the form of a string float
     /// @return rate in the form of an int16_t in rate quarters
-    static int16_t string_to_rate_quarters(std::string srate);
+    static int16_t string_to_rate_quarters(const std::string &srate);
 };
 
 }  // namespace openlcb

--- a/src/openlcb/BroadcastTimeDefs.hxx
+++ b/src/openlcb/BroadcastTimeDefs.hxx
@@ -341,6 +341,29 @@ struct BroadcastTimeDefs
         return event_base + RATE_EVENT_BASE_SUFFIX +
                ((r.rate_ & EVENT_RATE_MASK) << EVENT_RATE_SHIFT);
     }
+
+    /// Convert time in integer hours/minutes to a string ("hh:mm").
+    /// @param hour hours in integer form (0 to 23)
+    /// @param min minutes in integer form (0 to 59)
+    /// @return time represented in the form of a string ("hh:mm")
+    static std::string time_to_string(int hour, int min);
+
+    /// Convert rate in integer rate quarters to a string (float).
+    /// @param rate rate in the form of rate quarters
+    /// @return rate represented in the form of a string (float)
+    static std::string rate_quarters_to_string(int16_t rate);
+
+    /// Convert a string (hh:mm) to hour and minute component integers.
+    /// @param stime time in the form of a string
+    /// @param hour resulting hour integer (0 to 23)
+    /// @param min resulting minute integer (0 to 59)
+    /// @return true on success, else false on fault
+    static bool string_to_time(std::string stime, int *hour, int *min);
+    
+    /// Convert a string (float) to rate quarters.
+    /// @param srate rate in the form of a string float
+    /// @return rate in the form of an int16_t in rate quarters
+    static int16_t string_to_rate_quarters(std::string srate);
 };
 
 }  // namespace openlcb

--- a/src/openlcb/BroadcastTimeServer.hxx
+++ b/src/openlcb/BroadcastTimeServer.hxx
@@ -74,6 +74,13 @@ public:
         return true;
     }
 
+    /// Test if this is a server.
+    /// @return true if a BroadcastTimeServer, else false
+    bool is_server_self() override
+    {
+        return true;
+    }
+
 #if defined(GTEST)
     void shutdown();
 

--- a/src/openlcb/ConfigUpdateFlow.hxx
+++ b/src/openlcb/ConfigUpdateFlow.hxx
@@ -91,8 +91,17 @@ public:
     {
         fd_ = fd;
     }
-    bool TEST_is_terminated() {
+    bool TEST_is_terminated()
+    {
         return is_terminated();
+    }
+    bool TEST_get_needs_reboot()
+    {
+        return needsReboot_;
+    }
+    bool TEST_get_needs_reinit()
+    {
+        return needsReInit_;
     }
 #endif // GTEST
 

--- a/src/openlcb/sources
+++ b/src/openlcb/sources
@@ -6,6 +6,7 @@ CXXSRCS += \
            AliasAllocator.cxx \
            AliasCache.cxx \
            BroadcastTime.cxx \
+           BroadcastTimeDefs.cxx \
            BroadcastTimeClient.cxx \
            BroadcastTimeServer.cxx \
            BulkAliasAllocator.cxx \


### PR DESCRIPTION
- adds set_date_year_str to BroadcastTime (base class) to setthe date from an "MMM dd, yyyy" string format.
- adds query functions for year and month+day.
- adds an API call to distinguish generator and consumer.
- fixes bug where double trigger of a wakeup caused a crash
- adds utility function for parsing and rendering time and model clock rate