### PR TITLE
Fixes deterministic crash that's node ID dependent

### DIFF
--- a/src/openlcb/AliasAllocator.cxx
+++ b/src/openlcb/AliasAllocator.cxx
@@ -227,6 +227,10 @@ NodeAlias AliasAllocator::get_new_seed()
     {
         NodeAlias ret = seed_;
         next_seed();
+        if (!ret)
+        {
+            continue;
+        }
         LOG(VERBOSE, "(%p) alias test seed is %03X (next %03X)", this, ret,
             seed_);
         if (if_can()->local_aliases()->lookup(ret))

--- a/src/openlcb/AliasAllocator.cxxtest
+++ b/src/openlcb/AliasAllocator.cxxtest
@@ -5,6 +5,7 @@
 #include "openlcb/BulkAliasAllocator.hxx"
 #include "openlcb/CanDefs.hxx"
 #include "utils/async_if_test_helper.hxx"
+#include "os/FakeClock.hxx"
 
 namespace openlcb
 {
@@ -368,6 +369,50 @@ TEST_F(AsyncAliasAllocatorTest, DifferentGenerated)
     // Makes sure 'other' disappears from the executor before destructing it.
     wait();
 }
+
+TEST_F(AsyncAliasAllocatorTest, SequenceCrash)
+{
+    FakeClock clk;
+    alias_allocator_.~AliasAllocator();
+    NodeID id = 0x050101011415;
+    new (&alias_allocator_) AliasAllocator(id, ifCan_.get());
+    clear_expect(false); // any packet is okay.
+    for (int i = 0; i < 25; i++)
+    {
+        fprintf(stderr, ".");
+        mainBufferPool->alloc(&b_);
+        alias_allocator_.send(b_);
+        wait();
+        clk.advance(MSEC_TO_NSEC(250));
+        wait();
+    }
+    twait();
+}
+
+TEST_F(AsyncAliasAllocatorTest, SequenceCrashLong)
+{
+    FakeClock clk;
+    alias_allocator_.~AliasAllocator();
+    NodeID id = 0x090099DD0002;
+    new (&alias_allocator_) AliasAllocator(id, ifCan_.get());
+    clear_expect(false); // any packet is okay.
+    // This wraps around more than once the entire sequence
+    for (int i = 0; i < 6000; i++)
+    {
+        if (i % 50 == 0)
+        {
+            LOG(INFO, " %d", i);
+        }
+        fprintf(stderr, ".");
+        mainBufferPool->alloc(&b_);
+        alias_allocator_.send(b_);
+        wait();
+        clk.advance(MSEC_TO_NSEC(250));
+        wait();
+    }
+    twait();
+}
+
 
 TEST_F(AsyncAliasAllocatorTest, BulkFew)
 {


### PR DESCRIPTION
We had a deterministic crash in the alias allocator that was triggered based on the exact bit pattern of the NodeID.

This PR fixes the crash, and adds a unit test that verifies that we can successfully allocate a full cycle of 4096 aliases.