### PR TITLE
Allows skipping unneeded event IDs from the factory initialization.

### DIFF
--- a/src/openlcb/ConfigRenderer.hxx
+++ b/src/openlcb/ConfigRenderer.hxx
@@ -51,7 +51,8 @@ struct AtomConfigDefs
     DECLARE_OPTIONALARG(Name, name, const char *, 0, nullptr);
     DECLARE_OPTIONALARG(Description, description, const char *, 1, nullptr);
     DECLARE_OPTIONALARG(MapValues, mapvalues, const char *, 2, nullptr);
-    using Base = OptionalArg<AtomConfigDefs, Name, Description, MapValues>;
+    DECLARE_OPTIONALARG(SkipInit, skip_init, int, 15, 0);
+    using Base = OptionalArg<AtomConfigDefs, Name, Description, MapValues, SkipInit>;
 };
 
 /// Configuration implementation class for CDI Atom elements (strings, events
@@ -68,6 +69,9 @@ public:
     DEFINE_OPTIONALARG(Description, description, const char *);
     /// Represent the value enclosed in the "<map>" tag of the data element.
     DEFINE_OPTIONALARG(MapValues, mapvalues, const char *);
+    /// When set to true, the event initializers will be skipped in this event
+    /// or group.
+    DEFINE_OPTIONALARG(SkipInit, skip_init, int);
 
     void render_cdi(std::string *r) const
     {
@@ -132,7 +136,7 @@ struct NumericConfigDefs : public AtomConfigDefs
     DECLARE_OPTIONALARG(Max, maxvalue, int, 7, INT_MAX);
     DECLARE_OPTIONALARG(Default, defaultvalue, int, 8, INT_MAX);
     using Base = OptionalArg<NumericConfigDefs, Name, Description, MapValues,
-        Min, Max, Default>;
+                             Min, Max, Default, SkipInit>;
 };
 
 /// Definitions for the options for numeric CDI entries.
@@ -152,6 +156,7 @@ public:
     DEFINE_OPTIONALARG(Min, minvalue, int);
     DEFINE_OPTIONALARG(Max, maxvalue, int);
     DEFINE_OPTIONALARG(Default, defaultvalue, int);
+    DEFINE_OPTIONALARG(SkipInit, skip_init, int);
 
     void render_cdi(std::string *r) const
     {
@@ -288,6 +293,11 @@ public:
         {
         }
         };*/
+
+    constexpr int skip_init()
+    {
+        return 0;
+    }
 
     ///
     /// @return true if this group is a toplevel CDI definition and shall only
@@ -461,6 +471,11 @@ public:
     DEFINE_OPTIONALARG(Model, model, const char *);
     DEFINE_OPTIONALARG(HwVersion, hardware_version, const char *);
     DEFINE_OPTIONALARG(SwVersion, software_version, const char *);
+
+    constexpr int skip_init()
+    {
+        return 0;
+    }
 };
 
 /// Helper class for rendering the "<identification>" tag.

--- a/src/openlcb/ConfigRepresentation.cxxtest
+++ b/src/openlcb/ConfigRepresentation.cxxtest
@@ -38,6 +38,8 @@
 #include "os/TempFile.hxx"
 #include "openlcb/EventHandler.hxx"
 
+using ::testing::ElementsAre;
+
 namespace openlcb
 {
 namespace
@@ -105,19 +107,25 @@ TEST(GroupConfig, WithHoles)
     EXPECT_EQ(31u, cfg.last().offset());
 }
 
+using RepHoleTest = RepeatedGroup<HoleTestGroup, 3>;
+
 CDI_GROUP(IoBoardSegment, Segment(MemoryConfigDefs::SPACE_CONFIG),
           Offset(128));
 CDI_GROUP_ENTRY(first, Uint8ConfigEntry);
+CDI_GROUP_ENTRY(ev, EventConfigEntry);
+CDI_GROUP_ENTRY(rgrp, RepHoleTest);
 CDI_GROUP_END();
 
 CDI_GROUP(SecondSegment, Segment(MemoryConfigDefs::SPACE_CONFIG));
 CDI_GROUP_ENTRY(first, Uint8ConfigEntry);
+CDI_GROUP_ENTRY(ev, EventConfigEntry);
+CDI_GROUP_ENTRY(evtwo, EventConfigEntry, SkipInit(true));
 CDI_GROUP_END();
 
 CDI_GROUP(ThirdSegment);
 CDI_GROUP_ENTRY(first, Uint8ConfigEntry);
+CDI_GROUP_ENTRY(ev, EventConfigEntry);
 CDI_GROUP_END();
-
 
 CDI_GROUP(ConfigDef, MainCdi());
 CDI_GROUP_ENTRY(ident, Identification);
@@ -152,6 +160,17 @@ TEST(FullCdi, SegmentOffset)
 
     EXPECT_EQ(142u, def.seg3().first().offset());
     EXPECT_EQ(13, def.seg3_options().segment());
+}
+
+TEST(FullCdi, EventsList)
+{
+    ConfigDef def(0);
+    std::vector<unsigned> event_offsets;
+    def.handle_events([&event_offsets](unsigned o)
+        {
+            event_offsets.push_back(o);
+        });
+    EXPECT_THAT(event_offsets, ElementsAre(129, 143, 161, 179, 1));
 }
 
 TempDir dir;


### PR DESCRIPTION
Implements a heuristic and a manual control to avoid putting unneeded event offsets to the factory initialize event ID list.
- when there is a segment that's not SPACE_CONFIG, all events in that segment will be skipped.
- adds a SkipInit(true) option that can be set to manually force an individual event ID to not be factory initialized.