### PR TITLE
Ensure broadcast time sync

### DIFF
--- a/src/openlcb/BroadcastTime.hxx
+++ b/src/openlcb/BroadcastTime.hxx
@@ -107,6 +107,12 @@ public:
         new SetFlow(this, SetFlow::Command::STOP);
     }
 
+    /// Query the current time.
+    void query()
+    {
+        new SetFlow(this, SetFlow::Command::QUERY);
+    }
+
     /// Get the time as a value of seconds relative to the system epoch.  At the
     /// same time get an atomic matching pair of the rate
     /// @return pair<time in seconds relative to the system epoch, rate>
@@ -416,6 +422,7 @@ protected:
             SET_RATE, ///< set rate request
             START, ///< stop request
             STOP, ///< start request
+            QUERY, ///< issue a query
         };
 
         /// Constructor.
@@ -470,6 +477,10 @@ protected:
                 case STOP:
                     event_id = clock_->event_base() |
                                BroadcastTimeDefs::STOP_EVENT_SUFFIX;
+                    break;
+                case QUERY:
+                    event_id = clock_->event_base() |
+                               BroadcastTimeDefs::QUERY_EVENT_SUFFIX;
                     break;
                 default:
                     // should never get here.

--- a/src/openlcb/BroadcastTimeServer.cxx
+++ b/src/openlcb/BroadcastTimeServer.cxx
@@ -860,6 +860,23 @@ void BroadcastTimeServer::handle_consumer_identified(
     }
 }
 
+/// Called on another node sending ConsumerRangeIdentified. @param event
+/// stores information about the incoming message. Filled: event id, mask
+/// (!= 1), src_node. Not filled: state.  @param registry_entry gives the
+/// registry entry for which the current handler is being called. @param
+/// done must be notified when the processing is done.
+void BroadcastTimeServer::handle_consumer_range_identified(
+    const EventRegistryEntry &registry_entry, EventReport *event,
+    BarrierNotifiable *done)
+{
+    done->notify();
+    if (event->event == eventBase_ && event->mask == 0xFFFF)
+    {
+        // A new time client was identified, send a time sync.
+        sync_->request_sync();
+    }
+}
+
 //
 // BroadcastTimeServer::handle_event_report()
 //

--- a/src/openlcb/BroadcastTimeServer.cxxtest
+++ b/src/openlcb/BroadcastTimeServer.cxxtest
@@ -359,6 +359,29 @@ TEST_F(BroadcastTimeServerTest, Query)
     EXPECT_EQ(server_->day_of_year(), 0);
 };
 
+TEST_F(BroadcastTimeServerTest, DiscoverConsumerRange)
+{
+    FakeClock clk;
+    ::testing::Sequence s1;
+
+    clear_expect(true);
+
+    // sync response
+    expect_packet(":X1954422AN010100000100F001;").InSequence(s1);
+    expect_packet(":X1954422AN0101000001004000;").InSequence(s1);
+    expect_packet(":X1954422AN01010000010037B2;").InSequence(s1);
+    expect_packet(":X1954422AN0101000001002101;").InSequence(s1);
+    expect_packet(":X1954422AN0101000001000000;").InSequence(s1);
+
+    send_packet(":X194A4001N010100000100FFFF;"); // consumer range identified
+    wait();
+
+    // time is not setup, clock is not running, expect 0 as default
+    EXPECT_EQ(server_->time(), 0);
+    EXPECT_EQ(server_->day_of_week(), BroadcastTimeDefs::THURSDAY);
+    EXPECT_EQ(server_->day_of_year(), 0);
+}
+
 TEST_F(BroadcastTimeServerTest, StartSetTime)
 {
     FakeClock clk;

--- a/src/openlcb/BroadcastTimeServer.hxx
+++ b/src/openlcb/BroadcastTimeServer.hxx
@@ -164,6 +164,16 @@ private:
                                     EventReport *event,
                                     BarrierNotifiable *done) override;
 
+
+    /// Called on another node sending ConsumerRangeIdentified. @param event
+    /// stores information about the incoming message. Filled: event id, mask
+    /// (!= 1), src_node. Not filled: state.  @param registry_entry gives the
+    /// registry entry for which the current handler is being called. @param
+    /// done must be notified when the processing is done.
+    void handle_consumer_range_identified(
+        const EventRegistryEntry &registry_entry, EventReport *event,
+        BarrierNotifiable *done) override;
+
     /// Handle an incoming event report.
     /// @param entry registry entry for the event range
     /// @param event information about the incoming message


### PR DESCRIPTION
The OpenLCB Broadcast Time Protocol does not require a client to send a query when it starts up. It does however require a client (that tracks the progression of time) to send an event consumer range identified for the whole 16-bit clock ID range. This ensures that when a server sees the event consumer range identified, it sends out a clock sync so that the client can begin tracking the server.

Also on this pull request is a new API to asynchronously request a query event be sent.