### PR TITLE
BroadcastTimeClient Sends Query on Each Identify Events Received from Self

### DIFF
--- a/src/openlcb/BroadcastTimeClient.cxxtest
+++ b/src/openlcb/BroadcastTimeClient.cxxtest
@@ -106,7 +106,7 @@ protected:
         expect_packet(":X195B422AN010100000100F000;");
         expect_packet(":X195B422AN010100000101F000;");
 
-        // expect consumer identify range and producder idenfied query (unknown)
+        // expect consumer identify range and producer identified query (unknown)
         expect_packet(":X194A422AN010100000100FFFF;");
         expect_packet(":X1954722AN010100000100F000;");
 
@@ -120,7 +120,8 @@ protected:
         client2_ = new MockBroadcastTimeClient(
             node_, BroadcastTimeDefs::DEFAULT_REALTIME_CLOCK_ID, true);
 
-        send_packet(":X19970001N;");
+        // identify events addressed
+        send_packet(":X19968001N022A;");
         wait_for_event_thread();
 
         clear_expect(true);

--- a/src/openlcb/BroadcastTimeClient.hxx
+++ b/src/openlcb/BroadcastTimeClient.hxx
@@ -103,6 +103,13 @@ public:
             return;
         }
 
+        if (event->dst_node == node_)
+        {
+            // This is directed at us. We were likely re-initialized, so we
+            // need to query for a new clock server and possibly sync.
+            query();
+        }
+
         if (is_terminated())
         {
             start_flow(STATE(initialize));
@@ -257,24 +264,13 @@ private:
     }
 
     /// Initialize client by sending a time query.
-    /// @return next state is initialize_done
+    /// @return next state is client_update
     Action initialize()
     {
         rolloverPending_ = false;
         rolloverPendingDate_ = false;
         rolloverPendingYear_ = false;
 
-        writer_.WriteAsync(node_, Defs::MTI_EVENT_REPORT, WriteHelper::global(),
-            eventid_to_buffer(eventBase_ |
-                              BroadcastTimeDefs::QUERY_EVENT_SUFFIX),
-            this);
-        return wait_and_call(STATE(initialize_done));
-    }
-
-    /// Initialize finished
-    /// @return next state client_update.
-    Action initialize_done()
-    {
         waiting();
         return wait_and_call(STATE(client_update));
     }
@@ -282,7 +278,7 @@ private:
     /// Notification arrived that we should update our state.
     /// @return next state client_update_commit if an update is to be made,
     ///         else next state client_update_wait if we are expecting more
-    ///         incoming clock set events or producer identifieds
+    ///         incoming clock set events or producer identified
     Action client_update()
     {
         if (immediateUpdate_ || rolloverPending_)


### PR DESCRIPTION
This ensures that every time the node is reinitialized, a new time query gets sent.