### PR TITLE
Adds a hook for the bootloader loop.

### DIFF
--- a/src/openlcb/Bootloader.hxx
+++ b/src/openlcb/Bootloader.hxx
@@ -1041,9 +1041,13 @@ bool bootloader_init() {
 /// Called repeatedly in an infinite loop to run the bootloader.
 ///
 /// @return true if the board has to be rebooted, false if the bootloader
-/// should keep running (i.e. to call again).
+/// should keep running (i.e., to call again).
 bool bootloader_loop()
 {
+#ifdef BOOTLOADER_LOOP_HOOK
+    BOOTLOADER_LOOP_HOOK();
+#endif
+
     {
 #ifdef __linux__
         AtomicHolder h(&g_bootloader_lock);


### PR DESCRIPTION
This hook can be used by applications needing to do periodic processing on the main thread after they called bootloader_entry().