### PR TITLE
Fix compile errors under llvm.

### DIFF
--- a/src/openlcb/ConfigRenderer.hxx
+++ b/src/openlcb/ConfigRenderer.hxx
@@ -294,7 +294,7 @@ public:
         }
         };*/
 
-    constexpr int skip_init()
+    constexpr int skip_init() const
     {
         return 0;
     }
@@ -472,7 +472,7 @@ public:
     DEFINE_OPTIONALARG(HwVersion, hardware_version, const char *);
     DEFINE_OPTIONALARG(SwVersion, software_version, const char *);
 
-    constexpr int skip_init()
+    constexpr int skip_init() const
     {
         return 0;
     }


### PR DESCRIPTION
Fixes errors like this:
```
openmrn/src/openlcb/ConfigRenderer.hxx:475:19: error: 
      'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior
      [-Werror,-Wconstexpr-not-const]
    constexpr int skip_init()
                  ^
                              const
```