### PR TITLE
Fixes constructor of Velocity class.

### DIFF
--- a/src/openlcb/Velocity.cxxtest
+++ b/src/openlcb/Velocity.cxxtest
@@ -89,6 +89,16 @@ TEST(NMRAnetVelocityTest, constructor_float16)
     EXPECT_EQ(velocity->direction(), Velocity::FORWARD);
 }
 
+TEST(NMRAnetVelocityTest, constructor_float16_example)
+{
+    // Example from the Traction Protocol TN.
+    Velocity *velocity = new Velocity((float16_t)0x5640);
+
+    EXPECT_FALSE(*velocity == 0.0f);
+    EXPECT_NEAR(velocity->mph(), 223, 1);
+    EXPECT_EQ(velocity->direction(), Velocity::FORWARD);
+}
+
 TEST(NMRAnetVelocityTest, constructor_copy)
 {
     Velocity *velocity = new Velocity(1.7F);

--- a/src/openlcb/Velocity.hxx
+++ b/src/openlcb/Velocity.hxx
@@ -123,8 +123,9 @@ public:
      * @param value starting value for Velocity as IEEE half precision float.
      */
     Velocity(float16_t value)
-        : velocity(halfp2singles(&velocity, &value, 1))
+        : velocity(0)
     {
+        halfp2singles(&velocity, &value, 1);
     }
 
     /** Copy constructor. */


### PR DESCRIPTION
The constructor that took a float16_t value did not work (ever). 

Adds a unit test to cover the example from the Traction TN, which says that 0x5640 as a float16_t means 100 m/s, which should be 223 mph.