### PR TITLE
Fix nullptr dereference error in CallableFlow and MemoryConfigClient.

### DIFF
--- a/src/dcc/ProgrammingTrackBackend.hxx
+++ b/src/dcc/ProgrammingTrackBackend.hxx
@@ -224,7 +224,7 @@ public:
     /// the short detector.
     void notify_service_mode_ack()
     {
-        if (!request())
+        if (!has_request())
         {
             return;
         }
@@ -242,7 +242,7 @@ public:
     /// Call this function when the service mode current limit is exceeded.
     void notify_service_mode_short()
     {
-        if (!request())
+        if (!has_request())
         {
             return;
         }
@@ -362,7 +362,7 @@ private:
     /// @param packet buffer to fill in with next packet to send.
     void get_next_packet(unsigned code, dcc::Packet *packet) override
     {
-        if (request() == nullptr)
+        if (!has_request())
         {
             packet->set_dcc_reset_all_decoders();
 #ifdef DEBUG_PROGRAMTRACK_BACKEND

--- a/src/executor/CallableFlow.hxx
+++ b/src/executor/CallableFlow.hxx
@@ -63,9 +63,27 @@ public:
 protected:
     using Action = StateFlowBase::Action;
     
-    /// @return the current request we are working on.
-    RequestType* request() {
-        return this->message() ? this->message()->data() : nullptr;
+    /// @return the current request we are working on. This function may be
+    /// called only if there is an active request. If unsure, use
+    /// {\link has_request() } to verify it first.
+    RequestType *request()
+    {
+        if (!this->message())
+        {
+            // This is not an assert macro, because this function gets inlined
+            // into a lot of places, and we want the shortest possible code
+            // size. However, letting this pass into a hard fault due to the
+            // nullptr dereference is extremely hard to debug.
+            abort();
+        }
+        return this->message()->data();
+    }
+
+    /// @return true if there is an active request, i.e., when request() is
+    /// allowed to be called.
+    bool has_request()
+    {
+        return this->message() != nullptr;
     }
 
     /// Terminates the flow and returns the request buffer to the caller with

--- a/src/openlcb/MemoryConfigClient.hxx
+++ b/src/openlcb/MemoryConfigClient.hxx
@@ -661,6 +661,10 @@ private:
     private:
         Action entry() override
         {
+            if (!parent_->has_request())
+            {
+                return respond_reject(Defs::ERROR_OUT_OF_ORDER);
+            }
             if (!parent_->node_->iface()->matching_node(
                     parent_->request()->dst, message()->data()->src))
             {


### PR DESCRIPTION
- Makes a stricter contract around using CallableFlow::request(). This function is mostly used as `request()->fooBar_`, the new contract is that `request()` may be called only there is a non-null currentMessage.
- Aborts the program if this contract is missed to aid in debugging such failures.
- Adds a `has_request()` function to inquire if it's safe to call `request()`. Updates existing checks to use `has_request()`.
- Fixes crash in MemoryConfigClient when a response datagram arrives unexpectedly as a race condition between the main flow and ResponseFlow.