### PR TITLE
SimpleStack Delay Node Initialization

### DIFF
--- a/src/openlcb/DefaultNode.cxx
+++ b/src/openlcb/DefaultNode.cxx
@@ -41,15 +41,26 @@ namespace openlcb
 
 extern void StartInitializationFlow(Node* node);
 
-DefaultNode::DefaultNode(If* iface, NodeID node_id)
+DefaultNode::DefaultNode(If* iface, NodeID node_id, bool init)
     : nodeId_(node_id), isInitialized_(0), iface_(iface)
 {
     iface_->add_local_node(this);
-    StartInitializationFlow(this);
+    if (init)
+    {
+        StartInitializationFlow(this);
+    }
 }
 
 DefaultNode::~DefaultNode()
 {
+}
+
+void DefaultNode::initialize()
+{
+    // Ensures the caller's logic is statefully correct.
+    HASSERT(!isInitialized_);
+
+    StartInitializationFlow(this);
 }
 
 } // namespace openlcb

--- a/src/openlcb/DefaultNode.cxx
+++ b/src/openlcb/DefaultNode.cxx
@@ -39,28 +39,18 @@
 namespace openlcb
 {
 
-extern void StartInitializationFlow(Node* node);
-
 DefaultNode::DefaultNode(If* iface, NodeID node_id, bool init)
     : nodeId_(node_id), isInitialized_(0), iface_(iface)
 {
     iface_->add_local_node(this);
     if (init)
     {
-        StartInitializationFlow(this);
+        initialize();
     }
 }
 
 DefaultNode::~DefaultNode()
 {
-}
-
-void DefaultNode::initialize()
-{
-    // Ensures the caller's logic is statefully correct.
-    HASSERT(!isInitialized_);
-
-    StartInitializationFlow(this);
 }
 
 } // namespace openlcb

--- a/src/openlcb/DefaultNode.hxx
+++ b/src/openlcb/DefaultNode.hxx
@@ -79,9 +79,6 @@ public:
         isInitialized_ = 0;
     }
 
-    /// Initialize the node.
-    void initialize() override;
-    
 private:
     /** 48-bit node identifier of this node. */
     NodeID nodeId_ : 48;

--- a/src/openlcb/DefaultNode.hxx
+++ b/src/openlcb/DefaultNode.hxx
@@ -45,7 +45,13 @@ namespace openlcb
 class DefaultNode: public Node
 {
 public:
-    DefaultNode(If* iface, NodeID node_id);
+    /// Constructor.
+    /// @param iface network interface to be bound to
+    /// @param node_id 48-bit OpenLCB ID of the node
+    /// @param init true to start the initialization flow upon construction
+    DefaultNode(If* iface, NodeID node_id, bool init = true);
+
+    /// Destructor.
     virtual ~DefaultNode();
 
     NodeID node_id() OVERRIDE
@@ -73,6 +79,9 @@ public:
         isInitialized_ = 0;
     }
 
+    /// Initialize the node.
+    void initialize() override;
+    
 private:
     /** 48-bit node identifier of this node. */
     NodeID nodeId_ : 48;

--- a/src/openlcb/Node.cxx
+++ b/src/openlcb/Node.cxx
@@ -26,7 +26,7 @@
  *
  * @file Node.cxx
  *
- * Node definition for asynchronous NMRAnet nodes.
+ * Node definition for asynchronous OpenLCB nodes.
  *
  * @author Stuart Baker
  * @date 28 November 2022

--- a/src/openlcb/Node.cxx
+++ b/src/openlcb/Node.cxx
@@ -1,5 +1,5 @@
-/** \copyright
- * Copyright (c) 2013, Balazs Racz
+/** @copyright
+ * Copyright (c) 2022, Stuart Baker
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,56 +24,27 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * \file Node.hxx
+ * @file Node.cxx
  *
  * Node definition for asynchronous NMRAnet nodes.
  *
- * @author Balazs Racz
- * @date 7 December 2013
+ * @author Stuart Baker
+ * @date 28 November 2022
  */
 
-#ifndef _OPENLCB_NODE_HXX_
-#define _OPENLCB_NODE_HXX_
-
-#include "openlcb/Defs.hxx"  // for NodeID
+#include "openlcb/Node.hxx"
 
 namespace openlcb
 {
 
-class If;
+extern void StartInitializationFlow(Node* node);
 
-/** Base class for NMRAnet nodes conforming to the asynchronous interface.
- *
- * It is important for this interface to contain no data members, since certain
- * implementations might need to be very lightweight (e.g. a command station
- * might have hundreds of train nodes.)
- */
-class Node
+void Node::initialize()
 {
-public:
-    virtual ~Node() {}
-    // @returns the 48-bit NMRAnet node id for this node.
-    virtual NodeID node_id() = 0;
-    // @returns the interface this virtual node is bound to.
-    virtual If* iface() = 0;
-    /** @returns true if the node is in the initialized state.
-     *
-     * Nodes not in initialized state may not send traffic to the bus. */
-    virtual bool is_initialized() = 0;
+    // Ensures the caller's logic is statefully correct.
+    HASSERT(!is_initialized());
 
-    /** Callback from the node initialization flow when the node finished
-     * initialization. Nodes are not required to implement if they are not
-     * using NodeInitializationFlow. */
-    virtual void set_initialized() {}
-
-    /** Callback from the simple stack when the node has to return to
-     * uninitialized state. */
-    virtual void clear_initialized() = 0;
-
-    /** Callback from the simple stack to start the initialization process. */
-    void initialize();
-};
+    StartInitializationFlow(this);
+}
 
 } // namespace openlcb
-
-#endif // _OPENLCB_NODE_HXX_

--- a/src/openlcb/Node.hxx
+++ b/src/openlcb/Node.hxx
@@ -69,6 +69,9 @@ public:
     /** Callback from the simple stack when the node has to return to
      * uninitialized state. */
     virtual void clear_initialized() = 0;
+
+    /** Callback from the simple stack to start the initialization process. */
+    virtual void initialize() {}
 };
 
 } // namespace openlcb

--- a/src/openlcb/SimpleStack.cxx
+++ b/src/openlcb/SimpleStack.cxx
@@ -115,8 +115,7 @@ void SimpleStackBase::start_stack(bool delay_start)
 
     if (!delay_start)
     {
-        start_iface(false);
-        node()->initialize();
+        start_after_delay();
     }
 
     // Adds memory spaces.
@@ -194,7 +193,12 @@ void SimpleTrainCanStack::start_node()
 void SimpleStackBase::start_after_delay()
 {
     start_iface(false);
-    node()->initialize();
+    for (Node *node = iface()->first_local_node();
+         node != nullptr;
+         node = iface()->next_local_node(node->node_id()))
+    {
+        node->initialize();
+    }
 }
 
 void SimpleTcpStackBase::start_iface(bool restart)

--- a/src/openlcb/SimpleStack.cxx
+++ b/src/openlcb/SimpleStack.cxx
@@ -89,13 +89,13 @@ std::unique_ptr<SimpleStackBase::PhysicalIf> SimpleTcpStackBase::create_if(
 
 SimpleCanStack::SimpleCanStack(const openlcb::NodeID node_id)
     : SimpleCanStackBase(node_id)
-    , node_(iface(), node_id)
+    , node_(iface(), node_id, false)
 {
 }
 
 SimpleTcpStack::SimpleTcpStack(const openlcb::NodeID node_id)
     : SimpleTcpStackBase(node_id)
-    , node_(iface(), node_id)
+    , node_(iface(), node_id, false)
 {
 }
 
@@ -116,6 +116,7 @@ void SimpleStackBase::start_stack(bool delay_start)
     if (!delay_start)
     {
         start_iface(false);
+        node()->initialize();
     }
 
     // Adds memory spaces.
@@ -193,6 +194,7 @@ void SimpleTrainCanStack::start_node()
 void SimpleStackBase::start_after_delay()
 {
     start_iface(false);
+    node()->initialize();
 }
 
 void SimpleTcpStackBase::start_iface(bool restart)

--- a/src/openlcb/sources
+++ b/src/openlcb/sources
@@ -27,6 +27,7 @@ CXXSRCS += \
            NodeBrowser.cxx \
            NodeInitializeFlow.cxx \
            NonAuthoritativeEventProducer.cxx \
+           Node.cxx \
            PIPClient.cxx \
            RoutingLogic.cxx \
            TractionDefs.cxx \


### PR DESCRIPTION
This fixes an issue whereby delaying the startup of a SimpleStack based node caused all of the initialization messages to be absent from the physical CAN bus if the CAN interface had not been bound to the node prior to the SimpleStack construction.