### PR TITLE
Fix Bus-Off error handling

### DIFF
--- a/src/freertos_drivers/ti/TivaCan.cxx
+++ b/src/freertos_drivers/ti/TivaCan.cxx
@@ -210,17 +210,15 @@ void TivaCan::interrupt_handler()
             txBuf->flush();
             txPending = false;
             txBuf->signal_condition_from_isr();
+
+            /* attempt recovery */
+            MAP_CANEnable(base);
         }
         if (status & CAN_STATUS_EWARN)
         {
             /* One of the error counters has exceded a value of 96 */
             ++softErrorCount;
             canState = CAN_STATE_BUS_PASSIVE;
-
-            /* flush data in the tx pipeline */
-            txBuf->flush();
-            txPending = false;
-            txBuf->signal_condition_from_isr();
         }
         if (status & CAN_STATUS_EPASS)
         {


### PR DESCRIPTION
- Restarts CAN controller once in Bus-Off state.
- Removes TX flush from EWARN state.