### PR TITLE
Adds stream read support to the memory config handler

### DIFF
--- a/src/openlcb/CanDefs.hxx
+++ b/src/openlcb/CanDefs.hxx
@@ -207,9 +207,17 @@ struct CanDefs {
      */
     static bool is_cid_frame(uint32_t can_id)
     {
-        return ((can_id >> CAN_FRAME_TYPE_SHIFT) & 0x14) == 0x14;
+        return ((can_id >> CAN_FRAME_TYPE_SHIFT) & 0x1C) == 0x14;
     }
 
+    /** Tests if the incoming frame is a stream data send frame.
+     * @param can_id identifier to act upon
+     * @return true for Stream Data frame, false for any other frame.
+     */
+    static bool is_stream_frame(uint32_t can_id)
+    {
+        return ((can_id >> CAN_FRAME_TYPE_SHIFT) & 0xF) == 0xF;
+    }
 
     /** Set the MTI field value of the CAN ID.
      * @param can_id identifier to act upon, passed by reference

--- a/src/openlcb/If.hxx
+++ b/src/openlcb/If.hxx
@@ -383,7 +383,7 @@ private:
     VNodeMap localNodes_;
 
     /// Accessor for the objects and variables for supporting stream transport.
-    StreamTransport* streamTransport_{nullptr};
+    StreamTransport *streamTransport_ {nullptr};
 
     friend class VerifyNodeIdHandler;
 

--- a/src/openlcb/If.hxx
+++ b/src/openlcb/If.hxx
@@ -52,6 +52,7 @@ namespace openlcb
 {
 
 class Node;
+class StreamTransport;
 
 /// Helper function to send an event report to the bus. Performs
 /// synchronous (dynamic) memory allocation so use it sparingly and when
@@ -338,8 +339,27 @@ public:
         txHook_ = std::move(hook);
     }
 
+    /// @return the object supporting stream transport in OpenLCB. May be null
+    /// if stream transport was not initialized for this interface. This is
+    /// typical when a small node is low on flash space for code.
+    StreamTransport *stream_transport()
+    {
+        return streamTransport_;
+    }
+
+    /// Adds the necessary object for this interface to support stream
+    /// transport. May be called only once per interface.
+    /// @param s the stream transport object. Ownership is not transferred. (If
+    /// needed, see add_owned_flow.)
+    void set_stream_transport(StreamTransport *s)
+    {
+        HASSERT(streamTransport_ == nullptr);
+        streamTransport_ = s;
+    }
+
 protected:
-    void remove_local_node_from_map(Node *node) {
+    void remove_local_node_from_map(Node *node)
+    {
         auto it = localNodes_.find(node->node_id());
         HASSERT(it != localNodes_.end());
         localNodes_.erase(it);
@@ -361,6 +381,9 @@ private:
 
     /// Local virtual nodes registered on this interface.
     VNodeMap localNodes_;
+
+    /// Accessor for the objects and variables for supporting stream transport.
+    StreamTransport* streamTransport_{nullptr};
 
     friend class VerifyNodeIdHandler;
 

--- a/src/openlcb/IfCan.cxx
+++ b/src/openlcb/IfCan.cxx
@@ -127,6 +127,17 @@ public:
             // This is not a local alias of ours.
             return exit();
         }
+        if (CanDefs::is_stream_frame(id))
+        {
+            // Checks for localhost stream data payloads. These are ok to see
+            // in the incoming data since they are looped back.
+            NodeAlias dst = CanDefs::get_dst(id);
+            NodeID dnode = dst ? if_can()->local_aliases()->lookup(dst) : 0;
+            if (dnode)
+            {
+                return exit();
+            }
+        }
         if (CanDefs::is_cid_frame(id))
         {
             // This is a CID frame. We own the alias, let them know.

--- a/src/openlcb/MemoryConfig.hxx
+++ b/src/openlcb/MemoryConfig.hxx
@@ -336,19 +336,19 @@ protected:
     MemoryConfigHandlerBase(DatagramService *if_dg)
         : DefaultDatagramHandler(if_dg)
         , responseFlow_(nullptr)
-    { }
+    {
+    }
 
     typedef MemorySpace::address_t address_t;
     typedef MemorySpace::errorcode_t errorcode_t;
     typedef TypedNodeHandlerMap<Node, MemorySpace> Registry;
 
-    
     Action ok_response_sent() OVERRIDE
     {
         if (!response_.empty())
         {
-            return allocate_and_call(STATE(client_allocated),
-                                     dg_service()->client_allocator());
+            return allocate_and_call(
+                STATE(client_allocated), dg_service()->client_allocator());
         }
         else
         {
@@ -367,17 +367,16 @@ protected:
     {
         responseFlow_ =
             full_allocation_result(dg_service()->client_allocator());
-        return allocate_and_call(dg_service()->iface()->dispatcher(),
-                                 STATE(send_response_datagram));
+        return allocate_and_call(
+            dg_service()->iface()->dispatcher(), STATE(send_response_datagram));
     }
 
     Action send_response_datagram()
     {
-        auto *b =
-            get_allocation_result(dg_service()->iface()->dispatcher());
+        auto *b = get_allocation_result(dg_service()->iface()->dispatcher());
         b->set_done(b_.reset(this));
         b->data()->reset(Defs::MTI_DATAGRAM, message()->data()->dst->node_id(),
-                         message()->data()->src, EMPTY_PAYLOAD);
+            message()->data()->src, EMPTY_PAYLOAD);
         b->data()->payload.swap(response_);
         release(); /// @TODO(balazs.racz) Should this be here or elsewhere?
         responseFlow_->write_datagram(b);
@@ -395,7 +394,6 @@ protected:
         dg_service()->client_allocator()->typed_insert(responseFlow_);
         return call_immediately(STATE(cleanup));
     }
-
 
     /// @return true iff we have a custom space
     bool has_custom_space()
@@ -415,13 +413,14 @@ protected:
         if (!has_custom_space())
         {
             return MemoryConfigDefs::COMMAND_MASK +
-                   (cmd & ~MemoryConfigDefs::COMMAND_MASK);
+                (cmd & ~MemoryConfigDefs::COMMAND_MASK);
         }
         if (len <= 6)
         {
-            LOG(WARNING, "MemoryConfig: Incoming datagram asked for custom "
-                         "space but datagram not long enough. command=0x%02x, "
-                         "length=%d. Source {0x%012" PRIx64 ", %03x}",
+            LOG(WARNING,
+                "MemoryConfig: Incoming datagram asked for custom "
+                "space but datagram not long enough. command=0x%02x, "
+                "length=%d. Source {0x%012" PRIx64 ", %03x}",
                 cmd, len, message()->data()->src.id,
                 message()->data()->src.alias);
             return -1;
@@ -448,9 +447,10 @@ protected:
         }
         if (len <= ofs)
         {
-            LOG(WARNING, "MemoryConfig::read_len: Incoming datagram not long "
-                         "enough. command=0x%02x, length=%d. Source "
-                         "{0x%012" PRIx64 ", %03x}",
+            LOG(WARNING,
+                "MemoryConfig::read_len: Incoming datagram not long "
+                "enough. command=0x%02x, length=%d. Source "
+                "{0x%012" PRIx64 ", %03x}",
                 cmd, len, message()->data()->src.id,
                 message()->data()->src.alias);
             return -1;
@@ -1058,13 +1058,12 @@ private:
     DatagramHandlerFlow* client_{nullptr};
     /// If there is a handler for stream requests, we will forward the
     /// respective traffic to it.
-    DatagramHandlerFlow* streamHandler_{nullptr};
+    DatagramHandlerFlow *streamHandler_ {nullptr};
 
     /** Offset withing the current write/read datagram. This does not include
      * the offset from the incoming datagram. */
     uint8_t currentOffset_;
 };
-
 
 } // namespace openlcb
 

--- a/src/openlcb/MemoryConfigDefs.hxx
+++ b/src/openlcb/MemoryConfigDefs.hxx
@@ -68,6 +68,8 @@ struct MemoryConfigDefs
         COMMAND_READ_REPLY        = 0x50, /**< reply to read data from address space */
         COMMAND_READ_FAILED       = 0x58, /**< failed to read data from address space */
         COMMAND_READ_STREAM       = 0x60, /**< command to read data using a stream */
+        COMMAND_READ_STREAM_REPLY = 0x70, /**< reply to read data using a stream */
+        COMMAND_READ_STREAM_FAILED= 0x78, /**< failed to read data using a stream */
         COMMAND_MAX_FOR_RW        = 0x80, /**< command <= this value have fixed bit arrangement. */
         COMMAND_OPTIONS           = 0x80,
         COMMAND_OPTIONS_REPLY     = 0x82,

--- a/src/openlcb/MemoryConfigStream.cxxtest
+++ b/src/openlcb/MemoryConfigStream.cxxtest
@@ -1,20 +1,9 @@
-
 #include "openlcb/MemoryConfigStream.hxx"
 
-#include "utils/async_datagram_test_helper.hxx"
+#include "utils/async_stream_test_helper.hxx"
 
 namespace openlcb
 {
-
-string get_payload_data(size_t length)
-{
-    string r(length, 0);
-    for (size_t i = 0; i < length; ++i)
-    {
-        r[i] = i & 0xff;
-    }
-    return r;
-}
 
 string largePayload {get_payload_data(15000)};
 string smallPayload {get_payload_data(15)};
@@ -40,6 +29,11 @@ protected:
     ~MemoryConfigTest()
     {
         wait();
+    }
+
+    void setup_two_nodes()
+    {
+        
     }
 
     StreamTransportCan t_ {ifCan_.get(), 2};

--- a/src/openlcb/MemoryConfigStream.cxxtest
+++ b/src/openlcb/MemoryConfigStream.cxxtest
@@ -12,7 +12,10 @@ ReadOnlyMemoryBlock largeBlock {
 ReadOnlyMemoryBlock smallBlock {
     smallPayload.data(), (unsigned)smallPayload.size()};
 
-class MemoryConfigTest : public TwoNodeDatagramTest
+/// Stream ID used for the receiver on the second interface.
+static constexpr uint8_t STREAM_DST_ID = 0x43;
+
+class MemoryConfigTest : public StreamTestBase
 {
 protected:
     MemoryConfigTest()
@@ -33,12 +36,54 @@ protected:
 
     void setup_two_nodes()
     {
-        
+        setup_other_node(true);
+        wait();
+        clear_expect(false);
+        run_x([this]() { ifCan_->send_global_alias_enquiry(node_); });
+        otherT_.reset(new StreamTransportCan(otherIfCan_.get(), 1));
+        receiver_.reset(
+            new StreamReceiverCan(otherIfCan_.get(), STREAM_DST_ID));
+        wait();
     }
 
+    /// Sends a datagram from the second node to the first node. The addresses
+    /// are automatically
+    /// @param payload the contents that this datagram should have.
+    void inject_datagram(string payload)
+    {
+        DatagramClient *c =
+            otherNodeDatagram_->client_allocator()->next_blocking();
+        auto *b = ifCan_->dispatcher()->alloc();
+        b->set_done(datagramDoneBn_.reset(EmptyNotifiable::DefaultInstance()));
+        b->data()->reset(Defs::MTI_DATAGRAM, otherNode_->node_id(),
+            first_node(), hex2str(payload.c_str()));
+        c->write_datagram(b);
+    }
+
+    NodeHandle first_node()
+    {
+        return NodeHandle(node_->node_id());
+    }
+
+    void invoke_receiver(uint8_t src_stream_id = StreamDefs::INVALID_STREAM_ID)
+    {
+        recvRequest_->data()->reset(&sink_, otherNode_.get(),
+                                    first_node(), src_stream_id);
+        recvRequest_->data()->done.reset(&sn_);
+        run_x([this]() { receiver_->send(recvRequest_->ref()); });
+    }
+    
     StreamTransportCan t_ {ifCan_.get(), 2};
     MemoryConfigHandler memoryOne_ {&datagram_support_, nullptr, 10};
     MemoryConfigStreamHandler memoryStream_ {&memoryOne_};
+    /// This barrier is used for the outgoing datagram created by
+    /// inject_datagram().
+    BarrierNotifiable datagramDoneBn_;
+    /// Stream support for second interface.
+    std::unique_ptr<StreamTransportCan> otherT_;
+    /// Stream receiver bound to the second interface.
+    std::unique_ptr<StreamReceiverCan> receiver_;
+    SyncNotifiable sn_;
 };
 
 TEST_F(MemoryConfigTest, create)
@@ -176,6 +221,99 @@ TEST_F(MemoryConfigTest, stream_reject)
     clear_expect(true);
 }
 
+// End to end test case with stream receiver.
+TEST_F(MemoryConfigTest, two_node)
+{
+    setup_two_nodes();
+    twait();
+    clear_expect(true);
 
+    expect_packet(":X1B22A225N20600000000228FF;");
+    expect_packet(":X1D22A225N43FFFFFFFF;");
+    // stream initiate request, SID 0x02 DID 0x43 buffer infinite
+    expect_packet(":X19CC822AN0225FFFF00000243;");
+
+    // Read stream request, space 0x28, offset 2, length infinite, dst stream
+    // iD 0x43.
+    inject_datagram("20600000000228FF43FFFFFFFF");
+
+    wait();
+    clear_expect(true);
+    EXPECT_FALSE(datagramDoneBn_.is_done());
+
+    // stream initiate reply
+    expect_packet(":X19868225N022A00F080000243;");
+    // datgram ack-ed, reply pending.
+    expect_packet(":X19A2822AN022580;");
+
+    // datagram memory config read stream reply success, offset 2, len inf,
+    // space 0x28, SID 02 DID 43.
+    expect_packet(":X1B22522AN2070000000022802;");
+    expect_packet(":X1D22522AN43FFFFFFFF;");
+
+    // response datagram is rejected because noone is listening on the second
+    // node.
+    expect_packet(":X19A48225N022A1000;");
+    
+    // Reply accept, buffer length 240, src ID 02 dst id 43.
+    send_message(otherNode_.get(), Defs::MTI_STREAM_INITIATE_REPLY,
+        first_node(), hex2str("00F080000243"));
+    wait();
+
+    // stream payloads
+    expect_packet(":X1F22522AN4302030405060708;");
+    expect_packet(":X1F22522AN43090A0B0C0D0E;");
+
+    // stream complete, SID 02 DID 43 sent bytes 13
+    expect_packet(":X198A822AN022502430000000D;");
+    
+    twait();
+    clear_expect(true);
+    EXPECT_TRUE(datagramDoneBn_.is_done());
+}
+
+// End to end test case with stream receiver.
+TEST_F(MemoryConfigTest, end_to_end)
+{
+    setup_two_nodes();
+    twait();
+    clear_expect(false);
+    invoke_receiver();
+
+    EXPECT_EQ(0x20000, recvRequest_->data()->resultCode);
+
+    // Read stream request, space 0x28, offset 2, length infinite, dst stream
+    // iD 0x43.
+    inject_datagram("20600000000228FF43FFFFFFFF");
+
+    twait();
+
+    EXPECT_TRUE(datagramDoneBn_.is_done());
+    EXPECT_EQ(smallPayload.substr(2), sink_.data);
+    sn_.wait_for_notification();
+    EXPECT_EQ(0x0000, recvRequest_->data()->resultCode);
+}
+
+// End to end test case with stream receiver.
+TEST_F(MemoryConfigTest, end_to_end_long)
+{
+    setup_two_nodes();
+    twait();
+    clear_expect(false);
+    invoke_receiver();
+
+    EXPECT_EQ(0x20000, recvRequest_->data()->resultCode);
+
+    // Read stream request, space 0x28, offset 2, length infinite, dst stream
+    // iD 0x43.
+    inject_datagram("20600000000227FF43FFFFFFFF");
+
+    twait();
+
+    EXPECT_TRUE(datagramDoneBn_.is_done());
+    EXPECT_EQ(largePayload.substr(2), sink_.data);
+    sn_.wait_for_notification();
+    EXPECT_EQ(0x0000, recvRequest_->data()->resultCode);
+}
 
 } // namespace openlcb

--- a/src/openlcb/MemoryConfigStream.cxxtest
+++ b/src/openlcb/MemoryConfigStream.cxxtest
@@ -18,8 +18,10 @@ string get_payload_data(size_t length)
 
 string largePayload {get_payload_data(15000)};
 string smallPayload {get_payload_data(15)};
-ReadOnlyMemoryBlock largeBlock {largePayload.data(), (unsigned)largePayload.size()};
-ReadOnlyMemoryBlock smallBlock {smallPayload.data(), (unsigned)smallPayload.size()};
+ReadOnlyMemoryBlock largeBlock {
+    largePayload.data(), (unsigned)largePayload.size()};
+ReadOnlyMemoryBlock smallBlock {
+    smallPayload.data(), (unsigned)smallPayload.size()};
 
 class MemoryConfigTest : public TwoNodeDatagramTest
 {
@@ -53,17 +55,9 @@ TEST_F(MemoryConfigTest, manual)
     print_all_packets();
     clear_expect(true);
 
-    //expect_packet(":X19A2822AN077C80;"); // received ok, response pending
-
-#if 0    
     // stream initiate request, SID 0x02 DID 0x37 buffer infinite
-    expect_packet(":X19CC822AN077CFFFF00000237;").WillOnce(::testing::InvokeWithoutArgs([this]() {
-        // stream initiate reply, accept, window 240, SID 0x02 DID 0x37
-        send_packet(":X1986877CN022A00F080000237;");
-    }));
-#endif
     expect_packet(":X19CC822AN077CFFFF00000237;");
-    
+
     // Read stream request, space 0x28, offset 2, length infinite, dst stream
     // iD 0x37.
     send_packet(":X1B22A77CN20600000000228FF;");
@@ -76,15 +70,19 @@ TEST_F(MemoryConfigTest, manual)
     send_packet(":X1986877CN022A00F080000237;");
 
     //::testing::InSequence seq;
-    
-    expect_packet(":X19A2822AN077C80;"); // received ok, response pending
+
+    // datagram received ok, response pending. This is for the dg opening the
+    // interaction.
+    expect_packet(":X19A2822AN077C80;");
     // datagram memory config read stream reply success, offset 2, len inf,
     // space 0x28, SID 02 DID 37.
     expect_packet(":X1B77C22AN2070000000022802;");
-    expect_packet(":X1D77C22AN37FFFFFFFF;").WillOnce(::testing::InvokeWithoutArgs([this]() {
-        // Datagram accept
-        send_packet(":X19A2877CN022A00;");
-    }));
+    expect_packet(":X1D77C22AN37FFFFFFFF;")
+        .WillOnce(::testing::InvokeWithoutArgs([this]() {
+            // Datagram accept, no response. This is for the read reply
+            // datagram.
+            send_packet(":X19A2877CN022A00;");
+        }));
 
     // stream payloads
     expect_packet(":X1F77C22AN3702030405060708;");
@@ -92,10 +90,98 @@ TEST_F(MemoryConfigTest, manual)
 
     // stream complete, SID 02 DID 37 sent bytes 13
     expect_packet(":X198A822AN077C02370000000D;");
-    
+
     twait();
-    
+
     clear_expect(true);
 }
+
+// Tihs test is a successful run when the datagram open does not specify the
+// stream destination ID. It will get filled in by the stream initiate reply
+// command.
+TEST_F(MemoryConfigTest, no_stream_did)
+{
+    print_all_packets();
+    clear_expect(true);
+
+    // stream initiate request, SID 0x02 DID unknown buffer infinite
+    expect_packet(":X19CC822AN077CFFFF000002FF;");
+
+    // Read stream request, space 0x28, offset 2, length infinite, dst stream
+    // iD unknown.
+    send_packet(":X1B22A77CN20600000000228FF;");
+    send_packet(":X1D22A77CNFFFFFFFFFF;");
+
+    wait();
+    clear_expect(true);
+
+    // stream initiate reply, accept, window 240, SID 0x02 DID 0x39
+    send_packet(":X1986877CN022A00F080000239;");
+
+    //::testing::InSequence seq;
+
+    // datagram received ok, response pending. This is for the dg opening the
+    // interaction.
+    expect_packet(":X19A2822AN077C80;");
+    // datagram memory config read stream reply success, offset 2, len inf,
+    // space 0x28, SID 02 DID 39.
+    expect_packet(":X1B77C22AN2070000000022802;");
+    expect_packet(":X1D77C22AN39FFFFFFFF;")
+        .WillOnce(::testing::InvokeWithoutArgs([this]() {
+            // Datagram accept, no response. This is for the read reply
+            // datagram.
+            send_packet(":X19A2877CN022A00;");
+        }));
+
+    // stream payloads
+    expect_packet(":X1F77C22AN3902030405060708;");
+    expect_packet(":X1F77C22AN39090A0B0C0D0E;");
+
+    // stream complete, SID 02 DID 39 sent bytes 13
+    expect_packet(":X198A822AN077C02390000000D;");
+
+    twait();
+
+    clear_expect(true);
+}
+
+// Tests the case when a stream read happens, then the stream initiate gets
+// rejected by the source node.
+TEST_F(MemoryConfigTest, stream_reject)
+{
+    print_all_packets();
+    clear_expect(true);
+
+    // stream initiate request, SID 0x02 DID 0x37 buffer infinite
+    expect_packet(":X19CC822AN077CFFFF00000237;");
+
+    // Read stream request, space 0x28, offset 2, length infinite, dst stream
+    // iD 0x37.
+    send_packet(":X1B22A77CN20600000000228FF;");
+    send_packet(":X1D22A77CN37FFFFFFFF;");
+
+    wait();
+    clear_expect(true);
+
+    // stream initiate reply, reject, error 0x2123, window 240, SID 0x02 DID
+    // 0x37
+    send_packet(":X1986877CN022A00F021230237;");
+
+    expect_packet(":X19A2822AN077C80;"); // received ok, response pending
+
+    // datagram memory config read stream reply failure, offset 2, len inf,
+    // space 0x28, error 0x2123.
+    expect_packet(":X1B77C22AN2078000000022821;");
+    expect_packet(":X1D77C22AN23;")
+        .WillOnce(::testing::InvokeWithoutArgs([this]() {
+            // Datagram accept
+            send_packet(":X19A2877CN022A00;");
+        }));
+
+    twait();
+    clear_expect(true);
+}
+
+
 
 } // namespace openlcb

--- a/src/openlcb/MemoryConfigStream.cxxtest
+++ b/src/openlcb/MemoryConfigStream.cxxtest
@@ -67,12 +67,12 @@ protected:
 
     void invoke_receiver(uint8_t src_stream_id = StreamDefs::INVALID_STREAM_ID)
     {
-        recvRequest_->data()->reset(&sink_, otherNode_.get(),
-                                    first_node(), src_stream_id);
+        recvRequest_->data()->reset(
+            &sink_, otherNode_.get(), first_node(), src_stream_id);
         recvRequest_->data()->done.reset(&sn_);
         run_x([this]() { receiver_->send(recvRequest_->ref()); });
     }
-    
+
     StreamTransportCan t_ {ifCan_.get(), 2};
     MemoryConfigHandler memoryOne_ {&datagram_support_, nullptr, 10};
     MemoryConfigStreamHandler memoryStream_ {&memoryOne_};
@@ -87,7 +87,8 @@ protected:
 };
 
 TEST_F(MemoryConfigTest, create)
-{ }
+{
+}
 
 TEST_F(MemoryConfigTest, manual)
 {
@@ -254,7 +255,7 @@ TEST_F(MemoryConfigTest, two_node)
     // response datagram is rejected because noone is listening on the second
     // node.
     expect_packet(":X19A48225N022A1000;");
-    
+
     // Reply accept, buffer length 240, src ID 02 dst id 43.
     send_message(otherNode_.get(), Defs::MTI_STREAM_INITIATE_REPLY,
         first_node(), hex2str("00F080000243"));
@@ -266,7 +267,7 @@ TEST_F(MemoryConfigTest, two_node)
 
     // stream complete, SID 02 DID 43 sent bytes 13
     expect_packet(":X198A822AN022502430000000D;");
-    
+
     twait();
     clear_expect(true);
     EXPECT_TRUE(datagramDoneBn_.is_done());
@@ -305,7 +306,7 @@ TEST_F(MemoryConfigTest, length_limit)
     // response datagram is rejected because noone is listening on the second
     // node.
     expect_packet(":X19A48225N022A1000;");
-    
+
     // Reply accept, buffer length 240, src ID 02 dst id 43.
     send_message(otherNode_.get(), Defs::MTI_STREAM_INITIATE_REPLY,
         first_node(), hex2str("00F080000243"));
@@ -317,12 +318,11 @@ TEST_F(MemoryConfigTest, length_limit)
 
     // stream complete, SID 02 DID 43 sent bytes 13
     expect_packet(":X198A822AN0225024300000009;");
-    
+
     twait();
     clear_expect(true);
     EXPECT_TRUE(datagramDoneBn_.is_done());
 }
-
 
 // End to end test case with stream receiver.
 TEST_F(MemoryConfigTest, end_to_end)

--- a/src/openlcb/MemoryConfigStream.cxxtest
+++ b/src/openlcb/MemoryConfigStream.cxxtest
@@ -221,7 +221,7 @@ TEST_F(MemoryConfigTest, stream_reject)
     clear_expect(true);
 }
 
-// End to end test case with stream receiver.
+// End to end test case with two nodes on separate interfaces.
 TEST_F(MemoryConfigTest, two_node)
 {
     setup_two_nodes();
@@ -272,6 +272,58 @@ TEST_F(MemoryConfigTest, two_node)
     EXPECT_TRUE(datagramDoneBn_.is_done());
 }
 
+// End to end test case with length limits.
+TEST_F(MemoryConfigTest, length_limit)
+{
+    setup_two_nodes();
+    twait();
+    clear_expect(true);
+
+    expect_packet(":X1B22A225N20600000000228FF;");
+    expect_packet(":X1D22A225N4300000009;");
+    // stream initiate request, SID 0x02 DID 0x43 buffer infinite
+    expect_packet(":X19CC822AN0225FFFF00000243;");
+
+    // Read stream request, space 0x28, offset 2, length 9, dst stream
+    // iD 0x43.
+    inject_datagram("20600000000228FF4300000009");
+
+    wait();
+    clear_expect(true);
+    EXPECT_FALSE(datagramDoneBn_.is_done());
+
+    // stream initiate reply
+    expect_packet(":X19868225N022A00F080000243;");
+    // datgram ack-ed, reply pending.
+    expect_packet(":X19A2822AN022580;");
+
+    // datagram memory config read stream reply success, offset 2, len inf,
+    // space 0x28, SID 02 DID 43.
+    expect_packet(":X1B22522AN2070000000022802;");
+    expect_packet(":X1D22522AN4300000009;");
+
+    // response datagram is rejected because noone is listening on the second
+    // node.
+    expect_packet(":X19A48225N022A1000;");
+    
+    // Reply accept, buffer length 240, src ID 02 dst id 43.
+    send_message(otherNode_.get(), Defs::MTI_STREAM_INITIATE_REPLY,
+        first_node(), hex2str("00F080000243"));
+    wait();
+
+    // stream payloads
+    expect_packet(":X1F22522AN4302030405060708;");
+    expect_packet(":X1F22522AN43090A;");
+
+    // stream complete, SID 02 DID 43 sent bytes 13
+    expect_packet(":X198A822AN0225024300000009;");
+    
+    twait();
+    clear_expect(true);
+    EXPECT_TRUE(datagramDoneBn_.is_done());
+}
+
+
 // End to end test case with stream receiver.
 TEST_F(MemoryConfigTest, end_to_end)
 {
@@ -304,7 +356,7 @@ TEST_F(MemoryConfigTest, end_to_end_long)
 
     EXPECT_EQ(0x20000, recvRequest_->data()->resultCode);
 
-    // Read stream request, space 0x28, offset 2, length infinite, dst stream
+    // Read stream request, space 0x27, offset 2, length infinite, dst stream
     // iD 0x43.
     inject_datagram("20600000000227FF43FFFFFFFF");
 
@@ -312,6 +364,52 @@ TEST_F(MemoryConfigTest, end_to_end_long)
 
     EXPECT_TRUE(datagramDoneBn_.is_done());
     EXPECT_EQ(largePayload.substr(2), sink_.data);
+    sn_.wait_for_notification();
+    EXPECT_EQ(0x0000, recvRequest_->data()->resultCode);
+}
+
+// End to end test case with stream receiver but empty data coming due to out
+// of bounds request.
+TEST_F(MemoryConfigTest, end_to_end_out_of_bound)
+{
+    setup_two_nodes();
+    twait();
+    clear_expect(false);
+    invoke_receiver();
+
+    EXPECT_EQ(0x20000, recvRequest_->data()->resultCode);
+
+    // Read stream request, space 0x28, offset 0xF2, length infinite, dst stream
+    // iD 0x43.
+    inject_datagram("2060000000F228FF43FFFFFFFF");
+
+    twait();
+
+    EXPECT_TRUE(datagramDoneBn_.is_done());
+    EXPECT_EQ("", sink_.data);
+    sn_.wait_for_notification();
+    EXPECT_EQ(0x0000, recvRequest_->data()->resultCode);
+}
+
+// End to end test case with stream receiver but empty data coming due to out
+// of bounds request.
+TEST_F(MemoryConfigTest, end_to_end_length_limit)
+{
+    setup_two_nodes();
+    twait();
+    clear_expect(false);
+    invoke_receiver();
+
+    EXPECT_EQ(0x20000, recvRequest_->data()->resultCode);
+
+    // Read stream request, space 0x28, offset 0xF2, length 9, dst stream
+    // iD 0x43.
+    inject_datagram("20600000000228FF4300000009");
+
+    twait();
+
+    EXPECT_TRUE(datagramDoneBn_.is_done());
+    EXPECT_EQ(smallPayload.substr(2, 9), sink_.data);
     sn_.wait_for_notification();
     EXPECT_EQ(0x0000, recvRequest_->data()->resultCode);
 }

--- a/src/openlcb/MemoryConfigStream.cxxtest
+++ b/src/openlcb/MemoryConfigStream.cxxtest
@@ -1,5 +1,101 @@
 
 #include "openlcb/MemoryConfigStream.hxx"
 
-#include "utils/test_main.hxx"
+#include "utils/async_datagram_test_helper.hxx"
 
+namespace openlcb
+{
+
+string get_payload_data(size_t length)
+{
+    string r(length, 0);
+    for (size_t i = 0; i < length; ++i)
+    {
+        r[i] = i & 0xff;
+    }
+    return r;
+}
+
+string largePayload {get_payload_data(15000)};
+string smallPayload {get_payload_data(15)};
+ReadOnlyMemoryBlock largeBlock {largePayload.data(), (unsigned)largePayload.size()};
+ReadOnlyMemoryBlock smallBlock {smallPayload.data(), (unsigned)smallPayload.size()};
+
+class MemoryConfigTest : public TwoNodeDatagramTest
+{
+protected:
+    MemoryConfigTest()
+        : memoryOne_(&datagram_support_, nullptr, 10)
+    {
+        memoryOne_.registry()->insert(node_, 0x27, &largeBlock);
+        memoryOne_.registry()->insert(node_, 0x28, &smallBlock);
+        wait();
+        // Throw away the first two stream IDs.
+        t_.get_send_stream_id();
+        t_.get_send_stream_id();
+    }
+
+    ~MemoryConfigTest()
+    {
+        wait();
+    }
+
+    StreamTransportCan t_ {ifCan_.get(), 2};
+    MemoryConfigHandler memoryOne_ {&datagram_support_, nullptr, 10};
+    MemoryConfigStreamHandler memoryStream_ {&memoryOne_};
+};
+
+TEST_F(MemoryConfigTest, create)
+{ }
+
+TEST_F(MemoryConfigTest, manual)
+{
+    print_all_packets();
+    clear_expect(true);
+
+    //expect_packet(":X19A2822AN077C80;"); // received ok, response pending
+
+#if 0    
+    // stream initiate request, SID 0x02 DID 0x37 buffer infinite
+    expect_packet(":X19CC822AN077CFFFF00000237;").WillOnce(::testing::InvokeWithoutArgs([this]() {
+        // stream initiate reply, accept, window 240, SID 0x02 DID 0x37
+        send_packet(":X1986877CN022A00F080000237;");
+    }));
+#endif
+    expect_packet(":X19CC822AN077CFFFF00000237;");
+    
+    // Read stream request, space 0x28, offset 2, length infinite, dst stream
+    // iD 0x37.
+    send_packet(":X1B22A77CN20600000000228FF;");
+    send_packet(":X1D22A77CN37FFFFFFFF;");
+
+    wait();
+    clear_expect(true);
+
+    // stream initiate reply, accept, window 240, SID 0x02 DID 0x37
+    send_packet(":X1986877CN022A00F080000237;");
+
+    //::testing::InSequence seq;
+    
+    expect_packet(":X19A2822AN077C80;"); // received ok, response pending
+    // datagram memory config read stream reply success, offset 2, len inf,
+    // space 0x28, SID 02 DID 37.
+    expect_packet(":X1B77C22AN2070000000022802;");
+    expect_packet(":X1D77C22AN37FFFFFFFF;").WillOnce(::testing::InvokeWithoutArgs([this]() {
+        // Datagram accept
+        send_packet(":X19A2877CN022A00;");
+    }));
+
+    // stream payloads
+    expect_packet(":X1F77C22AN3702030405060708;");
+    expect_packet(":X1F77C22AN37090A0B0C0D0E;");
+
+    // stream complete, SID 02 DID 37 sent bytes 13
+    expect_packet(":X198A822AN077C02370000000D;");
+    
+    twait();
+    
+    clear_expect(true);
+}
+
+} // namespace openlcb

--- a/src/openlcb/MemoryConfigStream.cxxtest
+++ b/src/openlcb/MemoryConfigStream.cxxtest
@@ -1,0 +1,5 @@
+
+#include "openlcb/MemoryConfigStream.hxx"
+
+#include "utils/test_main.hxx"
+

--- a/src/openlcb/MemoryConfigStream.hxx
+++ b/src/openlcb/MemoryConfigStream.hxx
@@ -284,6 +284,16 @@ private:
         size_t len = message()->data()->payload.size();
         const uint8_t *bytes = in_bytes();
 
+        if (len < 8)
+        {
+            return respond_reject(Defs::ERROR_INVALID_ARGS);
+        }
+        MemorySpace *space = get_space();
+        if (!space)
+        {
+            return respond_reject(MemoryConfigDefs::ERROR_SPACE_NOT_KNOWN);
+        }
+
         size_t stream_data_offset = 6;
         if (has_custom_space())
         {

--- a/src/openlcb/MemoryConfigStream.hxx
+++ b/src/openlcb/MemoryConfigStream.hxx
@@ -145,7 +145,7 @@ private:
 
     Action have_raw_buffer()
     {
-        LOG(INFO, "have raw buf len %u", (unsigned) len_);
+        LOG(INFO, "have raw buf len %u", (unsigned)len_);
 
         RawBufferPtr raw_buffer(get_allocation_result<RawData>(nullptr));
         sendBuffer_ = get_buffer_deleter(sender_->alloc());

--- a/src/openlcb/MemoryConfigStream.hxx
+++ b/src/openlcb/MemoryConfigStream.hxx
@@ -122,6 +122,7 @@ private:
         auto state = senderCan_->get_state();
         if (state == StreamSender::RUNNING)
         {
+            dstStreamId_ = senderCan_->get_dst_stream_id();
             startedCb_(0);
             return call_immediately(STATE(alloc_buffer));
         }

--- a/src/openlcb/MemoryConfigStream.hxx
+++ b/src/openlcb/MemoryConfigStream.hxx
@@ -1,0 +1,192 @@
+/** \copyright
+ * Copyright (c) 2014, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file MemoryConfigStream.hxx
+ *
+ * Implementation of the stream support for Memory Config Protocol server
+ *
+ * @author Balazs Racz
+ * @date 20 Dec 2022
+ */
+
+#ifndef _OPENLCB_MEMORYCONFIGSTREAM_HXX_
+#define _OPENLCB_MEMORYCONFIGSTREAM_HXX_
+
+#include "openlcb/MemoryConfig.hxx"
+#include "openlcb/If.hxx"
+#include "openlcb/StreamTransport.hxx"
+#include "openlcb/StreamSender.hxx"
+
+namespace openlcb {
+
+/// This is a self-owned flow which reads an memory space into a stream.
+class MemorySpaceStreamReadFlow : public StateFlowBase
+{
+public:
+    MemorySpaceStreamReadFlow(Node *node, MemorySpace *space, NodeHandle dst,
+        uint8_t dst_stream_id, uint32_t ofs, uint32_t len)
+        : StateFlowBase(node->iface())
+        , dst_(dst)
+        , space_(space)
+        , dstStreamId_(dst_stream_id)
+        , node_(node)
+        , ofs_(ofs)
+        , len_(len)
+    {
+        start_flow(STATE(initiate_stream));
+    }
+
+
+private:
+    Action alloc_stream() {
+        return exit();
+    }
+
+    Action initiate_stream() {
+        return exit();
+
+    }
+
+    
+    /// Address to which we are sending the stream.
+    NodeHandle dst_;
+    /// Memory space we are reading.
+    MemorySpace* space_;
+    /// Destination stream ID on the target node.
+    uint8_t dstStreamId_;
+    /// Node from which we are sending the stream.
+    Node* node_;
+    /// Next byte to read.
+    uint32_t ofs_;
+    /// How many bytes are left to read. 0xFFFFFFFF if all bytes until EOF need
+    /// to be read.
+    uint32_t len_;
+    /// 
+    /// 
+    StreamSenderCan* senderCan_;
+    StreamSender* sender_;
+};
+
+/// Handler for the stream read/write commands in the memory config protocol
+/// (server side).
+class MemoryConfigStreamHandler : public MemoryConfigHandlerBase
+{
+public:
+    MemoryConfigStreamHandler(MemoryConfigHandler *parent)
+        : MemoryConfigHandlerBase(parent->dg_service())
+        , parent_(parent)
+    {
+        parent_->set_stream_handler(this);
+    }
+
+    Action entry() override
+    {
+        // The virification of the incoming data is already done by the calling
+        // MemoryConfigHandler.
+        response_.clear();
+        const uint8_t *bytes = in_bytes();
+        uint8_t cmd = bytes[1];
+
+        switch (cmd & MemoryConfigDefs::COMMAND_MASK)
+        {
+            case MemoryConfigDefs::COMMAND_READ_STREAM:
+            {
+                return call_immediately(STATE(handle_read_stream));
+            }
+            /// @todo handle write stream
+        }
+        return exit();
+    }
+
+private:
+    Action handle_read_stream()
+    {
+        size_t len = message()->data()->payload.size();
+        const uint8_t *bytes = in_bytes();
+
+        size_t stream_data_offset = 6;
+        if (has_custom_space())
+        {
+            ++stream_data_offset;
+        }
+        if (len < stream_data_offset + 2)
+        {
+            return respond_reject(Defs::ERROR_INVALID_ARGS);
+        }
+
+        uint8_t dst_stream_id = bytes[stream_data_offset + 1];
+        uint32_t num_bytes_to_read = 0xFFFFFFFFu;
+        if (len >= stream_data_offset + 6)
+        {
+            memcpy(&num_bytes_to_read, bytes + stream_data_offset + 2, 4);
+            num_bytes_to_read = be32toh(num_bytes_to_read);
+        }
+        new MemorySpaceStreamReadFlow(message()->data()->dst, get_space(),
+            message()->data()->src, dst_stream_id, get_address(),
+            num_bytes_to_read);
+        /// @todo
+        return exit();
+    }
+
+    /** Looks up the memory space for the current datagram. Returns NULL if no
+     * space was registered (for neither the current node, nor global). */
+    MemorySpace *get_space()
+    {
+        int space_number = get_space_number();
+        if (space_number < 0)
+            return nullptr;
+        MemorySpace *space =
+            registry()->lookup(message()->data()->dst, space_number);
+        if (!space)
+        {
+            LOG(WARNING, "MemoryConfig: asked node 0x%012" PRIx64 " for unknown space "
+                         "%d. Source {0x%012" PRIx64 ", %03x}",
+                message()->data()->dst->node_id(), space_number,
+                message()->data()->src.id, message()->data()->src.alias);
+            return nullptr;
+        }
+        if (!space->set_node(message()->data()->dst))
+        {
+            LOG(WARNING, "MemoryConfig: Global space %d rejected node.",
+                space_number);
+            return nullptr;
+        }
+        return space;
+    }
+    
+    Registry *registry()
+    {
+        return parent_->registry();
+        ;
+    }
+
+    /// Parent object from which we are getting commands forwarded.
+    MemoryConfigHandler *parent_;
+};
+
+} // namespace openlcb
+
+#endif // _OPENLCB_MEMORYCONFIGSTREAM_HXX_

--- a/src/openlcb/StreamDefs.hxx
+++ b/src/openlcb/StreamDefs.hxx
@@ -54,7 +54,10 @@ struct StreamDefs
     {
         FLAG_CARRIES_ID = 0x01,
         FLAG_REJECT_OUT_OF_ORDER = 0x02,
-        FLAG_PERMANENT_ERROR = 0x40,
+        /// @todo synchronize the draft text in the standards repository with
+        /// these definitions. These definitions match other OpenLCB protocols.
+        FLAG_PERMANENT_ERROR = 0x10,
+        FLAG_TEMPORARY_ERROR = 0x20,
         FLAG_ACCEPT = 0x80,
     };
 

--- a/src/openlcb/StreamReceiver.cxx
+++ b/src/openlcb/StreamReceiver.cxx
@@ -261,6 +261,7 @@ public:
         uint32_t frame_id = 0;
         CanDefs::set_datagram_fields(
             &frame_id, remote_alias, local_alias, CanDefs::STREAM_DATA);
+        LOG(VERBOSE, "register frame ID %x", (unsigned)frame_id);
         parent_->if_can()->frame_dispatcher()->register_handler(
             this, frame_id, CanDefs::STREAM_DG_RECV_MASK);
     }

--- a/src/openlcb/StreamReceiver.cxxtest
+++ b/src/openlcb/StreamReceiver.cxxtest
@@ -312,4 +312,25 @@ TEST_F(StreamReceiverTest, two_streams)
     EXPECT_EQ(p, sink2.data);
 }
 
+/// Runs a localhost stream.
+TEST_F(StreamReceiverTest, localhost)
+{
+    print_all_packets();
+    // Reallocates the stream sender to the same interface.
+    sender_.~StreamSenderCan();
+    new (&sender_) StreamSenderCan(&g_service, ifCan_.get());
+    
+    recvRequest_->data()->reset(&sink_, node_, NodeHandle(node_->node_id()),
+        StreamDefs::INVALID_STREAM_ID);
+    recvRequest_->data()->done.reset(&sn_);
+    run_x([this]() { receiver_.send(recvRequest_->ref()); });
+
+    sender_.start_stream(node_, NodeHandle(node_->node_id()), SRC_STREAM_ID);
+
+    send_data(35);
+    sender_.close_stream();
+    wait();
+    EXPECT_EQ(dataSent_, sink_.data);
+}
+
 } // namespace openlcb

--- a/src/openlcb/StreamReceiver.cxxtest
+++ b/src/openlcb/StreamReceiver.cxxtest
@@ -1,55 +1,11 @@
 #include "openlcb/StreamReceiver.hxx"
 
 #include "openlcb/StreamSender.hxx"
-#include "utils/async_datagram_test_helper.hxx"
+#include "utils/async_stream_test_helper.hxx"
 
-namespace openlcb
-{
+namespace openlcb {
 
-static constexpr uint8_t LOCAL_STREAM_ID = 0x3a;
-static constexpr uint8_t SRC_STREAM_ID = 0xa7;
-
-string get_payload_data(size_t length)
-{
-    string r(length, 0);
-    for (size_t i = 0; i < length; ++i)
-    {
-        r[i] = i & 0xff;
-    }
-    return r;
-}
-
-struct CollectData : public ByteSink
-{
-    /// Bytes that arrived so far.
-    string data;
-    /// Holds buffers.
-    Q q;
-    /// if true, the buffers are added to the queue instead of unref'ed.
-    bool keepBuffers_ {false};
-
-    void send(ByteBuffer *msg, unsigned prio) override
-    {
-        auto rb = get_buffer_deleter(msg);
-        data.append((char *)msg->data()->data_, msg->data()->size());
-        if (keepBuffers_)
-        {
-            q.insert(msg->ref());
-        }
-    }
-
-    /// Takes a single element from the queue, and releases it.
-    string qtake()
-    {
-        ByteBuffer *b = (ByteBuffer *)q.next(0);
-        HASSERT(b != nullptr);
-        string ret((char *)b->data()->data_, b->data()->size());
-        b->unref();
-        return ret;
-    }
-};
-
-class StreamReceiverTestBase : public TwoNodeDatagramTest
+class StreamReceiverTestBase : public StreamTestBase
 {
 protected:
     StreamReceiverTestBase()
@@ -67,7 +23,6 @@ class StreamReceiverTest : public StreamReceiverTestBase
 protected:
     StreamReceiverTest()
     {
-        mainBufferPool->alloc(&recvRequest_);
     }
 
     ~StreamReceiverTest()
@@ -121,8 +76,6 @@ protected:
 
     StreamReceiverCan receiver_ {ifCan_.get(), LOCAL_STREAM_ID};
     SyncNotifiable sn_;
-    CollectData sink_;
-    BufferPtr<StreamReceiveRequest> recvRequest_;
 
     StreamSenderCan sender_ {&g_service, otherIfCan_.get()};
     string dataSent_;

--- a/src/openlcb/StreamReceiver.cxxtest
+++ b/src/openlcb/StreamReceiver.cxxtest
@@ -3,7 +3,8 @@
 #include "openlcb/StreamSender.hxx"
 #include "utils/async_stream_test_helper.hxx"
 
-namespace openlcb {
+namespace openlcb
+{
 
 class StreamReceiverTestBase : public StreamTestBase
 {
@@ -272,7 +273,7 @@ TEST_F(StreamReceiverTest, localhost)
     // Reallocates the stream sender to the same interface.
     sender_.~StreamSenderCan();
     new (&sender_) StreamSenderCan(&g_service, ifCan_.get());
-    
+
     recvRequest_->data()->reset(&sink_, node_, NodeHandle(node_->node_id()),
         StreamDefs::INVALID_STREAM_ID);
     recvRequest_->data()->done.reset(&sn_);

--- a/src/openlcb/StreamReceiver.cxxtest
+++ b/src/openlcb/StreamReceiver.cxxtest
@@ -89,7 +89,8 @@ protected:
 
     void invoke_sender()
     {
-        sender_.start_stream(NodeHandle(node_->node_id()), SRC_STREAM_ID);
+        sender_.start_stream(
+            otherNode_.get(), NodeHandle(node_->node_id()), SRC_STREAM_ID);
     }
 
     void send_data(size_t bytes)
@@ -123,7 +124,7 @@ protected:
     CollectData sink_;
     BufferPtr<StreamReceiveRequest> recvRequest_;
 
-    StreamSenderCan sender_ {&g_service, otherIfCan_.get(), otherNode_.get()};
+    StreamSenderCan sender_ {&g_service, otherIfCan_.get()};
     string dataSent_;
 };
 
@@ -257,7 +258,7 @@ TEST_F(StreamReceiverTest, blocked_sink)
 /// Runs two streams at the same time.
 TEST_F(StreamReceiverTest, two_streams)
 {
-    StreamSenderCan sender2 {&g_service, otherIfCan_.get(), otherNode_.get()};
+    StreamSenderCan sender2 {&g_service, otherIfCan_.get()};
     StreamReceiverCan receiver2 {ifCan_.get(), LOCAL_STREAM_ID + 1};
     CollectData sink2;
     sink2.keepBuffers_ = true;
@@ -273,7 +274,9 @@ TEST_F(StreamReceiverTest, two_streams)
     wait();
 
     // Starts sender 2.
-    sender2.start_stream(NodeHandle(node_->node_id()), SRC_STREAM_ID + 1)
+    sender2
+        .start_stream(
+            otherNode_.get(), NodeHandle(node_->node_id()), SRC_STREAM_ID + 1)
         .set_proposed_window_size(2);
 
     wait();

--- a/src/openlcb/StreamReceiverInterface.hxx
+++ b/src/openlcb/StreamReceiverInterface.hxx
@@ -52,6 +52,11 @@ class Node;
 
 struct StreamReceiveRequest : public CallableFlowRequestBase
 {
+    enum
+    {
+        OPERATION_PENDING =  0x20000, //< cleared when done is called.
+    };
+
     /// Gets a local stream ID. This will be returning the assigned local
     /// stream ID from the stream receiver object.
     void reset()
@@ -59,6 +64,7 @@ struct StreamReceiveRequest : public CallableFlowRequestBase
         reset_base();
         target_ = nullptr;
         localStreamId_ = StreamDefs::INVALID_STREAM_ID;
+        resultCode = OPERATION_PENDING;
     }
 
     /// Starts the stream receiver and prepares for an announced stream. This
@@ -92,6 +98,7 @@ struct StreamReceiveRequest : public CallableFlowRequestBase
         srcStreamId_ = src_stream_id;
         localStreamId_ = dst_stream_id;
         streamWindowSize_ = max_window;
+        resultCode = OPERATION_PENDING;
     }
 
     /// Where to send the incoming stream data.

--- a/src/openlcb/StreamReceiverInterface.hxx
+++ b/src/openlcb/StreamReceiverInterface.hxx
@@ -54,7 +54,7 @@ struct StreamReceiveRequest : public CallableFlowRequestBase
 {
     enum
     {
-        OPERATION_PENDING =  0x20000, //< cleared when done is called.
+        OPERATION_PENDING = 0x20000, //< cleared when done is called.
     };
 
     /// Gets a local stream ID. This will be returning the assigned local

--- a/src/openlcb/StreamSender.cxxtest
+++ b/src/openlcb/StreamSender.cxxtest
@@ -140,12 +140,12 @@ TEST_F(StreamSenderTest, initiate_rejected)
     sender_.start_stream(node_, other_handle(), 0xaa);
     wait();
     EXPECT_EQ(StreamSender::INITIATING, sender_.get_state());
-    // Rejects with a weird error code.
-    send_packet(":X19868225N022A00004220AA55;");
+    // Rejects with a standard error code.
+    send_packet(":X19868225N022A00001234AA55;");
     wait();
     EXPECT_EQ(StreamSender::STATE_ERROR, sender_.get_state());
     // Translated into a permanent error.
-    EXPECT_EQ(0x1020, sender_.get_error());
+    EXPECT_EQ(0x1234, sender_.get_error());
 }
 
 TEST_F(StreamSenderTest, initiate_accepted)

--- a/src/openlcb/StreamSender.cxxtest
+++ b/src/openlcb/StreamSender.cxxtest
@@ -128,7 +128,8 @@ TEST_F(StreamSenderTest, initiate_with_bufsize)
     clear_expect(true);
     EXPECT_EQ(StreamSender::IDLE, sender_.get_state());
     expect_packet(":X19CC822AN0225EF320000AAFF;");
-    sender_.start_stream(node_, other_handle(), 0xaa).set_proposed_window_size(0xef32);
+    sender_.start_stream(node_, other_handle(), 0xaa)
+        .set_proposed_window_size(0xef32);
     wait();
     EXPECT_EQ(StreamSender::INITIATING, sender_.get_state());
 }

--- a/src/openlcb/StreamSender.cxxtest
+++ b/src/openlcb/StreamSender.cxxtest
@@ -64,7 +64,7 @@ protected:
     {
         clear_expect(true);
         expect_packet(":X19CC822AN0225FFFF0000AAFF;");
-        sender_.start_stream(other_handle(), 0xaa);
+        sender_.start_stream(node_, other_handle(), 0xaa);
         wait();
         EXPECT_EQ(StreamSender::INITIATING, sender_.get_state());
         // Accepts with buffer size of 8 bytes.
@@ -103,7 +103,7 @@ protected:
         sender_.send(chunk);
     }
 
-    StreamSenderCan sender_ {&g_service, ifCan_.get(), node_};
+    StreamSenderCan sender_ {&g_service, ifCan_.get()};
     /// Temporary storage of externally owned payload.
     vector<std::unique_ptr<string>> ownedPayload_;
 };
@@ -118,7 +118,7 @@ TEST_F(StreamSenderTest, initiate)
     clear_expect(true);
     EXPECT_EQ(StreamSender::IDLE, sender_.get_state());
     expect_packet(":X19CC822AN0225FFFF0000AAFF;");
-    sender_.start_stream(other_handle(), 0xaa);
+    sender_.start_stream(node_, other_handle(), 0xaa);
     wait();
     EXPECT_EQ(StreamSender::INITIATING, sender_.get_state());
 }
@@ -128,7 +128,7 @@ TEST_F(StreamSenderTest, initiate_with_bufsize)
     clear_expect(true);
     EXPECT_EQ(StreamSender::IDLE, sender_.get_state());
     expect_packet(":X19CC822AN0225EF320000AAFF;");
-    sender_.start_stream(other_handle(), 0xaa).set_proposed_window_size(0xef32);
+    sender_.start_stream(node_, other_handle(), 0xaa).set_proposed_window_size(0xef32);
     wait();
     EXPECT_EQ(StreamSender::INITIATING, sender_.get_state());
 }
@@ -137,7 +137,7 @@ TEST_F(StreamSenderTest, initiate_rejected)
 {
     clear_expect(true);
     expect_packet(":X19CC822AN0225FFFF0000AAFF;");
-    sender_.start_stream(other_handle(), 0xaa);
+    sender_.start_stream(node_, other_handle(), 0xaa);
     wait();
     EXPECT_EQ(StreamSender::INITIATING, sender_.get_state());
     // Rejects with a weird error code.

--- a/src/openlcb/StreamSender.hxx
+++ b/src/openlcb/StreamSender.hxx
@@ -97,11 +97,14 @@ public:
     /// @param dst Destination node ID to send the stream to.
     /// @param source_stream_id 8-bit stream ID to use on the this (the source)
     /// side.
+    /// @param dst_stream_id 8-bit stream ID to use on the this (the source)
+    /// side.
     ///
     /// @return *this for calling optional settings API commands.
     ///
-    StreamSenderCan &start_stream(
-        Node *src, NodeHandle dst, uint8_t source_stream_id)
+    StreamSenderCan &start_stream(Node *src, NodeHandle dst,
+        uint8_t source_stream_id,
+        uint8_t dst_stream_id = StreamDefs::INVALID_STREAM_ID)
     {
         DASSERT(state_ == IDLE);
         state_ = STARTED;
@@ -109,7 +112,7 @@ public:
         dst_ = dst;
         totalByteCount_ = 0;
         localStreamId_ = source_stream_id;
-        dstStreamId_ = 0xFF;
+        dstStreamId_ = dst_stream_id;
         HASSERT(sleeping_ == false);
         HASSERT(requestClose_ == 0);
         requestInit_ = true;

--- a/src/openlcb/StreamSender.hxx
+++ b/src/openlcb/StreamSender.hxx
@@ -556,18 +556,18 @@ private:
     IfCan *ifCan_;
     /// Which node are we sending the outgoing data from. This is a local
     /// virtual node.
-    Node *node_{nullptr};
+    Node *node_ {nullptr};
     /// Destination node that we are sending to. It is important that the alias
     /// is filled in here.
     NodeHandle dst_;
     /// How many bytes we have transmitted in this stream so far.
-    size_t totalByteCount_{0};
+    size_t totalByteCount_ {0};
     /// What state the current class is in.
     StreamSenderState state_ {IDLE};
     /// Stream ID at the source node. @todo fill in
-    uint8_t localStreamId_{StreamDefs::INVALID_STREAM_ID};
+    uint8_t localStreamId_ {StreamDefs::INVALID_STREAM_ID};
     /// Stream ID at the destination node. @todo fill in
-    uint8_t dstStreamId_{StreamDefs::INVALID_STREAM_ID};
+    uint8_t dstStreamId_ {StreamDefs::INVALID_STREAM_ID};
     /// Determines whether the stream transmission is happening to
     /// localhost. Almost never true.
     uint8_t isLoopbackStream_ : 1;
@@ -578,15 +578,15 @@ private:
     /// 1 if there is a pending initialize request.
     uint8_t requestInit_ : 1;
     /// Flags from the remote node that we got in stream initiate reply
-    uint8_t streamFlags_{0};
+    uint8_t streamFlags_ {0};
     /// More flags from the remote node that we got in stream initiate reply
-    uint8_t streamAdditionalFlags_{0};
+    uint8_t streamAdditionalFlags_ {0};
     /// Total stream window size. @todo fill in
-    uint16_t streamWindowSize_{StreamDefs::MAX_PAYLOAD};
+    uint16_t streamWindowSize_ {StreamDefs::MAX_PAYLOAD};
     /// Remaining stream window size. @todo fill in
-    uint16_t streamWindowRemaining_{0};
+    uint16_t streamWindowRemaining_ {0};
     /// When the stream process fails, this variable contains an error code.
-    uint32_t errorCode_{0};
+    uint32_t errorCode_ {0};
     /// Source of buffers for outgoing CAN frames. Limtedpool is allocating and
     /// releasing to the mainBufferPool, but blocks when we exceed a certain
     /// number of allocations until some buffers get freed.

--- a/src/openlcb/StreamSender.hxx
+++ b/src/openlcb/StreamSender.hxx
@@ -97,8 +97,8 @@ public:
     /// @param dst Destination node ID to send the stream to.
     /// @param source_stream_id 8-bit stream ID to use on the this (the source)
     /// side.
-    /// @param dst_stream_id 8-bit stream ID to use on the this (the source)
-    /// side.
+    /// @param dst_stream_id 8-bit stream ID to use on the remote side (the
+    /// destination).
     ///
     /// @return *this for calling optional settings API commands.
     ///

--- a/src/openlcb/StreamSender.hxx
+++ b/src/openlcb/StreamSender.hxx
@@ -199,6 +199,18 @@ public:
         return errorCode_;
     }
 
+    /// @return the stream SID (identifier on this node).
+    uint8_t get_src_stream_id()
+    {
+        return localStreamId_;
+    }
+
+    /// @return the stream DID (identifier on the receiving node).
+    uint8_t get_dst_stream_id()
+    {
+        return dstStreamId_;
+    }
+
     /// Start of state machine, called when a buffer of data to send arrives
     /// from the application layer.
     Action entry()
@@ -325,14 +337,14 @@ private:
         {
             if (streamFlags_ & StreamDefs::FLAG_PERMANENT_ERROR)
             {
-                return return_error(
-                    DatagramDefs::PERMANENT_ERROR | streamAdditionalFlags_,
+                return return_error(DatagramDefs::PERMANENT_ERROR |
+                        (streamFlags_ << 8) | streamAdditionalFlags_,
                     "Stream initiate request was denied (permanent error).");
             }
             else
             {
-                return return_error(
-                    Defs::ERROR_TEMPORARY | streamAdditionalFlags_,
+                return return_error(Defs::ERROR_TEMPORARY |
+                        (streamFlags_ << 8) | streamAdditionalFlags_,
                     "Stream initiate request was denied (temporary error).");
             }
         }

--- a/src/openlcb/StreamSender.hxx
+++ b/src/openlcb/StreamSender.hxx
@@ -126,7 +126,11 @@ public:
     }
 
     /// Closes the stream when all the bytes are transferred.
-    void close_stream()
+    /// @param error_code 0 upon success. This code is intended to be
+    /// transferred in the stream close message, but that is not yet
+    /// implemented, because the draft protocol does not have provisions for
+    /// an error code at close.
+    void close_stream(uint16_t error_code = 0)
     {
         requestClose_ = true;
         trigger();
@@ -254,7 +258,7 @@ private:
         b->data()->reset(Defs::MTI_STREAM_INITIATE_REQUEST, node_->node_id(),
             dst_,
             StreamDefs::create_initiate_request(
-                streamWindowSize_, false, localStreamId_));
+                streamWindowSize_, false, localStreamId_, dstStreamId_));
 
         node_->iface()->dispatcher()->register_handler(
             &streamInitiateReplyHandler_, Defs::MTI_STREAM_INITIATE_REPLY,

--- a/src/openlcb/StreamTransport.cxx
+++ b/src/openlcb/StreamTransport.cxx
@@ -47,7 +47,8 @@ StreamTransport::StreamTransport(If *iface)
 }
 
 StreamTransport::~StreamTransport()
-{ }
+{
+}
 
 StreamTransportCan::StreamTransportCan(IfCan *iface, unsigned num_senders)
     : StreamTransport(iface)
@@ -59,6 +60,7 @@ StreamTransportCan::StreamTransportCan(IfCan *iface, unsigned num_senders)
 }
 
 StreamTransportCan::~StreamTransportCan()
-{ }
+{
+}
 
 } // namespace openlcb

--- a/src/openlcb/StreamTransport.cxx
+++ b/src/openlcb/StreamTransport.cxx
@@ -1,0 +1,64 @@
+/** \copyright
+ * Copyright (c) 2022, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file StreamTransport.cxx
+ *
+ * Interface for stream functionality attached to an OpenLCB interface.
+ *
+ * @author Balazs Racz
+ * @date 20 Dec 2022
+ */
+
+#include "openlcb/StreamTransport.hxx"
+
+#include "openlcb/StreamSender.hxx"
+
+namespace openlcb
+{
+
+StreamTransport::StreamTransport(If *iface)
+    : inUseSendStreamIds_(0)
+    , nextSendStreamId_(0)
+{
+    iface->set_stream_transport(this);
+}
+
+StreamTransport::~StreamTransport()
+{ }
+
+StreamTransportCan::StreamTransportCan(IfCan *iface, unsigned num_senders)
+    : StreamTransport(iface)
+{
+    for (unsigned i = 0; i < num_senders; ++i)
+    {
+        senders_.typed_insert(new StreamSenderCan(iface, iface));
+    }
+}
+
+StreamTransportCan::~StreamTransportCan()
+{ }
+
+} // namespace openlcb

--- a/src/openlcb/StreamTransport.cxxtest
+++ b/src/openlcb/StreamTransport.cxxtest
@@ -8,7 +8,7 @@ namespace openlcb
 class StreamTransportTest : public AsyncNodeTest
 {
 protected:
-    StreamTransportCan t_{ifCan_.get(), 2};
+    StreamTransportCan t_ {ifCan_.get(), 2};
 
     std::vector<uint8_t> get_stream_ids(unsigned count)
     {
@@ -44,6 +44,5 @@ TEST_F(StreamTransportTest, registered)
 {
     EXPECT_EQ(&t_, ifCan_->stream_transport());
 }
-
 
 } // namespace openlcb

--- a/src/openlcb/StreamTransport.cxxtest
+++ b/src/openlcb/StreamTransport.cxxtest
@@ -8,7 +8,7 @@ namespace openlcb
 class StreamTransportTest : public AsyncNodeTest
 {
 protected:
-    StreamTransportCan t_{ifCan_.get(), 1};
+    StreamTransportCan t_{ifCan_.get(), 2};
 
     std::vector<uint8_t> get_stream_ids(unsigned count)
     {
@@ -34,5 +34,16 @@ TEST_F(StreamTransportTest, send_id)
         ::testing::ElementsAre(20, 21, 22, 23, 24, 25, 26, 10, 12, 14));
     EXPECT_THAT(get_stream_ids(3), ::testing::ElementsAre(255, 255, 255));
 }
+
+TEST_F(StreamTransportTest, allocate_sender)
+{
+    EXPECT_EQ(2u, t_.sender_allocator()->pending());
+}
+
+TEST_F(StreamTransportTest, registered)
+{
+    EXPECT_EQ(&t_, ifCan_->stream_transport());
+}
+
 
 } // namespace openlcb

--- a/src/openlcb/StreamTransport.cxxtest
+++ b/src/openlcb/StreamTransport.cxxtest
@@ -1,0 +1,38 @@
+#include "openlcb/StreamTransport.hxx"
+
+#include "utils/async_datagram_test_helper.hxx"
+
+namespace openlcb
+{
+
+class StreamTransportTest : public ::testing::Test
+{
+protected:
+    StreamTransport t_;
+
+    std::vector<uint8_t> get_stream_ids(unsigned count)
+    {
+        std::vector<uint8_t> ret;
+        for (unsigned i = 0; i < count; ++i)
+        {
+            ret.push_back(t_.get_send_stream_id());
+        }
+        return ret;
+    }
+};
+
+TEST_F(StreamTransportTest, send_id)
+{
+    EXPECT_THAT(get_stream_ids(10),
+        ::testing::ElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
+    EXPECT_THAT(get_stream_ids(10),
+        ::testing::ElementsAre(10, 11, 12, 13, 14, 15, 16, 17, 18, 19));
+    t_.release_send_stream_id(10);
+    t_.release_send_stream_id(12);
+    t_.release_send_stream_id(14);
+    EXPECT_THAT(get_stream_ids(10),
+        ::testing::ElementsAre(20, 21, 22, 23, 24, 25, 26, 10, 12, 14));
+    EXPECT_THAT(get_stream_ids(3), ::testing::ElementsAre(255, 255, 255));
+}
+
+} // namespace openlcb

--- a/src/openlcb/StreamTransport.cxxtest
+++ b/src/openlcb/StreamTransport.cxxtest
@@ -5,10 +5,10 @@
 namespace openlcb
 {
 
-class StreamTransportTest : public ::testing::Test
+class StreamTransportTest : public AsyncNodeTest
 {
 protected:
-    StreamTransport t_;
+    StreamTransportCan t_{ifCan_.get(), 1};
 
     std::vector<uint8_t> get_stream_ids(unsigned count)
     {

--- a/src/openlcb/StreamTransport.hxx
+++ b/src/openlcb/StreamTransport.hxx
@@ -1,0 +1,94 @@
+/** \copyright
+ * Copyright (c) 2022, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file StreamTransport.hxx
+ *
+ * Interface for stream functionality attached to an OpenLCB interface.
+ *
+ * @author Balazs Racz
+ * @date 20 Dec 2022
+ */
+
+#ifndef _OPENLCB_STREAMTRANSPORT_HXX_
+#define _OPENLCB_STREAMTRANSPORT_HXX_
+
+#include "utils/Destructable.hxx"
+
+#include <inttypes.h>
+
+namespace openlcb
+{
+
+/// Collects the objects needed to support streams on an OpenLCB interface.
+class StreamTransport : public Destructable
+{
+public:
+    StreamTransport()
+        : inUseSendStreamIds_(0)
+        , nextSendStreamId_(0)
+    { }
+
+    /// @return an unused transmit stream source ID. If all transmit stream
+    /// source IDs are in use, then returns 0xFF (which is an invalid stream
+    /// ID).
+    uint8_t get_send_stream_id()
+    {
+        int ret = -1;
+        for (int i = 0; i < MAX_SEND_STREAM_ID && ret < 0; ++i)
+        {
+            if ((inUseSendStreamIds_ & (1u << nextSendStreamId_)) == 0)
+            {
+                ret = nextSendStreamId_;
+                inUseSendStreamIds_ |= (1u << nextSendStreamId_);
+            }
+            if (++nextSendStreamId_ > MAX_SEND_STREAM_ID)
+            {
+                nextSendStreamId_ = 0;
+            }
+        }
+        return ret & 0xFF;
+    }
+
+    /// @param stream_id a transmit stream source ID which was previously
+    /// allocated using { \link get_send_stream_id } and no longer used.
+    void release_send_stream_id(uint8_t stream_id)
+    {
+        inUseSendStreamIds_ &= ~(1u << stream_id);
+    }
+
+private:
+    /// Largest stream ID we will be using for transmit stream's local IDs.
+    static constexpr uint8_t MAX_SEND_STREAM_ID = 26;
+    /// Bits are 1 if the respective stream ID is in use (for transmit
+    /// streams).
+    unsigned inUseSendStreamIds_ : 27;
+    /// Index of the next bit to check in the inUseSendStreamIds_.
+    unsigned nextSendStreamId_ : 5;
+};
+
+} // namespace openlcb
+
+#endif // _OPENLCB_STREAMTRANSPORT_HXX_

--- a/src/openlcb/StreamTransport.hxx
+++ b/src/openlcb/StreamTransport.hxx
@@ -53,7 +53,7 @@ class StreamTransport : public Destructable
 public:
     /// Constructor.
     ///
-    /// @param if OpenLCB interface object.
+    /// @param iface OpenLCB interface object.
     StreamTransport(If *iface);
 
     /// Destructor.

--- a/src/openlcb/sources
+++ b/src/openlcb/sources
@@ -45,6 +45,7 @@ CXXSRCS += \
            SimpleNodeInfoMockUserFile.cxx \
            SimpleStack.cxx \
            StreamReceiver.cxx \
+           StreamTransport.cxx \
            TractionTestTrain.cxx \
            TractionProxy.cxx \
            TcpDefs.cxx \

--- a/src/utils/ByteBuffer.hxx
+++ b/src/utils/ByteBuffer.hxx
@@ -146,6 +146,25 @@ struct ByteChunk
         return len;
     }
 
+    /// @return the place where data can be written to append to this buffer.
+    /// Requirement: this chunk must be a data source, and there has to be an
+    /// ownedData_ set.
+    uint8_t *append_ptr()
+    {
+        HASSERT(ownedData_.get());
+        uint8_t *end = data_ + size_;
+        return end;
+    }
+
+    /// Notifies that a certain number of bytes have been appended, i.e.,
+    /// written into append_ptr().
+    /// Requirement: this chunk must be a data source, and there has to be an
+    /// ownedData_ set.
+    void append_complete(size_t len)
+    {
+        size_ += len;
+    }
+
     /// @return how many free bytes are there in the underlying raw
     /// buffer. This shall only be used by the source (who set ownedData_ to a
     /// real raw buffer), and assumes that all bytes beyond the end are

--- a/src/utils/CanIf.hxx
+++ b/src/utils/CanIf.hxx
@@ -222,7 +222,7 @@ public:
     {
         return &frameReadFlow_;
     }
-    
+
 private:
     friend class CanFrameWriteFlow;
     // friend class CanFrameReadFlow;

--- a/src/utils/CanIf.hxx
+++ b/src/utils/CanIf.hxx
@@ -216,6 +216,13 @@ public:
         return &frameWriteFlow_;
     }
 
+    /// @returns the flow for writing CAN frames for localhost (as if they came
+    /// from the bus).
+    OutgoingFrameHandler *loopback_frame_write_flow()
+    {
+        return &frameReadFlow_;
+    }
+    
 private:
     friend class CanFrameWriteFlow;
     // friend class CanFrameReadFlow;

--- a/src/utils/OpenSSLAesCcm.cxxtest
+++ b/src/utils/OpenSSLAesCcm.cxxtest
@@ -1,30 +1,6 @@
 #include "utils/test_main.hxx"
 #include "utils/OpenSSLAesCcm.hxx"
 
-
-int nibble_to_int(char n) {
-    if ('0' <= n && n <= '9') {
-        return n - '0';
-    }
-    if ('a' <= n && n <= 'f') {
-        return n - 'a'+ 10;
-    }
-    if ('A' <= n && n <= 'F') {
-        return n - 'A'+ 10;
-    }
-    DIE("Unknown nibble arrived.");
-}
-  
-std::string hex2str(const char* hex) {
-    std::string ret;
-    while (*hex && *(hex+1)) {
-        ret.push_back((nibble_to_int(*hex) << 4) |
-                      (nibble_to_int(*(hex+1))));
-        hex += 2;
-    }
-    return ret;
-}
-
 void get_example(int index, string& Key, string& Nonce, string& Adata, string& Payload, string& CT) {
 #include "utils/AesCcmTestVectors.hxx"
 }

--- a/src/utils/async_stream_test_helper.hxx
+++ b/src/utils/async_stream_test_helper.hxx
@@ -1,0 +1,67 @@
+#include "utils/async_datagram_test_helper.hxx"
+#include "openlcb/StreamReceiver.hxx"
+
+namespace openlcb
+{
+
+static constexpr uint8_t LOCAL_STREAM_ID = 0x3a;
+static constexpr uint8_t SRC_STREAM_ID = 0xa7;
+
+/// Generates some deterministic data to send via streams.
+string get_payload_data(size_t length)
+{
+    string r(length, 0);
+    for (size_t i = 0; i < length; ++i)
+    {
+        r[i] = i & 0xff;
+    }
+    return r;
+}
+
+/// Helper class that acts as a data sink for a stream receiver. This class
+/// collects the bytes in a string. By default the stream is unthrottled (all
+/// buffers are immediately freed), but there are provisions to let the test
+/// manually drive how fast the incoming data buffers get freed.
+struct CollectData : public ByteSink
+{
+    /// Bytes that arrived so far.
+    string data;
+    /// Holds buffers.
+    Q q;
+    /// if true, the buffers are added to the queue instead of unref'ed.
+    bool keepBuffers_ {false};
+
+    void send(ByteBuffer *msg, unsigned prio) override
+    {
+        auto rb = get_buffer_deleter(msg);
+        data.append((char *)msg->data()->data_, msg->data()->size());
+        if (keepBuffers_)
+        {
+            q.insert(msg->ref());
+        }
+    }
+
+    /// Takes a single element from the queue, and releases it.
+    string qtake()
+    {
+        ByteBuffer *b = (ByteBuffer *)q.next(0);
+        HASSERT(b != nullptr);
+        string ret((char *)b->data()->data_, b->data()->size());
+        b->unref();
+        return ret;
+    }
+};
+
+class StreamTestBase : public TwoNodeDatagramTest
+{
+protected:
+    StreamTestBase()
+    {
+        mainBufferPool->alloc(&recvRequest_);
+    }
+
+    BufferPtr<StreamReceiveRequest> recvRequest_;
+    CollectData sink_;
+};
+
+} // namespace openlcb

--- a/src/utils/test_main.hxx
+++ b/src/utils/test_main.hxx
@@ -412,7 +412,8 @@ std::string hex2str(const char *hex)
     std::string ret;
     while (*hex && *(hex + 1))
     {
-        if (*hex == ' ') {
+        if (*hex == ' ')
+        {
             ++hex;
             continue;
         }
@@ -429,10 +430,12 @@ const char HEXCHR[17] = "0123456789abcdef";
 /// @param s Arbitrary byte payload.
 /// @return string containing two hex digits per incoming byte, with the
 /// respective value..
-std::string str2hex(const string& s) {
+std::string str2hex(const string &s)
+{
     std::string ret;
-    for (char c : s) {
-        ret.push_back(HEXCHR[c>>4]);
+    for (char c : s)
+    {
+        ret.push_back(HEXCHR[c >> 4]);
         ret.push_back(HEXCHR[c & 0xf]);
     }
     return ret;

--- a/src/utils/test_main.hxx
+++ b/src/utils/test_main.hxx
@@ -381,4 +381,61 @@ private:
     std::unique_ptr<HolderBase> holder_;
 };
 
+/// Converts a character containing a hex digit to the value of that digit.
+///
+/// @param n character with lower or upper case hex digit.
+///
+/// @return int value of that digit.
+int nibble_to_int(char n)
+{
+    if ('0' <= n && n <= '9')
+    {
+        return n - '0';
+    }
+    if ('a' <= n && n <= 'f')
+    {
+        return n - 'a' + 10;
+    }
+    if ('A' <= n && n <= 'F')
+    {
+        return n - 'A' + 10;
+    }
+    DIE("Unknown nibble arrived.");
+}
+
+/// Converts a hex string into the respective byte string.
+/// @param hex a string containing hex digits. Separators between hex bytes are
+/// allowed and ignored.
+/// @return string containing bytes respective to the hex.
+std::string hex2str(const char *hex)
+{
+    std::string ret;
+    while (*hex && *(hex + 1))
+    {
+        if (*hex == ' ') {
+            ++hex;
+            continue;
+        }
+        ret.push_back((nibble_to_int(*hex) << 4) | (nibble_to_int(*(hex + 1))));
+        hex += 2;
+    }
+    return ret;
+}
+
+const char HEXCHR[17] = "0123456789abcdef";
+
+/// Converts a byte string into the hexadecimal representation, with no
+/// separators.
+/// @param s Arbitrary byte payload.
+/// @return string containing two hex digits per incoming byte, with the
+/// respective value..
+std::string str2hex(const string& s) {
+    std::string ret;
+    for (char c : s) {
+        ret.push_back(HEXCHR[c>>4]);
+        ret.push_back(HEXCHR[c & 0xf]);
+    }
+    return ret;
+}
+
 #endif // _UTILS_TEST_MAIN_HXX_


### PR DESCRIPTION
The new stream-related functionality is factored out into separate classes such that it is possible to link against OpenMRN without including the code size impact of streams.

- Refactors the MemoryConfigHandler into a base class with a bunch of utilities and the actual command handlers.
- Adds an alternate child class with the command handler for stream reads.
- Registers the alternate implementation with the base handler and forwards the stream read/write commands to it.
- Creates a new class StreamTransport which will be available as a pointer from the If* object. This is optional to instantiate, and keeps the stream-related objects of the interface.
- Adds an async allocator to StreamTransport to acquire stream sender objects. This is similar to how DatagramService deals with datagram send clients.
- Makes stream sender and receiver not be tied to a Node* object, but only to an If* object. The node_ is then taken only when the transmit/receive is invoked. This makes it possible to operate with a single stream sender/receiver across multiple virtual nodes.
- Adds APIs for specifying and querying the stream dst IDs on/from the StreamSender.
- Adds ability to send a CAN frame to the local interface (as if it came from the network).
- Updates Stream Sender to be able to send streams to localhost (either same or different virtual node). This uses the frame loopback functionality of CanIf.
- Ignores loopback stream data packets when checking for alias conflicts.
- fixed bug in alias conflict handler which misinterpreted a stream frame as a CID frame.
- Expands byte buffer API for direct (zero-copy) appends.
- Updates stream initiate response error flags to match the error codes of other standards. This needs to be brought into the draft text as well.
- creates async_stream_test_helper.hxx with refactoring some of the common classes from the stream receive test.