### PR TITLE
Makes the PWM interface compatible with constexpr.

### DIFF
--- a/src/freertos_drivers/common/PWM.hxx
+++ b/src/freertos_drivers/common/PWM.hxx
@@ -83,15 +83,14 @@ public:
 
 protected:
     /// Constructor.
-    PWM()
-    {
-    }
+    constexpr PWM() = default;
 
-    /// Destructor.
-    ~PWM()
-    {
-    }
-
+    /// Destructor. This is protected, because only child classes should be
+    /// allowed to destruct a PWM; but no implementation exists in order to
+    /// make the the destructor trivial for C++. A trivial destructor is
+    /// required for a constexpr class.
+    ~PWM() = default;
+    
 private:
 
     DISALLOW_COPY_AND_ASSIGN(PWM);


### PR DESCRIPTION
Similar to GPIO classes, we often have many PWM objects allocated for multi-channel output use-cases. By making PWM interface compatible with constexpr, we allow for implementations to build these definitions into read-only memory (flash), reducing the RAM footprint of a multi-channel PWM device.

There are specific requirements for making a class constexpr in C++11, and the base classes have to comply with them as well. This PR makes the PWM base class comply with these requirements.