### PR TITLE
Stores the last offset in the configuration space when generating the XML.

### DIFF
--- a/src/openlcb/CompileCdiMain.cxx
+++ b/src/openlcb/CompileCdiMain.cxx
@@ -42,6 +42,8 @@ void render_cdi_helper(const CdiType &t, string ns, string name)
         printf("extern const size_t %s_SIZE;\n", name.c_str());
         printf("const size_t %s_SIZE = sizeof(%s_DATA);\n", name.c_str(),
             name.c_str());
+        printf("const size_t %s_END_OFFSET = %u;\n", name.c_str(),
+               (unsigned)t.end_offset());
         printf("\n}  // namespace %s\n\n", ns.c_str());
     }
 }


### PR DESCRIPTION
This is helpful in determining how much eeprom space is needed for a given project. The developer just has to check the cdi.xmlout file.

(note: this is not the byte size of the XML, but the byte size of the config represented by it.)