### PR TITLE
Fix build of Arduino STM32 CAN driver.

### DIFF
--- a/src/freertos_drivers/st/Stm32Can.cxx
+++ b/src/freertos_drivers/st/Stm32Can.cxx
@@ -145,7 +145,7 @@ int Stm32Can::ioctl(File *file, unsigned long int key, unsigned long data)
     }
     return -EINVAL;
 }
-#endif
+#endif // !ARDUINO
 
 /** Enable use of the device.
  */

--- a/src/freertos_drivers/st/Stm32Can.cxx
+++ b/src/freertos_drivers/st/Stm32Can.cxx
@@ -132,6 +132,7 @@ Stm32Can::Stm32Can(const char *name)
 #endif
 }
 
+#ifndef ARDUINO
 //
 // Stm32Can::ioctl()
 //
@@ -144,6 +145,7 @@ int Stm32Can::ioctl(File *file, unsigned long int key, unsigned long data)
     }
     return -EINVAL;
 }
+#endif
 
 /** Enable use of the device.
  */

--- a/src/freertos_drivers/st/Stm32Can.hxx
+++ b/src/freertos_drivers/st/Stm32Can.hxx
@@ -72,13 +72,15 @@ public:
     static Stm32Can *instances[1];
 
 private:
+#ifndef ARDUINO    
     /// Request an ioctl transaction.
     /// @param file file reference for this device
     /// @param key ioctl key
     /// @param data key data
     /// @return >= 0 upon success, -errno upon failure
     int ioctl(File *file, unsigned long int key, unsigned long data) override;
-
+#endif
+    
     void enable() override; /**< function to enable device */
     void disable() override; /**< function to disable device */
     void tx_msg() override; /**< function to try and transmit a message */


### PR DESCRIPTION
It was broken by #644 which added a new feature for which there is no API on the Arduino.