### PR TITLE
Eliminates b'' from the revision strings.

### DIFF
--- a/bin/revision.py
+++ b/bin/revision.py
@@ -103,7 +103,7 @@ for x in inputs :
 
     # get the short hash
     git_hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'])
-    git_hash = str(git_hash[:7])
+    git_hash = str(git_hash[:7].decode())
 
     # get the dirty flag
     dirty = os.system('git diff --quiet')


### PR DESCRIPTION
The data parsed from the git output was rteated as a byte array by python. Doing str() on a byte array gives b'1234567'. By doing decode() on the byte array we turn it into a string and this liminates the unneeded quotation marks.