### PR TITLE
Adds STM32 RailcomDriver

### DIFF
--- a/boards/armv7m/target.ld
+++ b/boards/armv7m/target.ld
@@ -8,7 +8,7 @@ INCLUDE memory_map.ld
 
 __top_RAM = ORIGIN(RAM) + LENGTH(RAM);
 
-__cs3_heap_end = __top_RAM;
+__cs3_heap_end = __top_RAM - 1024;
 
 __start_ram = ORIGIN(RAM);
 __end_ram = __top_RAM;
@@ -41,6 +41,8 @@ SECTIONS
         __bss_section_table = .;
         LONG(    ADDR(.bss));
         LONG(  SIZEOF(.bss));
+        LONG(__cs3_heap_end);
+        LONG(__top_RAM - __cs3_heap_end - 64);
         __bss_section_table_end = .;
         __section_table_end = . ;
         /* End of Global Section Table */

--- a/src/dcc/RailcomBroadcastDecoder.cxx
+++ b/src/dcc/RailcomBroadcastDecoder.cxx
@@ -68,13 +68,17 @@ bool RailcomBroadcastDecoder::process_data(const uint8_t *data, unsigned size)
     for (unsigned i = 0; i < size; ++i)
     {
         if (railcom_decode[data[i]] == RailcomDefs::INV)
+        {
             return true; // garbage.
+        }
     }
     /// TODO(balazs.racz) if we have only one byte in ch1 but we have a second
     /// byte in ch2, we should still process those because it might be a
     /// misaligned window.
     if (size < 2)
-        return true; // Dunno what this is.a
+    {
+        return true; // Dunno what this is.
+    }
     uint8_t type = (dcc::railcom_decode[data[0]] >> 2);
     if (size == 2)
     {
@@ -84,17 +88,29 @@ bool RailcomBroadcastDecoder::process_data(const uint8_t *data, unsigned size)
         switch (type)
         {
             case dcc::RMOB_ADRLOW:
-                if (currentL_ == payload) {
-                    if (countL_ < MAX_REPEAT_COUNT) countL_ += 2;
-                } else {
+                if (currentL_ == payload)
+                {
+                    if (countL_ < MIN_EMPTY_COUNT)
+                    {
+                        countL_ += 2;
+                    }
+                }
+                else
+                {
                     currentL_ = payload;
                     countL_ = 0;
                 }
                 break;
             case dcc::RMOB_ADRHIGH:
-                if (currentH_ == payload) {
-                    if (countH_ < MAX_REPEAT_COUNT) countH_ += 2;
-                } else {
+                if (currentH_ == payload)
+                {
+                    if (countH_ < MIN_EMPTY_COUNT)
+                    {
+                        countH_ += 2;
+                    }
+                }
+                else
+                {
                     currentH_ = payload;
                     countH_ = 0;
                 }
@@ -102,7 +118,9 @@ bool RailcomBroadcastDecoder::process_data(const uint8_t *data, unsigned size)
             default:
                 return false; // This is something we don't know about.
         }
-        if (countL_ >= MIN_REPEAT_COUNT && countH_ >= MIN_REPEAT_COUNT) {
+        if (countL_ >= (MIN_REPEAT_COUNT * 2) &&
+            countH_ >= (MIN_REPEAT_COUNT * 2))
+        {
             currentAddress_ = (uint16_t(currentH_) << 8) | currentL_;
         }
         return true;

--- a/src/dcc/RailcomBroadcastDecoder.hxx
+++ b/src/dcc/RailcomBroadcastDecoder.hxx
@@ -91,10 +91,10 @@ private:
     
     /// How many times we shall get the same data out of railcom before we
     /// believe it and report to the bus.
-    static const uint8_t MIN_REPEAT_COUNT = 6;
-    /// Maximum number of repeats we remember. This is how many empty packets
-    /// we need to forget the current address when we're getting empty packets.
-    static const uint8_t MAX_REPEAT_COUNT = 8;
+    static const uint8_t MIN_REPEAT_COUNT = 3;
+    /// This is how many empty packets we need to forget the current address
+    /// when we're getting empty packets.
+    static const uint8_t MIN_EMPTY_COUNT = 8;
 
     uint8_t currentH_; ///< last received high address bits
     uint8_t currentL_; ///< last received low address bits

--- a/src/dcc/RailcomBroadcastDecoder.hxx
+++ b/src/dcc/RailcomBroadcastDecoder.hxx
@@ -86,9 +86,15 @@ private:
     /// bytes arethere to decode. @return dunno.
     bool process_data(const uint8_t *data, unsigned size);
 
+    /// Notifies the state machine that there is no occupancy detected.
+    void notify_empty();
+    
     /// How many times we shall get the same data out of railcom before we
     /// believe it and report to the bus.
-    static const uint8_t REPEAT_COUNT = 3;
+    static const uint8_t MIN_REPEAT_COUNT = 6;
+    /// Maximum number of repeats we remember. This is how many empty packets
+    /// we need to forget the current address when we're getting empty packets.
+    static const uint8_t MAX_REPEAT_COUNT = 8;
 
     uint8_t currentH_; ///< last received high address bits
     uint8_t currentL_; ///< last received low address bits

--- a/src/dcc/RailcomPortDebug.hxx
+++ b/src/dcc/RailcomPortDebug.hxx
@@ -214,14 +214,17 @@ public:
     RailcomToOpenLCBDebugProxy(dcc::RailcomHubFlow *parent, Node *node,
         dcc::RailcomHubPort *occupancy_port, bool ch1_enabled = true,
         bool ack_enabled = true)
-        : dcc::RailcomHubPort(parent->service())
+        : dcc::RailcomHubPort(node->iface())
         , parent_(parent)
         , node_(node)
         , occupancyPort_(occupancy_port)
         , ch1Enabled_(ch1_enabled)
         , ackEnabled_(ack_enabled)
     {
-        parent_->register_port(this);
+        if (parent_)
+        {
+            parent_->register_port(this);
+        }
     }
 
     RailcomToOpenLCBDebugProxy(Node *node)

--- a/src/dcc/RailcomPortDebug.hxx
+++ b/src/dcc/RailcomPortDebug.hxx
@@ -36,6 +36,7 @@
 #define _DCC_RAILCOMPORTDEBUG_HXX
 
 #include "dcc/RailcomHub.hxx"
+#include "utils/LimitedPool.hxx"
 
 namespace dcc
 {
@@ -254,11 +255,15 @@ public:
         {
             return release_and_exit();
         }
+        if (outputPool_.free_items() == 0)
+        {
+            return release_and_exit();
+        }
         if (message()->data()->ch1Size && ch1Enabled_)
         {
             return allocate_and_call(
                 node_->iface()->global_message_write_flow(),
-                STATE(ch1_msg_allocated));
+                STATE(ch1_msg_allocated), &outputPool_);
         }
         else
         {
@@ -285,13 +290,14 @@ public:
     Action maybe_send_ch2()
     {
         if (message()->data()->ch2Size &&
+            outputPool_.free_items() != 0 &&
             (ackEnabled_ ||
                 dcc::railcom_decode[message()->data()->ch2Data[0]] !=
                     dcc::RailcomDefs::ACK))
         {
             return allocate_and_call(
                 node_->iface()->global_message_write_flow(),
-                STATE(ch2_msg_allocated));
+                STATE(ch2_msg_allocated), &outputPool_);
         }
         else
         {
@@ -318,6 +324,7 @@ public:
     dcc::RailcomHubFlow *parent_{nullptr};
     Node *node_;
     dcc::RailcomHubPort *occupancyPort_;
+    LimitedPool outputPool_{sizeof(Buffer<openlcb::GenMessage>), 20};
     /// True if we should transmit channel1 data.
     uint8_t ch1Enabled_ : 1;
     /// True if we should transmit data that starts with an ACK.

--- a/src/freertos_drivers/common/RailcomImpl.hxx
+++ b/src/freertos_drivers/common/RailcomImpl.hxx
@@ -57,9 +57,8 @@
 #ifndef _FREERTOS_DRIVERS_COMMON_RAILCOMIMPL_HXX_
 #define _FREERTOS_DRIVERS_COMMON_RAILCOMIMPL_HXX_
 
-#include "TivaDCC.hxx"  // for FixedQueue
-
 #include "freertos_drivers/common/RailcomDriver.hxx"
+#include "freertos_drivers/common/FixedQueue.hxx"
 #include "dcc/RailCom.hxx"
 
 /*

--- a/src/freertos_drivers/common/libatomic.c
+++ b/src/freertos_drivers/common/libatomic.c
@@ -46,6 +46,18 @@
 /// Restores the interrupte enable flag from a register.
 #define REL_LOCK() __asm volatile(" msr PRIMASK, %0\n " : : "r"(_pastlock));
 
+/// __atomic_fetch_add_1
+///
+/// This function is needed for GCC-generated code.
+uint8_t __atomic_fetch_add_1(uint8_t *ptr, uint8_t val, int memorder)
+{
+    ACQ_LOCK();
+    uint16_t ret = *ptr;
+    *ptr += val;
+    REL_LOCK();
+    return ret;
+}
+
 /// __atomic_fetch_sub_2
 ///
 /// This function is needed for GCC-generated code.

--- a/src/freertos_drivers/st/Stm32Gpio.hxx
+++ b/src/freertos_drivers/st/Stm32Gpio.hxx
@@ -88,6 +88,12 @@ template <uint32_t GPIOx, uint16_t PIN, uint8_t PIN_NUM> struct Stm32GpioDefs
         return port()->IDR & pin();
     }
 
+    /// Changes the output pin level.
+    static void toggle()
+    {
+        set(!get());
+    }
+    
     /// @return a os-indepentent Gpio abstraction instance for use in
     /// libraries.
     static constexpr const Gpio *instance()

--- a/src/freertos_drivers/st/Stm32Railcom.hxx
+++ b/src/freertos_drivers/st/Stm32Railcom.hxx
@@ -24,45 +24,20 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * \file TivaRailcom.hxx
+ * \file Stm32Railcom.hxx
  *
- * Device driver for TivaWare to read one or more UART inputs for railcom data.
- *
- * usage:
- *
- * struct MyRailcomPins {
- *   // add all definitions from the example RailcomHw here
- * };
- * // Some definitions need to go outside of the class.
- * // no need for attribute weak if this is in a .cxx file.
- * const uint32_t MyRailcomPins::UART_BASE[] __attribute__((weak)) = {...};
- * ...
- *
- * TivaRailcomDriver<MyrailcomPins> railcom_driver("/dev/railcom");
- *
- * // assuming you put OS_INTERRRUPT = INT_UART3 into the structure.
- * void uart3_interrupt_handler() {
- *    railcom_driver.os_interrrupt();
- * }
- *
- * Then open /dev/railcom and read dcc::Feedback structures from it. Each read
- * much be exactly sizeof(dcc::Feedback) length. If there are no more packets to
- * read, you'll get return=0, errno==EAGAIN. Add an ioctl CAN_READ_ACTIVE to
- * get a notification when there is something to read.
+ * Device driver for STM32 chips to read one or more UART inputs for railcom
+ * data.
  *
  * @author Balazs Racz
- * @date 6 Jan 2015
+ * @date 6 Mar 2023
  */
 
-#ifndef _FREERTOS_DRIVERS_TI_TIVARAILCOM_HXX_
-#define _FREERTOS_DRIVERS_TI_TIVARAILCOM_HXX_
+#ifndef _FREERTOS_DRIVERS_ST_STM32RAILCOM_HXX_
+#define _FREERTOS_DRIVERS_ST_STM32RAILCOM_HXX_
 
-#if (!defined(TIVADCC_TIVA)) && (!defined(TIVADCC_CC3200))
-#error must define either TIVADCC_TIVA or TIVADCC_CC3200
-#endif
 
 #include "freertos_drivers/common/RailcomImpl.hxx"
-#include "dcc/RailCom.hxx"
 
 /*
 struct RailcomHw
@@ -120,24 +95,23 @@ const uint32_t RailcomHw::UART_PERIPH[]
 __attribute__((weak)) = {SYSCTL_PERIPH_UART4, SYSCTL_PERIPH_UART3, SYSCTL_PERIPH_UART2, SYSCTL_PERIPH_UART7};
 
 */
-
-/// Railcom driver for TI Tiva-class microcontrollers using the TivaWare
-/// peripheral library.
+/// Railcom driver for STM32-class microcontrollers using the HAL middleware
+/// library.
 ///
 /// This railcom driver supports parallel polling of multiple UART channels for
 /// the railcom data. 
-template <class HW> class TivaRailcomDriver : public RailcomDriverBase<HW>
+template <class HW> class Stm32RailcomDriver : public RailcomDriverBase<HW>
 {
 public:
     /// Constructor. @param path is the device node path (e.g. "/dev/railcom0").
-    TivaRailcomDriver(const char *path)
+    Stm32RailcomDriver(const char *path)
         : RailcomDriverBase<HW>(path)
     {
         MAP_IntPrioritySet(HW::OS_INTERRUPT, configKERNEL_INTERRUPT_PRIORITY);
         MAP_IntEnable(HW::OS_INTERRUPT);
     }
 
-    ~TivaRailcomDriver()
+    ~Stm32RailcomDriver()
     {
         MAP_IntDisable(HW::OS_INTERRUPT);
     }
@@ -326,4 +300,5 @@ private:
     }
 };
 
-#endif // _FREERTOS_DRIVERS_TI_TIVARAILCOM_HXX_
+
+#endif // _FREERTOS_DRIVERS_ST_STM32RAILCOM_HXX_

--- a/src/freertos_drivers/st/Stm32Railcom.hxx
+++ b/src/freertos_drivers/st/Stm32Railcom.hxx
@@ -40,16 +40,20 @@
 
 #include "freertos_drivers/common/RailcomImpl.hxx"
 
-
 #if defined(STM32F072xB) || defined(STM32F091xC)
+#include "stm32f0xx_ll_dma.h"
 #include "stm32f0xx_ll_usart.h"
 #elif defined(STM32F103xB)
+#include "stm32f1xx_ll_dma.h"
 #include "stm32f1xx_ll_usart.h"
 #elif defined(STM32F303xC) || defined(STM32F303xE)
+#include "stm32f3xx_ll_dma.h"
 #include "stm32f3xx_ll_usart.h"
 #elif defined(STM32L431xx) || defined(STM32L432xx)
+#include "stm32l4xx_ll_dma.h"
 #include "stm32l4xx_ll_usart.h"
 #elif defined(STM32F767xx)
+#include "stm32f7xx_ll_dma.h"
 #include "stm32f7xx_ll_usart.h"
 #else
 #error Dont know what STM32 chip you have.
@@ -70,14 +74,33 @@ struct RailcomUartHandle
     };
 };
 
+/// This struct helps casting the DMA channel base addresses to the appropriate
+/// type. It can be allocated in read-only memory (flash) as a static array.
+struct RailcomDmaChannel
+{
+    union
+    {
+        /// Initialized by the constants from the processor header like
+        /// USART1_BASE.
+        uint32_t baseAddress;
+        /// Use this to access the registers.
+        DMA_Channel_TypeDef *Instance;
+    };
+};
+
 /*
 struct RailcomHw
 {
     static const uint32_t CHANNEL_COUNT = 4;
-    static const RailcomUartHandle UART_BASE[CHANNEL_COUNT];
+    static const RailcomUartHandle UART[CHANNEL_COUNT];
+
+    // If DMA channel routing is in use, that has to be set up externally
+    // (e.g. in hw_preinit).
+    static const RailcomDmaChannel DMA[CHANNEL_COUNT];
+
     // Make sure there are enough entries here for all the channels times a few
     // DCC packets.
-    static const uint32_t Q_SIZE = 16;
+    static const uint32_t Q_SIZE = 32;
 
     static const auto OS_INTERRUPT = USART2_IRQn;
 
@@ -117,19 +140,29 @@ struct RailcomHw
         if (!CH4_Pin::get()) ret |= 8;
         return ret;
     }
-}; 
+};
 
 // The weak attribute is needed if the definition is put into a header file.
-const uint32_t RailcomHw::UART_BASE[] __attribute__((weak)) = {UART4_BASE, UART3_BASE, UART2_BASE, UART7_BASE};
-const uint32_t RailcomHw::UART_PERIPH[]
-__attribute__((weak)) = {SYSCTL_PERIPH_UART4, SYSCTL_PERIPH_UART3, SYSCTL_PERIPH_UART2, SYSCTL_PERIPH_UART7};
+const uint32_t RailcomHw::UART[] __attribute__((weak)) = { USART4_BASE,
+USART1_BASE, USART3_BASE, USART2_BASE };
+
+const RailcomDmaChannel RailcomHw::DMA[] __attribute__((weak)) = {
+DMA1_Channel1_BASE, DMA1_Channel3_BASE, DMA1_Channel6_BASE, DMA1_Channel5_BASE
+};
+
+In hw_preinit(), we have this for DMA channel routing:
+    //DMA channel routing for railcom UARTs
+    MODIFY_REG(DMA1->CSELR, DMA_CSELR_C1S_Msk, DMA1_CSELR_CH1_USART4_RX);
+    MODIFY_REG(DMA1->CSELR, DMA_CSELR_C3S_Msk, DMA1_CSELR_CH3_USART1_RX);
+    MODIFY_REG(DMA1->CSELR, DMA_CSELR_C6S_Msk, DMA1_CSELR_CH3_USART3_RX);
+    MODIFY_REG(DMA1->CSELR, DMA_CSELR_C5S_Msk, DMA1_CSELR_CH3_USART2_RX);
 
 */
 /// Railcom driver for STM32-class microcontrollers using the HAL middleware
 /// library.
 ///
 /// This railcom driver supports parallel polling of multiple UART channels for
-/// the railcom data. 
+/// the railcom data.
 template <class HW> class Stm32RailcomDriver : public RailcomDriverBase<HW>
 {
 public:
@@ -141,7 +174,7 @@ public:
         SetInterruptPriority(HW::OS_INTERRUPT, configKERNEL_INTERRUPT_PRIORITY);
 #else
         SetInterruptPriority(HW::OS_INTERRUPT, 0xff);
-#endif        
+#endif
         HAL_NVIC_EnableIRQ(HW::OS_INTERRUPT);
     }
 
@@ -155,6 +188,20 @@ private:
     bool inCutout_ = false;
 
     using RailcomDriverBase<HW>::returnedPackets_;
+
+    /// @param i channel number (0..HW::NUM_CHANNEL)
+    /// @return uart hardware instance for channel i.
+    static constexpr USART_TypeDef *uart(unsigned i)
+    {
+        return HW::UART[i].Instance;
+    }
+
+    /// @param i channel number (0..HW::NUM_CHANNEL)
+    /// @return dma channel instance for channel i.
+    static constexpr DMA_Channel_TypeDef *dma_ch(unsigned i)
+    {
+        return HW::DMA[i].Instance;
+    }
 
     /// Sets a given software interrupt pending.
     /// @param int_nr interrupt number (will be HW::OS_INTERRUPT)
@@ -170,153 +217,187 @@ private:
         {
             UART_HandleTypeDef uart_handle;
             memset(&uart_handle, 0, sizeof(uart_handle));
-            uart_handle.Init.BaudRate   = 250000;
+            uart_handle.Init.BaudRate = 250000;
             uart_handle.Init.WordLength = UART_WORDLENGTH_8B;
-            uart_handle.Init.StopBits   = UART_STOPBITS_1;
-            uart_handle.Init.Parity     = UART_PARITY_NONE;
-            uart_handle.Init.HwFlowCtl  = UART_HWCONTROL_NONE;
-            uart_handle.Init.Mode       = UART_MODE_RX;
+            uart_handle.Init.StopBits = UART_STOPBITS_1;
+            uart_handle.Init.Parity = UART_PARITY_NONE;
+            uart_handle.Init.HwFlowCtl = UART_HWCONTROL_NONE;
+            uart_handle.Init.Mode = UART_MODE_RX;
             uart_handle.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_NO_INIT;
-            uart_handle.Instance = HW::UART_BASE[i].Instance;
-            HAL_UART_DeInit(&uart_handle); 
+            uart_handle.Instance = uart(i);
+            HAL_UART_DeInit(&uart_handle);
             volatile auto ret = HAL_UART_Init(&uart_handle);
             HASSERT(HAL_OK == ret);
 
             // Disables the receiver.
-            LL_USART_SetTransferDirection(
-                HW::UART_BASE[i].Instance, LL_USART_DIRECTION_NONE);
-            LL_USART_Enable(HW::UART_BASE[i].Instance);
+            LL_USART_SetTransferDirection(uart(i), LL_USART_DIRECTION_NONE);
+
+            // configure DMA
+
+            // peripheral address
+            dma_ch(i)->CPAR = (uint32_t)(&uart(i)->RDR);
+
+            // memory address and num transfers not set, these will come from
+            // each cutout.
+            // dma_ch->CMAR = (uint32_t)adcSamplesRaw_;
+            // dma_ch->CNDTR = NUM_SAMPLES * NUM_CHANNELS;
+
+            uint32_t config = LL_DMA_DIRECTION_PERIPH_TO_MEMORY |
+                LL_DMA_MODE_NORMAL | LL_DMA_PERIPH_NOINCREMENT |
+                LL_DMA_MEMORY_INCREMENT | LL_DMA_PDATAALIGN_BYTE |
+                LL_DMA_MDATAALIGN_BYTE | LL_DMA_PRIORITY_HIGH;
+            MODIFY_REG(dma_ch(i)->CCR,
+                DMA_CCR_DIR | DMA_CCR_MEM2MEM | DMA_CCR_CIRC | DMA_CCR_PINC |
+                    DMA_CCR_MINC | DMA_CCR_PSIZE | DMA_CCR_MSIZE | DMA_CCR_PL |
+                    DMA_CCR_TCIE | DMA_CCR_HTIE | DMA_CCR_TEIE,
+                config);
+
+            LL_USART_Enable(uart(i));
         }
     }
-    void disable() OVERRIDE
+    void disable() override
     {
-        for (unsigned i = 0; i < ARRAYSIZE(HW::UART_BASE); ++i)
+        for (unsigned i = 0; i < HW::CHANNEL_COUNT; ++i)
         {
-            LL_USART_Disable(HW::UART_BASE[i].Instance);
+            LL_USART_Disable(uart(i));
         }
     }
 
     // RailcomDriver interface
-    void feedback_sample() OVERRIDE {
+    void feedback_sample() override
+    {
         HW::enable_measurement(true);
         this->add_sample(HW::sample());
         HW::disable_measurement();
     }
 
-    void start_cutout() OVERRIDE
+    void start_cutout() override
     {
         HW::enable_measurement(false);
-        const bool need_ch1_cutout = HW::need_ch1_cutout() || (this->feedbackKey_ < 11000);
+        const bool need_ch1_cutout =
+            HW::need_ch1_cutout() || (this->feedbackKey_ < 11000);
         Debug::RailcomRxActivate::set(true);
         for (unsigned i = 0; i < HW::CHANNEL_COUNT; ++i)
         {
-            if (need_ch1_cutout)
+            while (LL_USART_IsActiveFlag_RXNE(uart(i)))
             {
-                LL_USART_SetTransferDirection(
-                    HW::UART_BASE[i].Instance, LL_USART_DIRECTION_RX);
+                uint8_t data = uart(i)->RDR;
+                (void)data;
             }
-            while (LL_USART_IsActiveFlag_RXNE(HW::UART_BASE[i].Instance)) {
-                uint8_t data = HW::UART_BASE[i].Instance->RDR;
-                (void) data;
+            returnedPackets_[i] = this->alloc_new_packet(i);
+            if (need_ch1_cutout && returnedPackets_[i])
+            {
+                LL_USART_EnableDMAReq_RX(uart(i));
+                LL_USART_SetTransferDirection(uart(i), LL_USART_DIRECTION_RX);
+                LL_USART_ClearFlag_FE(uart(i));
+                LL_USART_Enable(uart(i));
+
+                dma_ch(i)->CNDTR = 2;
+                dma_ch(i)->CMAR = (uint32_t)returnedPackets_[i]->ch1Data;
+                dma_ch(i)->CCR |= DMA_CCR_EN; // enable DMA
             }
-            returnedPackets_[i] = 0;
         }
         Debug::RailcomDriverCutout::set(true);
     }
 
-    void middle_cutout() OVERRIDE
+    void middle_cutout() override
     {
         Debug::RailcomDriverCutout::set(false);
         for (unsigned i = 0; i < HW::CHANNEL_COUNT; ++i)
         {
-            while (LL_USART_IsActiveFlag_RXNE(HW::UART_BASE[i].Instance))
+            if (!returnedPackets_[i])
+            {
+                continue;
+            }
+            LL_USART_Disable(uart(i));
+            CLEAR_BIT(dma_ch(i)->CCR, DMA_CCR_EN);
+            // How many bytes did we transfer?
+            returnedPackets_[i]->ch1Size = 2 - dma_ch(i)->CNDTR;
+            if (returnedPackets_[i]->ch1Size == 1)
+            {
+                Debug::RailcomError::toggle();
+            }
+            if (returnedPackets_[i]->ch1Size)
             {
                 Debug::RailcomDataReceived::toggle();
                 Debug::RailcomAnyData::set(true);
-                if (!returnedPackets_[i])
-                {
-                    returnedPackets_[i] = this->alloc_new_packet(i);
-                }
-                if (!returnedPackets_[i])
-                {
-                    break;
-                }
-                uint8_t data = HW::UART_BASE[i].Instance->RDR;
-                if (LL_USART_IsActiveFlag_FE(HW::UART_BASE[i].Instance)) {
-                    // We reset the receiver circuitry because we got an error
-                    // in channel 1. Typical cause of this error is if there
-                    // are multiple locomotives on the block (e.g. if this is
-                    // the global detector) and they talk over each other
-                    // during ch1 broadcast. There is a good likelihood that
-                    // the asynchronous receiver is out of sync with the
-                    // transmitter, but right now we should be in the
-                    // between-byte space.
-                    LL_USART_SetTransferDirection(
-                        HW::UART_BASE[i].Instance, LL_USART_DIRECTION_NONE);
-                    LL_USART_ClearFlag_FE(HW::UART_BASE[i].Instance);
-                    Debug::RailcomError::toggle();
-                    // Not a valid railcom byte.
-                    //returnedPackets_[i]->add_ch1_data(0xF8);
-                    continue;
-                }
-                returnedPackets_[i]->add_ch1_data(data);
             }
-            LL_USART_Disable(HW::UART_BASE[i].Instance);
-            LL_USART_SetTransferDirection(
-                HW::UART_BASE[i].Instance, LL_USART_DIRECTION_RX);
-            LL_USART_Enable(HW::UART_BASE[i].Instance);
+
+            if (LL_USART_IsActiveFlag_FE(uart(i)))
+            {
+                // We reset the receiver circuitry because we got an error
+                // in channel 1. Typical cause of this error is if there
+                // are multiple locomotives on the block (e.g. if this is
+                // the global detector) and they talk over each other
+                // during ch1 broadcast. There is a good likelihood that
+                // the asynchronous receiver is out of sync with the
+                // transmitter, but right now we should be in the
+                // between-byte space.
+                LL_USART_SetTransferDirection(uart(i), LL_USART_DIRECTION_NONE);
+                LL_USART_ClearFlag_FE(uart(i));
+                Debug::RailcomError::toggle();
+                // Not a valid railcom byte.
+                returnedPackets_[i]->ch1Data[0] = 0xF8;
+                returnedPackets_[i]->ch1Size = 1;
+            }
+
+            // Set up channel 2 reception with DMA.
+            dma_ch(i)->CNDTR = 6;
+            dma_ch(i)->CMAR = (uint32_t)returnedPackets_[i]->ch2Data;
+            dma_ch(i)->CCR |= DMA_CCR_EN; // enable DMA
+
+            LL_USART_SetTransferDirection(uart(i), LL_USART_DIRECTION_RX);
+            LL_USART_ClearFlag_FE(uart(i));
+            LL_USART_Enable(uart(i));
         }
         HW::middle_cutout_hook();
         Debug::RailcomDriverCutout::set(true);
     }
 
-    void end_cutout() OVERRIDE
+    void end_cutout() override
     {
         HW::disable_measurement();
         bool have_packets = false;
         for (unsigned i = 0; i < HW::CHANNEL_COUNT; ++i)
         {
-            while (LL_USART_IsActiveFlag_RXNE(HW::UART_BASE[i].Instance))
+            LL_USART_Disable(uart(i));
+            if (!returnedPackets_[i])
+            {
+                continue;
+            }
+            CLEAR_BIT(dma_ch(i)->CCR, DMA_CCR_EN);
+            // How many bytes did we transfer?
+            returnedPackets_[i]->ch2Size = 6 - dma_ch(i)->CNDTR;
+            if (returnedPackets_[i]->ch2Size)
             {
                 Debug::RailcomDataReceived::toggle();
                 Debug::RailcomAnyData::set(true);
                 Debug::RailcomCh2Data::set(true);
-                if (!returnedPackets_[i])
-                {
-                    returnedPackets_[i] = this->alloc_new_packet(i);
-                }
-                if (!returnedPackets_[i])
-                {
-                    break;
-                }
-                uint8_t data = HW::UART_BASE[i].Instance->RDR;
-                if (LL_USART_IsActiveFlag_FE(HW::UART_BASE[i].Instance)) {
-                    Debug::RailcomError::toggle();
-                    LL_USART_ClearFlag_FE(HW::UART_BASE[i].Instance);
-                    //returnedPackets_[i]->add_ch2_data(0xF8);
-                    continue;
-                }
-                if (data == 0xE0) {
-                    Debug::RailcomE0::toggle();
-                }
-                returnedPackets_[i]->add_ch2_data(data);
             }
-            LL_USART_SetTransferDirection(
-                HW::UART_BASE[i].Instance, LL_USART_DIRECTION_NONE);
-            Debug::RailcomRxActivate::set(false);
-            if (returnedPackets_[i]) {
-                have_packets = true;
-                this->feedbackQueue_.commit_back();
-                Debug::RailcomPackets::toggle();
-                returnedPackets_[i] = nullptr;
-                HAL_NVIC_SetPendingIRQ(HW::OS_INTERRUPT);
+            if (LL_USART_IsActiveFlag_FE(uart(i)))
+            {
+                Debug::RailcomError::toggle();
+                LL_USART_ClearFlag_FE(uart(i));
+                if (returnedPackets_[i]->ch2Size < 6)
+                {
+                    returnedPackets_[i]->add_ch2_data(0xF8);
+                }
             }
+
+            LL_USART_SetTransferDirection(uart(i), LL_USART_DIRECTION_NONE);
+
+            Debug::RailcomPackets::toggle();
+            have_packets = true;
+            this->feedbackQueue_.commit_back();
+            returnedPackets_[i] = nullptr;
+            HAL_NVIC_SetPendingIRQ(HW::OS_INTERRUPT);
         }
+        Debug::RailcomRxActivate::set(false);
         if (!have_packets)
         {
             // Ensures that at least one feedback packet is sent back even when
             // it is with no railcom payload.
-            auto *p = this->alloc_new_packet(0);
+            auto *p = this->alloc_new_packet(15);
             if (p)
             {
                 this->feedbackQueue_.commit_back();
@@ -328,11 +409,11 @@ private:
         Debug::RailcomDriverCutout::set(false);
     }
 
-    void no_cutout() OVERRIDE
+    void no_cutout() override
     {
         // Ensures that at least one feedback packet is sent back even when
         // it is with no railcom payload.
-        auto *p = this->alloc_new_packet(0);
+        auto *p = this->alloc_new_packet(15);
         if (p)
         {
             this->feedbackQueue_.commit_back();

--- a/src/freertos_drivers/st/Stm32Railcom.hxx
+++ b/src/freertos_drivers/st/Stm32Railcom.hxx
@@ -1,5 +1,5 @@
 /** \copyright
- * Copyright (c) 2014, Balazs Racz
+ * Copyright (c) 2023, Balazs Racz
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This driver is based on a fork of the TivaRailcomDriver; the hardware interaction is rewritten to use the STM32 HAL libraries and in part direct access to the USART peripheral.

A major difference is that unlike the Tiva, the STM32 devices do not have a FIFO on the UART hardware. This makes it impossible to only perform reads from the UART data registers when the cutout is done.
To work around this issue, the STM32 Railcom Driver uses DMA to copy the data from the UART hardware register into the buffer in the driver. This requires a free DMA channel for each railcom channel that is in use.

Misc changes:
- Implements toggle() in STM32 GPIO driver.
- Adds a limit to how many buffers the RailcomToOpenlcbDebugProxy is willing to allocate. When we run out of buffers, we drop the packet to the floor.