### PR TITLE
Fixes some compile errors

### DIFF
--- a/boards/ti-ek-tm4c123gxl-launchpad/HwInit.cxx
+++ b/boards/ti-ek-tm4c123gxl-launchpad/HwInit.cxx
@@ -224,7 +224,10 @@ struct DccHwDefs {
   static const int RAILCOM_CUTOUT_POST_DELTA_USEC = -16;
   /// Adds this to the negative half after the railcom cutout is done.
   static const int RAILCOM_CUTOUT_POST_NEGATIVE_DELTA_USEC = -4;
-    
+  /// The DCC end of packet bit (after the cutout) has an asymmetry due to the
+  /// interrupt CPU latency, this constant tunes it to disappear. This time
+  /// gets deducted from the second half.
+  static const int RESYNC_DELAY_USEC = 7;
 
   /** These timer blocks will be synchronized once per packet, when the
    *  deadband delay is set up. */

--- a/src/openlcb/CompileCdiMain.cxx
+++ b/src/openlcb/CompileCdiMain.cxx
@@ -40,9 +40,9 @@ void render_cdi_helper(const CdiType &t, string ns, string name)
         printf("const char %s_DATA[] = R\"xmlpayload(%s)xmlpayload\";\n",
             name.c_str(), payload.c_str());
         printf("extern const size_t %s_SIZE;\n", name.c_str());
-        printf("const size_t %s_SIZE = sizeof(%s_DATA);\n", name.c_str(),
+        printf("extern const size_t %s_SIZE = sizeof(%s_DATA);\n", name.c_str(),
             name.c_str());
-        printf("const size_t %s_END_OFFSET = %u;\n", name.c_str(),
+        printf("extern const size_t %s_END_OFFSET = %u;\n", name.c_str(),
                (unsigned)t.end_offset());
         printf("\n}  // namespace %s\n\n", ns.c_str());
     }

--- a/src/openlcb/StreamReceiverInterface.hxx
+++ b/src/openlcb/StreamReceiverInterface.hxx
@@ -41,7 +41,7 @@
 
 template <class T> class FlowInterface;
 template <class T> class Buffer;
-class ByteChunk;
+struct ByteChunk;
 using ByteBuffer = Buffer<ByteChunk>;
 using ByteSink = FlowInterface<ByteBuffer>;
 


### PR DESCRIPTION
- ByteChunk was incorrectly forward declared
- CDI_END_OFFSET is unused and the compiler was complaining about this
- adds missing constant from tivadcc params.