### PR TITLE
Improve error handling in BroadcastTime::set_date_year_str()

### DIFF
--- a/src/openlcb/BroadcastTime.cxx
+++ b/src/openlcb/BroadcastTime.cxx
@@ -64,14 +64,40 @@ char *strptime(const char *, const char *, struct tm *);
 void BroadcastTime::set_date_year_str(const char *date_year)
 {
     struct tm tm;
-    if (strptime(date_year, "%b %e, %Y", &tm) != nullptr)
+    memset(&tm, 0, sizeof(tm));
+    if (strptime(date_year, "%b %e, %Y", &tm) == nullptr)
     {
-        if (tm.tm_year >= (0 - 1900) && tm.tm_year <= (4095 - 1900))
-        {
-            // date valid
-            set_date(tm.tm_mon + 1, tm.tm_mday);
-            set_year(tm.tm_year + 1900);
-        }
+        // Invalid result, don't set the data/year.
+        return;
+    }
+
+// It is assumed that this combination of compiler predefines is sufficent to
+// know that the compiler is GCC and [likely] using newlib for libc.
+#if defined(__GNUC__) && defined(__FreeRTOS__)
+    // newlib does not have proper boundary checking for strptime(). Therefore
+    // we will use mktime() to determine if the time we have is really valid
+    // or not. In newlib, mktime() can actually correct some invalid struct tm
+    // values my making some educated guesses.
+    //
+    // Also, newlib does not correctly set the errno value when mktime()
+    // encounters an error. Instead it "only" returns -1, which is technically
+    // a valie time. We are counting on the fact that we zero'd out the
+    // struct tm above, and subsequently -1 cannot be an expected result.
+    time_t t = mktime(&tm);
+    if (t == (time_t)-1)
+    {
+        // Not a valid (or correctable) struct tm input.
+        return;
+    }
+#endif
+
+    // If we have gotten here, our libc implementation should have the
+    // the struct tm filled in with a valid result.
+    if (tm.tm_year >= (0 - 1900) && tm.tm_year <= (4095 - 1900))
+    {
+        // date valid
+        set_date(tm.tm_mon + 1, tm.tm_mday);
+        set_year(tm.tm_year + 1900);
     }
 }
 

--- a/src/openlcb/BroadcastTimeServer.cxxtest
+++ b/src/openlcb/BroadcastTimeServer.cxxtest
@@ -145,6 +145,31 @@ TEST_F(BroadcastTimeServerTest, Time)
     EXPECT_EQ(server_->time(), -3);
 }
 
+TEST_F(BroadcastTimeServerTest, set_date_year_str)
+{
+    expect_any_packet();
+    EXPECT_CALL(*this, update_callback()).Times(AtLeast(0));
+
+    // Valid date.
+    server_->set_date_year_str("Dec 31, 1969");
+    wait_for_event_thread();
+    EXPECT_EQ(server_->time(), -86400);
+
+    // Invalid date, expect no update.
+    //
+    // Note: It is known that the expected result from newlib will not match
+    // glibc (used in this unit test). More details can be found inline to the
+    // BroadcastTime::set_date_year_str() method.
+    server_->set_date_year_str("Dec 32, 1969");
+    wait_for_event_thread();
+    EXPECT_EQ(server_->time(), -86400);
+
+    // Valid date.
+    server_->set_date_year_str("Jan 1, 1970");
+    wait_for_event_thread();
+    EXPECT_EQ(server_->time(), 0);
+}
+
 TEST_F(BroadcastTimeServerTest, FastSecToRealNsecPeriod)
 {
     long long real_nsec;


### PR DESCRIPTION
This pull request is superseded by #728 and #745.