### PR TITLE
Completes date-time parsing APIs in BroadcastTimeDefs.

### DIFF
--- a/src/openlcb/BroadcastTime.cxx
+++ b/src/openlcb/BroadcastTime.cxx
@@ -47,15 +47,9 @@ namespace openlcb
 void BroadcastTime::clear_timezone()
 {
 #ifndef ESP32
-        setenv("TZ", "GMT0", 1);
-        tzset();
+    setenv("TZ", "GMT0", 1);
+    tzset();
 #endif
-}
-
-extern "C"
-{
-// normally requires _GNU_SOURCE
-char *strptime(const char *, const char *, struct tm *);
 }
 
 //
@@ -63,15 +57,12 @@ char *strptime(const char *, const char *, struct tm *);
 //
 void BroadcastTime::set_date_year_str(const char *date_year)
 {
-    struct tm tm;
-    if (strptime(date_year, "%b %e, %Y", &tm) != nullptr)
+    int year, month, day;
+    if (BroadcastTimeDefs::string_to_date(date_year, &year, &month, &day))
     {
-        if (tm.tm_year >= (0 - 1900) && tm.tm_year <= (4095 - 1900))
-        {
-            // date valid
-            set_date(tm.tm_mon + 1, tm.tm_mday);
-            set_year(tm.tm_year + 1900);
-        }
+        // date valid
+        set_date(month, day);
+        set_year(year);
     }
 }
 

--- a/src/openlcb/BroadcastTime.hxx
+++ b/src/openlcb/BroadcastTime.hxx
@@ -99,7 +99,7 @@ public:
     }
 
     /// Set the date and year from a C string.
-    /// @param data_year date and year format in "Mmm dd, yyyy" format
+    /// @param date_year date and year format in "Mmm dd, yyyy" format
     void set_date_year_str(const char *date_year);
 
     /// Set Rate. The new rate does not become valid until the update callbacks

--- a/src/openlcb/BroadcastTimeDefs.cxxtest
+++ b/src/openlcb/BroadcastTimeDefs.cxxtest
@@ -11,12 +11,107 @@
 namespace openlcb
 {
 
+class BroadcastTimeDefsTest : public ::testing::Test
+{
+protected:
+    /// Use this function for testing successful date parsing.
+    ///
+    /// @param d text date to parse
+    /// @param exp_y expected year
+    /// @param exp_m expected month
+    /// @param exp_d expected day
+    ///
+    void parse_date(const string &d, int exp_y, int exp_m, int exp_d)
+    {
+        SCOPED_TRACE(d);
+        year = month = day = -1;
+        EXPECT_TRUE(BroadcastTimeDefs::string_to_date(d, &year, &month, &day));
+        EXPECT_EQ(exp_y, year);
+        EXPECT_EQ(exp_m, month);
+        EXPECT_EQ(exp_d, day);
+    }
+
+    /// Use this function for testing failed date parsing.
+    ///
+    /// @param d date string that should fail to parse
+    ///
+    /// @return false upon parse error
+    ///
+    bool parse_date(const string &d)
+    {
+        return BroadcastTimeDefs::string_to_date(d, &year, &month, &day);
+    }
+
+    /// Tests date canonicalization.
+    ///
+    /// @param d input date string
+    /// @param exp output date string; if left empty then assumes the same as d.
+    ///
+    bool canon_date(const string &d, string exp = "")
+    {
+        if (exp.empty())
+        {
+            exp = d;
+        }
+        SCOPED_TRACE(d + "->'" + exp + "'");
+        string io = d;
+        bool ret = BroadcastTimeDefs::canonicalize_date_string(&io);
+        EXPECT_EQ(d != exp, ret);
+        EXPECT_EQ(exp, io);
+        return ret;
+    }
+
+    /// Tests rate canonicalization.
+    ///
+    /// @param d input rate string
+    /// @param exp output rate string; if left empty then assumes the same as d.
+    ///
+    bool canon_rate(const string &d, string exp = "")
+    {
+        if (exp.empty())
+        {
+            exp = d;
+        }
+        SCOPED_TRACE(d + "->'" + exp + "'");
+        string io = d;
+        bool ret = BroadcastTimeDefs::canonicalize_rate_string(&io);
+        EXPECT_EQ(d != exp, ret);
+        EXPECT_EQ(exp, io);
+        return ret;
+    }
+
+    /// Tests time canonicalization.
+    ///
+    /// @param d input time string
+    /// @param exp output time string; if left empty then assumes the same as d.
+    ///
+    bool canon_time(const string &d, string exp = "")
+    {
+        if (exp.empty())
+        {
+            exp = d;
+        }
+        SCOPED_TRACE(d + "->'" + exp + "'");
+        string io = d;
+        bool ret = BroadcastTimeDefs::canonicalize_time_string(&io);
+        EXPECT_EQ(d != exp, ret);
+        EXPECT_EQ(exp, io);
+        return ret;
+    }
+    
+    /// Output of canonicalization.
+    string out;
+
+    /// Output of parsing.
+    int year = -1, month = -1, day = -1, hour = -1, min = -1;
+};
+
 TEST(BroadcastTimeDefs, string_to_rate_quarters)
 {
     int16_t rate;
 
     rate = BroadcastTimeDefs::string_to_rate_quarters("Freddy");
-    EXPECT_EQ(0, rate);
+    EXPECT_EQ(4, rate);
 
     rate = BroadcastTimeDefs::string_to_rate_quarters("2000");
     EXPECT_EQ(2047, rate);
@@ -25,13 +120,13 @@ TEST(BroadcastTimeDefs, string_to_rate_quarters)
     EXPECT_EQ(-2048, rate);
 
     rate = BroadcastTimeDefs::string_to_rate_quarters("");
-    EXPECT_EQ(0, rate);
+    EXPECT_EQ(4, rate);
 
     rate = BroadcastTimeDefs::string_to_rate_quarters("-");
-    EXPECT_EQ(0, rate);
+    EXPECT_EQ(4, rate);
 
     rate = BroadcastTimeDefs::string_to_rate_quarters("    ");
-    EXPECT_EQ(0, rate);
+    EXPECT_EQ(4, rate);
 
     rate = BroadcastTimeDefs::string_to_rate_quarters("511,75");
     EXPECT_EQ(2044, rate);
@@ -42,5 +137,121 @@ TEST(BroadcastTimeDefs, string_to_rate_quarters)
     rate = BroadcastTimeDefs::string_to_rate_quarters("-1.75");
     EXPECT_EQ(-7, rate);
 }
+
+TEST_F(BroadcastTimeDefsTest, string_to_date)
+{
+    parse_date("Aug 12, 2023", 2023, 8, 12);
+    parse_date("Jan 1, 1970", 1970, 1, 1);
+    parse_date("Oct 30, 2000", 2000, 10, 30);
+
+    parse_date("Jan 01, 1970", 1970, 1, 1);
+
+    // Some leading zeros get misinterpreted.
+    parse_date("Jan 09, 02023", 202, 1, 9);
+
+    // Examples with missing whitespace
+    parse_date("Aug 12,2023", 2023, 8, 12);
+    // Examples with missing whitespace
+    parse_date("Aug12,2023", 2023, 8, 12);
+
+    // Examples with more whitespace
+    parse_date("Aug     12,\n\n2023    ", 2023, 8, 12);
+    parse_date("Aug\r\n12,\t2023    ", 2023, 8, 12);
+
+    // Examples with garbage at end
+    parse_date("Aug 12, 2023xxxxx", 2023, 8, 12);
+
+    // Leap year
+    parse_date("Feb 29, 2024", 2024, 2, 29);
+
+    // Not leap year
+    parse_date("Feb 29, 2023", 2023, 2, 29);
+    // No canonicalization in glibc
+    parse_date("Feb 31, 2023", 2023, 2, 31);
+}
+
+TEST_F(BroadcastTimeDefsTest, string_to_date_fail)
+{
+    EXPECT_FALSE(parse_date("Freddy"));
+    EXPECT_FALSE(parse_date(""));
+    EXPECT_FALSE(parse_date("Mai 1, 2023"));
+    EXPECT_FALSE(parse_date("2023-08-12"));
+    EXPECT_FALSE(parse_date("Dec 32, 1969"));
+    EXPECT_FALSE(parse_date("Aug 12x2023"));
+    EXPECT_FALSE(parse_date("Feb 32, 2023"));
+    EXPECT_FALSE(parse_date("    Aug 12, 2023"));
+
+    EXPECT_FALSE(parse_date("Aug 12"));
+    EXPECT_FALSE(parse_date("Aug"));
+}
+
+TEST_F(BroadcastTimeDefsTest, date_to_string)
+{
+    EXPECT_EQ("Jan  1, 1970", BroadcastTimeDefs::date_to_string(1970, 1, 1));
+    EXPECT_EQ("Aug 12, 2023", BroadcastTimeDefs::date_to_string(2023, 8, 12));
+    EXPECT_EQ("Aug 12, 99", BroadcastTimeDefs::date_to_string(99, 8, 12));
+    EXPECT_EQ("Aug 12, 3099", BroadcastTimeDefs::date_to_string(3099, 8, 12));
+}
+
+TEST_F(BroadcastTimeDefsTest, date_canonicalize)
+{
+    EXPECT_TRUE(canon_date("", "Jan  1, 1970"));
+    EXPECT_TRUE(canon_date("Freddy", "Jan  1, 1970"));
+    EXPECT_TRUE(canon_date("Jan 1, 1970", "Jan  1, 1970"));
+    EXPECT_FALSE(canon_date("Jan  1, 1970", "Jan  1, 1970"));
+
+    EXPECT_FALSE(canon_date("Aug 12, 2023"));
+    EXPECT_TRUE(canon_date("Aug     12, \n\t   2023", "Aug 12, 2023"));
+    EXPECT_FALSE(canon_date("Feb 31, 2023"));
+    EXPECT_FALSE(canon_date("Feb 31, 23"));
+    EXPECT_FALSE(canon_date("Feb 31, 3023"));
+
+    EXPECT_TRUE(canon_date("Aug 9, 2023", "Aug  9, 2023"));
+
+    EXPECT_TRUE(canon_date("Feb 31, 5023", "Jan  1, 1970"));
+    EXPECT_TRUE(canon_date("Dec 32, 2023", "Jan  1, 1970"));
+    EXPECT_TRUE(canon_date("  Aug 9, 2023", "Jan  1, 1970"));
+}
+
+TEST_F(BroadcastTimeDefsTest, rate_canonicalize)
+{
+    EXPECT_TRUE(canon_rate("", "1.00"));
+    EXPECT_TRUE(canon_rate("3", "3.00"));
+    EXPECT_TRUE(canon_rate("-4", "-4.00"));
+    EXPECT_FALSE(canon_rate("1.25"));
+    EXPECT_FALSE(canon_rate("500.00"));
+    EXPECT_FALSE(canon_rate("-10.75"));
+    EXPECT_TRUE(canon_rate("12", "12.00"));
+    EXPECT_TRUE(canon_rate("-12", "-12.00"));
+    EXPECT_TRUE(canon_rate("Freddy", "1.00"));
+    EXPECT_TRUE(canon_rate("17,75", "17.00"));
+    EXPECT_TRUE(canon_rate("1200", "511.75"));
+    EXPECT_TRUE(canon_rate("-1200", "-512.00"));
+    EXPECT_TRUE(canon_rate("  13ab", "13.00"));
+}
+
+TEST_F(BroadcastTimeDefsTest, time_canonicalize)
+{
+    EXPECT_TRUE(canon_time("", "00:00"));
+    EXPECT_TRUE(canon_time("Freddy", "00:00"));
+    EXPECT_TRUE(canon_time("3:22asdasdas", "03:22"));
+    EXPECT_TRUE(canon_time("95:95", "00:00"));
+    EXPECT_TRUE(canon_time("-5:-2", "00:00"));
+    
+    EXPECT_TRUE(canon_time("1:2", "01:02"));
+    EXPECT_TRUE(canon_time("8pm", "00:00"));
+    EXPECT_TRUE(canon_time("8:15pm", "08:15"));
+    EXPECT_TRUE(canon_time("24:59", "00:00"));
+
+    EXPECT_FALSE(canon_time("20:15"));
+    EXPECT_TRUE(canon_time("20: 15", "20:15"));
+    EXPECT_TRUE(canon_time("   20:\n 15", "20:15"));
+    EXPECT_TRUE(canon_time("20: 15   ", "20:15"));
+    EXPECT_TRUE(canon_time("20: 15asdasdas   ", "20:15"));
+
+    EXPECT_FALSE(canon_time("23:59"));
+    EXPECT_FALSE(canon_time("12:00"));
+}
+
 
 } // namespace openlcb

--- a/src/openlcb/BroadcastTimeDefs.hxx
+++ b/src/openlcb/BroadcastTimeDefs.hxx
@@ -353,6 +353,12 @@ struct BroadcastTimeDefs
     /// @return rate represented in the form of a string (float)
     static std::string rate_quarters_to_string(int16_t rate);
 
+    /// Converts a date to a string "Mmm dd, yyyy".
+    /// @param year 0 to 4095
+    /// @param month 1 to 12 (warning! struct tm has 0 to 11)
+    /// @param day 1 to 31
+    static std::string date_to_string(int year, int month, int day);
+    
     /// Convert a string (hh:mm) to hour and minute component integers.
     /// @param stime time in the form of a string
     /// @param hour resulting hour integer (0 to 23)
@@ -366,6 +372,40 @@ struct BroadcastTimeDefs
     ///         conversion error occurs, then the returned value will be 0,
     ///         which is at least a valid rate.
     static int16_t string_to_rate_quarters(const std::string &srate);
+
+    /// Converts a (user-provided) string "Mmm dd, yyyy" to date. Verifies that
+    /// the values are in range for OpenLCB and for a real date.
+    /// @param sdate the input string in "Mmm dd, yyyy" format.
+    /// @param year will be filled in with the year (0 to 4095)
+    /// @param month will be filled in with the month (1 to 12) (warning!
+    /// struct tm has 0 to 11)
+    /// @param day will be filled in with the day (1 to 31)
+    /// @return true on success, false on parse error. Note that it is not
+    /// fully specified what is a parse error; certain errors will be corrected
+    /// (e.g. feb 30, 2001 will be fixed to march 2).
+    static bool string_to_date(
+        const std::string &sdate, int *year, int *month, int *day);
+
+    /// Verifies that a user-provided string parses as time, and canonicalizes
+    /// the string format. Parse errors get turned into "00:00".
+    /// @param stime input-output argument. Input is the user-provided time
+    /// (hh:mm), output is the canonicalized time.
+    /// @return true if the string has changed during canonicalization.
+    static bool canonicalize_time_string(std::string *stime);
+
+    /// Verifies that a user-provided string parses as rate quarters, and
+    /// canonicalizes the string format. Parse errors get turned into "0.00".
+    /// @param srate input-output argument. Input is user-provided rate, output
+    /// is the canonicalized rate.
+    /// @return true if the string has changed during canonicalization.
+    static bool canonicalize_rate_string(std::string* srate);
+
+    /// Verifies that a user-provided string parses as date, and canonicalizes
+    /// the string format. Parse errors get turned into "Jan 1, 1970".
+    /// @param sdate input-output argument. Input is user-provided date in "Mmm
+    /// dd, yyyy" format, output is the canonicalized date.
+    /// @return true if the string has changed during canonicalization.
+    static bool canonicalize_date_string(std::string* sdate);
 };
 
 }  // namespace openlcb


### PR DESCRIPTION
Changes the default (unparseable) rate to 1.00. Previously it was 0.00 which is although a valid rate, will make the clock be permanently stopped.

- Moves the date parsing from BroadcastTime to BroadcastTimeDefs. Makes the API similar to time and rate parsing.
- Adds canonicalization commands to the API. These parse then format a string. Useful for handling user-submitted configuration.
- Adds unit tests for the variety of date time handling.