### PR TITLE
Fix MultiConfiguredPC.hxx compilation with C++20

### DIFF
--- a/src/openlcb/MultiConfiguredPC.hxx
+++ b/src/openlcb/MultiConfiguredPC.hxx
@@ -152,6 +152,7 @@ public:
 #else
             alloc.construct(debouncers_ + i, 3);
 #endif // __cplusplus >= 202002L
+        }
     }
 
     ~MultiConfiguredPC()

--- a/src/openlcb/MultiConfiguredPC.hxx
+++ b/src/openlcb/MultiConfiguredPC.hxx
@@ -138,11 +138,20 @@ public:
         ConfigUpdateService::instance()->register_update_listener(this);
         producedEvents_ = new EventId[size * 2];
         std::allocator<debouncer_type> alloc;
+// C++20 standard removed the construct and destruct methods from
+// std::allocator which are now available in std::allocator_traits requiring
+// passing in the allocator to these methods.
+#if __cplusplus >= 202002L
+        std::allocator_traits<std::allocator<debouncer_type>> alloc_traits;
+#endif // __cplusplus >= 202002L
         debouncers_ = alloc.allocate(size_);
         for (unsigned i = 0; i < size_; ++i)
         {
+#if __cplusplus >= 202002L
+            alloc_traits.construct(alloc, debouncers_ + i, 3);
+#else
             alloc.construct(debouncers_ + i, 3);
-        }
+#endif // __cplusplus >= 202002L
     }
 
     ~MultiConfiguredPC()
@@ -151,9 +160,19 @@ public:
         ConfigUpdateService::instance()->unregister_update_listener(this);
         delete[] producedEvents_;
         std::allocator<debouncer_type> alloc;
+// C++20 standard removed the construct and destruct methods from
+// std::allocator which are now available in std::allocator_traits requiring
+// passing in the allocator to these methods.
+#if __cplusplus >= 202002L
+        std::allocator_traits<std::allocator<debouncer_type>> alloc_traits;
+#endif // __cplusplus >= 202002L
         for (unsigned i = 0; i < size_; ++i)
         {
+#if __cplusplus >= 202002L
+            alloc_traits.destroy(alloc, debouncers_ + i);
+#else
             alloc.destroy(debouncers_ + i);
+#endif // __cplusplus >= 202002L
         }
         alloc.deallocate(debouncers_, size_);
     }


### PR DESCRIPTION
Due to the C++20 standard removing the construct and destruct methods from std::allocator, it was necessary to adjust the code to use std::allocator_traits instead which has provided these methods since C++11.

Fixes https://github.com/bakerstu/openmrn/issues/711