### PR TITLE
Updates to send_datagram cmdline utility

### DIFF
--- a/applications/send_datagram/main.cxx
+++ b/applications/send_datagram/main.cxx
@@ -241,6 +241,7 @@ int appl_main(int argc, char *argv[])
         }
         if (wait_for_response) {
             g_datagram_can.registry()->insert(&g_node, payload[0], &printer);
+            g_datagram_can.registry()->insert(&g_node, payload[0] ^ 1, &printer);
         }
         Buffer<openlcb::GenMessage> *b;
         mainBufferPool->alloc(&b);
@@ -256,11 +257,11 @@ int appl_main(int argc, char *argv[])
         fprintf(stderr, "Datagram send result: %04x\n", client->result());
         if (!(client->result() & DatagramClient::OK_REPLY_PENDING)) {
             LOG(INFO, "Target node indicates no response pending.");
-        } else if (wait_for_response) {
-            printer.wait();
         }
         if (wait_for_response) {
+            printer.wait();
             g_datagram_can.registry()->erase(&g_node, payload[0], &printer);
+            g_datagram_can.registry()->erase(&g_node, payload[0] ^ 1, &printer);
         }
     }
 


### PR DESCRIPTION
- waits for the response datagram when the cmdline switch says so, even if the remote node does not say so
- waits for response datagrams at the odd ID as well, for protocols that use two adjacent IDs.