### PR TITLE
Unaligned read/write support in TivaEEPROM storage

### DIFF
--- a/src/freertos_drivers/ti/TivaEEPROMFile.hxx
+++ b/src/freertos_drivers/ti/TivaEEPROMFile.hxx
@@ -78,24 +78,24 @@ public:
         size_t count = 0;
         uint8_t *b = (uint8_t *)buf;
         // Partial write at the beginning.
-        if (index & 3)
+        if (index & 0x3)
         {
             uint32_t rd = 0;
-            MAP_EEPROMRead(&rd, (index + byteOffset_) & ~3, 4);
-            size_t actual_len = 4 - (index & 3);
+            MAP_EEPROMRead(&rd, (index + byteOffset_) & ~0x3, 4);
+            size_t actual_len = 4 - (index & 0x3);
             actual_len = std::min(len, actual_len);
-            memcpy(((uint8_t*)&rd) + (index & 3), b, actual_len);
-            MAP_EEPROMProgram(&rd, (index + byteOffset_) & ~3, 4);
+            memcpy(((uint8_t*)&rd) + (index & 0x3), b, actual_len);
+            MAP_EEPROMProgram(&rd, (index + byteOffset_) & ~0x3, 4);
             len -= actual_len;
             index += actual_len;
             b += actual_len;
             count += actual_len;
         }
         // Full writes in the middle.
-        size_t word_len = len & ~3;
+        size_t word_len = len & ~0x3;
         if (word_len)
         {
-            HASSERT(index % 4 == 0);
+            HASSERT(index & 0x3 == 0);
             MAP_EEPROMProgram((uint32_t *)b, index + byteOffset_, word_len);
             index += word_len;
             b += word_len;
@@ -103,9 +103,9 @@ public:
             count += word_len;
         }
         // Partial write at the end.
-        if (len & 3)
+        if (len & 0x3)
         {
-            HASSERT(index % 4 == 0);
+            HASSERT(index & 0x3 == 0);
             uint32_t rd = 0;
             MAP_EEPROMRead(&rd, index + byteOffset_, 4);
             memcpy(&rd, b, len);
@@ -125,23 +125,23 @@ public:
         size_t count = 0;
         uint8_t *b = (uint8_t *)buf;
         // Partial read at the beginning.
-        if (index & 3)
+        if (index & 0x3)
         {
             uint32_t rd = 0;
-            MAP_EEPROMRead(&rd, (index + byteOffset_) & ~3, 4);
-            size_t actual_len = 4 - (index & 3);
+            MAP_EEPROMRead(&rd, (index + byteOffset_) & ~0x3, 4);
+            size_t actual_len = 4 - (index & 0x3);
             actual_len = std::min(len, actual_len);
-            memcpy(b, ((uint8_t *)&rd) + (index & 3), actual_len);
+            memcpy(b, ((uint8_t *)&rd) + (index & 0x3), actual_len);
             len -= actual_len;
             index += actual_len;
             b += actual_len;
             count += actual_len;
         }
         // Full reads in the middle.
-        size_t word_len = len & ~3;
+        size_t word_len = len & ~0x3;
         if (word_len)
         {
-            HASSERT(index % 4 == 0);
+            HASSERT(index & 0x3 == 0);
             MAP_EEPROMRead((uint32_t *)b, index + byteOffset_, word_len);
             index += word_len;
             b += word_len;
@@ -149,9 +149,9 @@ public:
             count += word_len;
         }
         // Partial read at the end.
-        if (len & 3)
+        if (len & 0x3)
         {
-            HASSERT(index % 4 == 0);
+            HASSERT(index & 0x3 == 0);
             uint32_t rd = 0;
             MAP_EEPROMRead(&rd, index + byteOffset_, 4);
             memcpy(b, &rd, len);

--- a/src/freertos_drivers/ti/TivaEEPROMFile.hxx
+++ b/src/freertos_drivers/ti/TivaEEPROMFile.hxx
@@ -75,10 +75,44 @@ public:
     /// @return number of bytes written upon success, -errno upon failure
     ssize_t write(unsigned int index, const void *buf, size_t len) override
     {
-        HASSERT(index % 4 == 0);
-        HASSERT(len % 4 == 0);
-        MAP_EEPROMProgram((uint32_t *)buf, index + byteOffset_, len);
-        return len;
+        size_t count = 0;
+        uint8_t *b = (uint8_t *)buf;
+        // Partial write at the beginning.
+        if (index & 3)
+        {
+            uint32_t rd = 0;
+            MAP_EEPROMRead(&rd, (index + byteOffset_) & ~3, 4);
+            size_t actual_len = 4 - (index & 3);
+            actual_len = std::min(len, actual_len);
+            memcpy(((uint8_t*)&rd) + (index & 3), b, actual_len);
+            MAP_EEPROMProgram(&rd, (index + byteOffset_) & ~3, 4);
+            len -= actual_len;
+            index += actual_len;
+            b += actual_len;
+            count += actual_len;
+        }
+        // Full writes in the middle.
+        size_t word_len = len & ~3;
+        if (word_len)
+        {
+            HASSERT(index % 4 == 0);
+            MAP_EEPROMProgram((uint32_t *)b, index + byteOffset_, word_len);
+            index += word_len;
+            b += word_len;
+            len -= word_len;
+            count += word_len;
+        }
+        // Partial write at the end.
+        if (len & 3)
+        {
+            HASSERT(index % 4 == 0);
+            uint32_t rd = 0;
+            MAP_EEPROMRead(&rd, index + byteOffset_, 4);
+            memcpy(&rd, b, len);
+            MAP_EEPROMProgram(&rd, (index + byteOffset_), 4);
+            count += len;
+        }
+        return count;
     }
 
     /// Read from the eeprom.
@@ -88,10 +122,42 @@ public:
     /// @return number of bytes read upon success, -errno upon failure
     ssize_t read(unsigned int index, void *buf, size_t len) override
     {
-        HASSERT(index % 4 == 0);
-        HASSERT(len % 4 == 0);
-        MAP_EEPROMRead((uint32_t *)buf, index + byteOffset_, len);
-        return len;
+        size_t count = 0;
+        uint8_t *b = (uint8_t *)buf;
+        // Partial read at the beginning.
+        if (index & 3)
+        {
+            uint32_t rd = 0;
+            MAP_EEPROMRead(&rd, (index + byteOffset_) & ~3, 4);
+            size_t actual_len = 4 - (index & 3);
+            actual_len = std::min(len, actual_len);
+            memcpy(b, ((uint8_t *)&rd) + (index & 3), actual_len);
+            len -= actual_len;
+            index += actual_len;
+            b += actual_len;
+            count += actual_len;
+        }
+        // Full reads in the middle.
+        size_t word_len = len & ~3;
+        if (word_len)
+        {
+            HASSERT(index % 4 == 0);
+            MAP_EEPROMRead((uint32_t *)b, index + byteOffset_, word_len);
+            index += word_len;
+            b += word_len;
+            len -= word_len;
+            count += word_len;
+        }
+        // Partial read at the end.
+        if (len & 3)
+        {
+            HASSERT(index % 4 == 0);
+            uint32_t rd = 0;
+            MAP_EEPROMRead(&rd, index + byteOffset_, 4);
+            memcpy(b, &rd, len);
+            count += len;
+        }
+        return count;
     }
 
 private:

--- a/src/freertos_drivers/ti/TivaEEPROMFile.hxx
+++ b/src/freertos_drivers/ti/TivaEEPROMFile.hxx
@@ -95,7 +95,7 @@ public:
         size_t word_len = len & ~0x3;
         if (word_len)
         {
-            HASSERT(index & 0x3 == 0);
+            HASSERT((index & 0x3) == 0);
             MAP_EEPROMProgram((uint32_t *)b, index + byteOffset_, word_len);
             index += word_len;
             b += word_len;
@@ -105,7 +105,7 @@ public:
         // Partial write at the end.
         if (len & 0x3)
         {
-            HASSERT(index & 0x3 == 0);
+            HASSERT((index & 0x3) == 0);
             uint32_t rd = 0;
             MAP_EEPROMRead(&rd, index + byteOffset_, 4);
             memcpy(&rd, b, len);
@@ -141,7 +141,7 @@ public:
         size_t word_len = len & ~0x3;
         if (word_len)
         {
-            HASSERT(index & 0x3 == 0);
+            HASSERT((index & 0x3) == 0);
             MAP_EEPROMRead((uint32_t *)b, index + byteOffset_, word_len);
             index += word_len;
             b += word_len;
@@ -151,7 +151,7 @@ public:
         // Partial read at the end.
         if (len & 0x3)
         {
-            HASSERT(index & 0x3 == 0);
+            HASSERT((index & 0x3) == 0);
             uint32_t rd = 0;
             MAP_EEPROMRead(&rd, index + byteOffset_, 4);
             memcpy(b, &rd, len);


### PR DESCRIPTION
Adds support for unaligned reads and writes to the TivaEEPROMFile driver.
Previously this driver would only accept dword-aligned reads and writes.