### PR TITLE
Update HASSERT and DIE to use ets_printf() on ESP32

### DIFF
--- a/src/utils/macros.h
+++ b/src/utils/macros.h
@@ -89,7 +89,35 @@ extern const char* g_death_file;
 
 #define DIE(MSG) abort()
 
-#elif defined(ESP_NONOS) || defined(ARDUINO) || defined(ESP32)
+#elif defined(ESP32)
+
+// For the ESP32 family or MCUs use ets_printf() instead of printf() to bypass
+// internal locking within the newlib implementation which has been observed
+// crashing the MCU at times when printf() is used in conjuction with ISRs on
+// the same core. The call to assert() internally uses ets_printf() as well
+// prior to "hanging" the MCU core in a busy loop.
+
+#include <stdio.h>
+#include <assert.h>
+
+// Locate the relevant version of ets_sys.h based on the IDF_TARGET
+#if defined(CONFIG_IDF_TARGET_ESP32)
+#include <esp32/rom/ets_sys.h>
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+#include <esp32s2/rom/ets_sys.h>
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+#include <esp32s3/rom/ets_sys.h>
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+#include <esp32c3/rom/ets_sys.h>
+#else
+#error Unknown/Unsupported ESP32 variant.
+#endif // CONFIG_IDF_TARGET_ESP32
+
+#define HASSERT(x) do { if (!(x)) { ets_printf("Assertion failed in file " __FILE__ " line %d: assert(%s)\n", __LINE__, #x); g_death_file = __FILE__; g_death_lineno = __LINE__; assert(0); abort();} } while(0)
+
+#define DIE(MSG) do { ets_printf("Crashed in file " __FILE__ " line %d: " MSG "\n", __LINE__); assert(0); abort(); } while(0)
+
+#elif defined(ESP_NONOS) || defined(ARDUINO)
 
 #include <stdio.h>
 #include <assert.h>


### PR DESCRIPTION
It has been observed that HASSERT and DIE may encounter a crash due to internal locking of printf() resulting in the discard of the reason for the crash.