### PR TITLE
Limit the amount of input we read into memory in arduino sketches.

### DIFF
--- a/arduino/OpenMRNLite.cpp
+++ b/arduino/OpenMRNLite.cpp
@@ -34,6 +34,8 @@
 
 #include <OpenMRNLite.h>
 
+OVERRIDE_CONST(gridconnect_bridge_max_incoming_packets, 5);
+
 namespace openmrn_arduino {
 
 OpenMRN::OpenMRN(openlcb::NodeID node_id)

--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -117,8 +117,6 @@ constexpr UBaseType_t OPENMRN_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO - 1;
 
 #endif
 
-OVERRIDE_CONST(gridconnect_bridge_max_incoming_packets, 5);
-
 namespace openmrn_arduino
 {
 

--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -39,6 +39,7 @@
 #include <Arduino.h>
 
 #include "CDIXMLGenerator.hxx"
+#include "executor/Notifiable.hxx"
 #include "freertos_drivers/arduino/Can.hxx"
 #include "freertos_drivers/arduino/WifiDefs.hxx"
 #include "openlcb/SimpleStack.hxx"
@@ -116,6 +117,8 @@ constexpr UBaseType_t OPENMRN_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO - 1;
 
 #endif
 
+OVERRIDE_CONST(gridconnect_bridge_max_incoming_packets, 5);
+
 namespace openmrn_arduino
 {
 
@@ -178,14 +181,26 @@ private:
     /// Handles data coming in from the serial port and sends it to OpenMRN.
     void loop_for_read()
     {
+        if (!bn_.is_done())
+        {
+            // Blocked because data we've just read has not yet been processed.
+            return;
+        }
         int av = port_->available();
         if (av <= 0)
         {
             return;
         }
+        // We don't read too many bytes into one buffer. 64 is exactly one USB
+        // packet's length.
+        if (av > 64)
+        {
+            av = 64;
+        }
         auto *b = txtHub_.alloc();
         b->data()->skipMember_ = &writePort_;
         b->data()->resize(av);
+        b->set_done(bn_.reset(EmptyNotifiable::DefaultInstance()));
         port_->readBytes((char*)b->data()->data(), b->data()->size());
         txtHub_.send(b);
     }
@@ -247,6 +262,14 @@ private:
     size_t writeOfs_;
     /// Hub for the textual data.
     HubFlow txtHub_{service_};
+    /// This notifiable will know whether the txt packet we read from the
+    /// serial has been processed by the hub. This is a pushback mechanism for
+    /// us not to run out of memory when there is too many packets coming from
+    /// the host or socket.
+    ///
+    /// This notifiable is active while there is a message in flight to the txt
+    /// hub.
+    BarrierNotifiable bn_;
 };
 
 /// Bridge class that connects a native CAN controller to the OpenMRN core


### PR DESCRIPTION
Adds a pushback mechanism to not read faster from a serial bridge than how fast the stack, or a CAN-bus output can sink packets. This is especially important for USBSerial inputs, which can supply data as fast as we are willing to read it.

The implementation relies on two mechanisms:
- setting the gridconnect converter to keep track of the CAN frames and only let a fixed number of them (5) exist at any time in the CAN hub.
- adding a notifiable to the SerialBridge that keep track of the last txt buffer we sent to the gridconnect bridge. We do not read more bytes from the serial port in the read loop until the previous buffer is processed by the gridconnect parser.