### PR TITLE
Fix symlinking of library files to the lib directory.

### DIFF
--- a/etc/applib.mk
+++ b/etc/applib.mk
@@ -76,9 +76,9 @@ $(LIBNAME): $(OBJS)
 	$(AR) cr $(LIBNAME) $(OBJS)
 	mkdir -p ../lib
 ifeq ($(OS),Windows_NT)
-	cp -f $(LIBNAME) ../lib/
+	cp -f $(LIBNAME) ../lib/$(LIBNAME)
 else
-	(cd ../lib ; ln -sf ../$(BASENAME)/$(LIBNAME) . )	
+	(cd ../lib ; ln -sf ../$(BASENAME)/$(LIBNAME) ./$(LIBNAME) )	
 endif
 	touch ../lib/timestamp
 

--- a/etc/lib.mk
+++ b/etc/lib.mk
@@ -96,10 +96,11 @@ $(ARM_OBJS): %.o : %.c
 
 $(LIBNAME): $(OBJS)
 	$(AR) crs$(AROPTS) $(LIBNAME) $(OBJS)
+	mkdir -p $(OPENMRNPATH)/targets/$(TARGET)/lib/
 ifeq ($(OS),Windows_NT)
-	cp -f $(TGTDIR)/$(LIBNAME) $(OPENMRNPATH)/targets/$(TARGET)/lib
+	cp -f $(TGTDIR)/$(LIBNAME) $(OPENMRNPATH)/targets/$(TARGET)/lib/$(LIBNAME)
 else
-	ln -sf $(TGTDIR)/$(LIBNAME) $(OPENMRNPATH)/targets/$(TARGET)/lib
+	ln -sf $(TGTDIR)/$(LIBNAME) $(OPENMRNPATH)/targets/$(TARGET)/lib/$(LIBNAME)
 endif
 	touch $(OPENMRNPATH)/targets/$(TARGET)/lib/timestamp
 


### PR DESCRIPTION
- ensures that the target lib directory is created before linking something to it.
- links with a full filename instead of just a directory name to avoid misunderstandings by ln