### PR TITLE
Adds TinyUsb based CDC virtual Com port driver with an STM32 port.

### DIFF
--- a/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/HwInit.cxx
+++ b/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/HwInit.cxx
@@ -45,6 +45,7 @@
 #include "os/OS.hxx"
 #include "Stm32Uart.hxx"
 #include "Stm32Can.hxx"
+#include "Stm32UsbCdc.hxx"
 #include "Stm32EEPROMEmulation.hxx"
 #include "hardware.hxx"
 
@@ -67,6 +68,10 @@ static Stm32Can can0("/dev/can0");
 static Stm32EEPROMEmulation eeprom0("/dev/eeprom", 512);
 
 const size_t EEPROMEmulation::SECTOR_SIZE = 2048;
+
+/** USB-Serial instance */
+static Stm32UsbCdc serUSB0("/dev/serUSB0");
+
 
 extern "C" {
 

--- a/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/HwInit.cxx
+++ b/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/HwInit.cxx
@@ -278,4 +278,4 @@ void usb_interrupt_handler(void)
     dcd_int_handler(0);
 }
 
-}
+} // extern "C"

--- a/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/HwInit.cxx
+++ b/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/HwInit.cxx
@@ -72,7 +72,6 @@ const size_t EEPROMEmulation::SECTOR_SIZE = 2048;
 /** USB-Serial instance */
 static Stm32UsbCdc serUSB0("/dev/serUSB0");
 
-
 extern "C" {
 
 /** Blink LED */
@@ -155,7 +154,7 @@ static void clock_setup(void)
     while (!((RCC->CFGR & RCC_CFGR_SWS) == RCC_CFGR_SWS_PLL))
         ;
 
-    RCC_PeriphCLKInitTypeDef  PeriphClkInitStruct = {0};
+    RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
     /* Select HSI48 as USB clock source */
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_HSI48;
@@ -167,7 +166,7 @@ static void clock_setup(void)
     __HAL_RCC_CRS_CLK_ENABLE();
 
     RCC_CRSInitTypeDef RCC_CRSInitStruct = {0};
-    
+
     /* Default Synchro Signal division factor (not divided) */
     RCC_CRSInitStruct.Prescaler = RCC_CRS_SYNC_DIV1;
 
@@ -175,14 +174,15 @@ static void clock_setup(void)
     RCC_CRSInitStruct.Source = RCC_CRS_SYNC_SOURCE_USB;
 
     /* HSI48 is synchronized with USB SOF at 1KHz rate */
-    RCC_CRSInitStruct.ReloadValue =  __HAL_RCC_CRS_RELOADVALUE_CALCULATE(48000000, 1000);
+    RCC_CRSInitStruct.ReloadValue =
+        __HAL_RCC_CRS_RELOADVALUE_CALCULATE(48000000, 1000);
     RCC_CRSInitStruct.ErrorLimitValue = RCC_CRS_ERRORLIMIT_DEFAULT;
 
     /* Set the TRIM[5:0] to the default value*/
     RCC_CRSInitStruct.HSI48CalibrationValue = 0x20;
 
     /* Start automatic synchronization */
-    HAL_RCCEx_CRSConfig (&RCC_CRSInitStruct);
+    HAL_RCCEx_CRSConfig(&RCC_CRSInitStruct);
 }
 
 /** Initialize the processor hardware.
@@ -206,7 +206,7 @@ void hw_preinit(void)
     __HAL_RCC_USART1_CLK_ENABLE();
     __HAL_RCC_CAN1_CLK_ENABLE();
     __HAL_RCC_TIM14_CLK_ENABLE();
-    __HAL_RCC_USB_CLK_ENABLE();    
+    __HAL_RCC_USB_CLK_ENABLE();
 
     /* setup pinmux */
     GPIO_InitTypeDef gpio_init;

--- a/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/HwInit.cxx
+++ b/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/HwInit.cxx
@@ -1,0 +1,225 @@
+/** \copyright
+ * Copyright (c) 2012, Stuart W Baker
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file HwInit.cxx
+ * This file represents the hardware initialization for the TI Tiva MCU.
+ *
+ * @author Stuart W. Baker
+ * @date 5 January 2013
+ */
+
+#include <new>
+#include <cstdint>
+
+#include "freertos_drivers/st/stm32f_hal_conf.hxx"
+#include "stm32f0xx_hal_rcc.h"
+#include "stm32f0xx_hal_flash.h"
+#include "stm32f0xx_hal_gpio.h"
+#include "stm32f0xx_hal_gpio_ex.h"
+#include "stm32f0xx_hal_dma.h"
+#include "stm32f0xx_hal_tim.h"
+
+#include "os/OS.hxx"
+#include "Stm32Uart.hxx"
+#include "Stm32Can.hxx"
+#include "Stm32EEPROMEmulation.hxx"
+#include "hardware.hxx"
+
+/** override stdin */
+const char *STDIN_DEVICE = "/dev/ser0";
+
+/** override stdout */
+const char *STDOUT_DEVICE = "/dev/ser0";
+
+/** override stderr */
+const char *STDERR_DEVICE = "/dev/ser0";
+
+/** UART 0 serial driver instance */
+// static Stm32Uart uart0("/dev/ser0", USART1, USART1_IRQn);
+
+/** CAN 0 CAN driver instance */
+static Stm32Can can0("/dev/can0");
+
+/** EEPROM emulation driver. The file size might be made bigger. */
+static Stm32EEPROMEmulation eeprom0("/dev/eeprom", 512);
+
+const size_t EEPROMEmulation::SECTOR_SIZE = 2048;
+
+extern "C" {
+
+/** Blink LED */
+uint32_t blinker_pattern = 0;
+static uint32_t rest_pattern = 0;
+
+void hw_set_to_safe(void)
+{
+}
+
+void resetblink(uint32_t pattern)
+{
+    BLINKER_RAW_Pin::set(pattern ? true : false);
+    blinker_pattern = pattern;
+    /* make a timer event trigger immediately */
+}
+
+void setblink(uint32_t pattern)
+{
+    resetblink(pattern);
+}
+
+void timer14_interrupt_handler(void)
+{
+    //
+    // Clear the timer interrupt.
+    //
+    TIM14->SR = ~TIM_IT_UPDATE;
+
+    // Set output LED.
+    BLINKER_RAW_Pin::set(rest_pattern & 1);
+
+    // Shift and maybe reset pattern.
+    rest_pattern >>= 1;
+    if (!rest_pattern)
+    {
+        rest_pattern = blinker_pattern;
+    }
+}
+
+void diewith(uint32_t pattern)
+{
+    // vPortClearInterruptMask(0x20);
+    asm("cpsie i\n");
+
+    resetblink(pattern);
+    while (1)
+        ;
+}
+
+/** Setup the system clock */
+static void clock_setup(void)
+{
+    /* reset clock configuration to default state */
+    RCC->CR = RCC_CR_HSITRIM_4 | RCC_CR_HSION;
+    while (!(RCC->CR & RCC_CR_HSIRDY))
+        ;
+
+#define USE_EXTERNAL_8_MHz_CLOCK_SOURCE 0
+/* configure PLL:  8 MHz * 6 = 48 MHz */
+#if USE_EXTERNAL_8_MHz_CLOCK_SOURCE
+    RCC->CR |= RCC_CR_HSEON;
+    while (!(RCC->CR & RCC_CR_HSERDY))
+        ;
+    RCC->CFGR = RCC_CFGR_PLLMUL6 | RCC_CFGR_PLLSRC_HSE_PREDIV | RCC_CFGR_SW_HSE;
+    while (!((RCC->CFGR & RCC_CFGR_SWS) == RCC_CFGR_SWS_HSE))
+        ;
+#else
+    RCC->CFGR = RCC_CFGR_PLLMUL6 | RCC_CFGR_PLLSRC_HSI_PREDIV | RCC_CFGR_SW_HSI;
+    while (!((RCC->CFGR & RCC_CFGR_SWS) == RCC_CFGR_SWS_HSI))
+        ;
+#endif
+    /* enable PLL */
+    RCC->CR |= RCC_CR_PLLON;
+    while (!(RCC->CR & RCC_CR_PLLRDY))
+        ;
+
+    /* set PLL as system clock */
+    RCC->CFGR = (RCC->CFGR & (~RCC_CFGR_SW)) | RCC_CFGR_SW_PLL;
+    while (!((RCC->CFGR & RCC_CFGR_SWS) == RCC_CFGR_SWS_PLL))
+        ;
+}
+
+/** Initialize the processor hardware.
+ */
+void hw_preinit(void)
+{
+    /* Globally disables interrupts until the FreeRTOS scheduler is up. */
+    asm("cpsid i\n");
+
+    /* these FLASH settings enable opertion at 48 MHz */
+    __HAL_FLASH_PREFETCH_BUFFER_ENABLE();
+    __HAL_FLASH_SET_LATENCY(FLASH_LATENCY_1);
+
+    /* setup the system clock */
+    clock_setup();
+
+    /* enable peripheral clocks */
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+    __HAL_RCC_USART1_CLK_ENABLE();
+    __HAL_RCC_CAN1_CLK_ENABLE();
+    __HAL_RCC_TIM14_CLK_ENABLE();
+
+    /* setup pinmux */
+    GPIO_InitTypeDef gpio_init;
+    memset(&gpio_init, 0, sizeof(gpio_init));
+
+    /* USART1 pinmux on PA9 and PA10 */
+    gpio_init.Mode = GPIO_MODE_AF_PP;
+    gpio_init.Pull = GPIO_PULLUP;
+    gpio_init.Speed = GPIO_SPEED_FREQ_HIGH;
+    gpio_init.Alternate = GPIO_AF1_USART1;
+    gpio_init.Pin = GPIO_PIN_9;
+    HAL_GPIO_Init(GPIOA, &gpio_init);
+    gpio_init.Pin = GPIO_PIN_10;
+    HAL_GPIO_Init(GPIOA, &gpio_init);
+
+    /* CAN pinmux on PB8 and PB9 */
+    gpio_init.Mode = GPIO_MODE_AF_PP;
+    gpio_init.Pull = GPIO_PULLUP;
+    gpio_init.Speed = GPIO_SPEED_FREQ_HIGH;
+    gpio_init.Alternate = GPIO_AF4_CAN;
+    gpio_init.Pin = GPIO_PIN_8;
+    HAL_GPIO_Init(GPIOB, &gpio_init);
+    gpio_init.Pin = GPIO_PIN_9;
+    HAL_GPIO_Init(GPIOB, &gpio_init);
+
+    GpioInit::hw_init();
+
+    /* Initializes the blinker timer. */
+    TIM_HandleTypeDef TimHandle;
+    memset(&TimHandle, 0, sizeof(TimHandle));
+    TimHandle.Instance = TIM14;
+    TimHandle.Init.Period = configCPU_CLOCK_HZ / 10000 / 8;
+    TimHandle.Init.Prescaler = 10000;
+    TimHandle.Init.ClockDivision = 0;
+    TimHandle.Init.CounterMode = TIM_COUNTERMODE_UP;
+    TimHandle.Init.RepetitionCounter = 0;
+    if (HAL_TIM_Base_Init(&TimHandle) != HAL_OK)
+    {
+        /* Initialization Error */
+        HASSERT(0);
+    }
+    if (HAL_TIM_Base_Start_IT(&TimHandle) != HAL_OK)
+    {
+        /* Starting Error */
+        HASSERT(0);
+    }
+    SetInterruptPriority(TIM14_IRQn, 0);
+    NVIC_EnableIRQ(TIM14_IRQn);
+}
+
+}

--- a/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/Makefile
+++ b/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/Makefile
@@ -1,0 +1,77 @@
+APP_PATH ?= $(realpath ../..)
+-include $(APP_PATH)/config.mk
+-include local_config.mk
+
+SUBDIRS=
+
+OPENMRNPATH ?= $(shell \
+sh -c "if [ \"X`printenv OPENMRNPATH`\" != \"X\" ]; then printenv OPENMRNPATH; \
+     elif [ -d /opt/openmrn/src ]; then echo /opt/openmrn; \
+     elif [ -d ~/openmrn/src ]; then echo ~/openmrn; \
+     elif [ -d ../../../src ]; then echo ../../..; \
+     else echo OPENMRNPATH not found; fi" \
+)
+
+-include $(OPENMRNPATH)/etc/config.mk
+LINKCORELIBS = -lopenlcb -lutils
+
+include $(OPENMRNPATH)/etc/stm32cubef0.mk
+
+CFLAGSEXTRA += -DSTM32F072xB
+CXXFLAGSEXTRA += -DSTM32F072xB
+SYSLIBRARIES += -lfreertos_drivers_stm32cubef071xb_2xb
+include find-emulator.mk
+#OPENOCDARGS = -f board/st_nucleo_f0.cfg
+
+export TARGET := bare.armv6m
+
+include $(OPENMRNPATH)/etc/prog.mk
+
+ifndef DEFAULT_ADDRESS
+DEFAULT_ADDRESS=0xff
+endif
+
+include $(OPENMRNPATH)/etc/node_id.mk
+
+SYSLIB_SUBDIRS=
+OBJEXTRA=
+LDFLAGSEXTRA += -nostartfiles 
+
+all: $(EXECUTABLE).bin
+
+# How to use: make multibin ADDRESS=0x20 ADDRHIGH=0x45 NUM=3
+# starting address, high bits (user range), count
+multibin:
+	for i in $$(seq 1 $(NUM)) ; do $(MAKE) $(EXECUTABLE).bin ADDRESS=$$(printf 0x%02x $$(($(ADDRESS)+$$i))) ; cp $(EXECUTABLE).bin $(EXECUTABLE).$(MCU_SHORT).$$(printf %02x%02x $(ADDRHIGH) $$(($(ADDRESS)+$$i-1))).bin ; done
+
+ifeq ($(call find_missing_deps,OPENOCDPATH OPENOCDSCRIPTSPATH),)
+
+flash: $(EXECUTABLE)$(EXTENTION) $(EXECUTABLE).bin $(EXECUTABLE).lst
+	@if ps ax -o comm | grep -q openocd ; then echo openocd already running. quit existing first. ; exit 1 ; fi
+	$(GDB) $< -ex "target remote | $(OPENOCDPATH)/openocd -c \"gdb_port pipe\" --search $(OPENOCDSCRIPTSPATH) $(OPENOCDARGS)" -ex "monitor reset halt" -ex "load" -ex "monitor reset init" -ex "monitor reset run"  -ex "detach" -ex "quit"
+
+lflash: $(EXECUTABLE).bin $(EXECUTABLE).lst
+	@if ps ax -o comm | grep -q openocd ; then echo openocd already running. quit existing first. ; exit 1 ; fi
+	$(GDB) $< -ex "target remote | $(OPENOCDPATH)/openocd -c \"gdb_port pipe\" --search $(OPENOCDSCRIPTSPATH) $(OPENOCDARGS)" -ex "monitor reset halt" -ex "monitor program $< 0x08000000 verify reset exit" -ex "monitor reset run"  -ex "detach" -ex "quit"
+
+RELEASEDIR=./releases/$(shell date +%Y-%m-%d-%H-%M-%S)
+
+release: $(EXECUTABLE)$(EXTENTION) $(EXECUTABLE).bin $(EXECUTABLE).lst
+	mkdir -p $(RELEASEDIR)
+	cp -fax $(EXECUTABLE){$(EXTENTION),.bin,.lst,.map} $(RELEASEDIR)
+	ln -sf $(RELEASEDIR) latest-release
+
+release-flash:
+	$(GDB) latest-release/*elf -ex "target remote | $(OPENOCDPATH)/openocd -c \"gdb_port pipe\" --search $(OPENOCDSCRIPTSPATH) $(OPENOCDARGS)" -ex "monitor reset halt" -ex "load" -ex "monitor reset init" -ex "monitor reset run"  -ex "detach" -ex "quit"
+
+gdb:
+	@if ps ax -o comm | grep -q openocd ; then echo openocd already running. quit existing first. ; exit 1 ; fi
+	$(GDB) $(EXECUTABLE)$(EXTENTION) -ex "target remote | $(OPENOCDPATH)/openocd -c \"gdb_port pipe\" --search $(OPENOCDSCRIPTSPATH) $(OPENOCDARGS)" -ex "continue" # -ex "monitor reset halt"
+
+else
+
+flash gdb:
+	echo OPENOCD not found ; exit 1
+
+endif
+

--- a/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/Makefile
+++ b/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/Makefile
@@ -13,17 +13,14 @@ sh -c "if [ \"X`printenv OPENMRNPATH`\" != \"X\" ]; then printenv OPENMRNPATH; \
 )
 
 -include $(OPENMRNPATH)/etc/config.mk
-LINKCORELIBS = -lopenlcb -lutils
-
 include $(OPENMRNPATH)/etc/stm32cubef0.mk
 
 CFLAGSEXTRA += -DSTM32F072xB
 CXXFLAGSEXTRA += -DSTM32F072xB
-SYSLIBRARIES += -lfreertos_drivers_stm32cubef071xb_2xb
+SYSLIBRARIESEXTRA += -lfreertos_drivers_stm32cubef071xb_2xb -lfreertos_drivers_tinyusb_stm32f072xb
 include find-emulator.mk
-#OPENOCDARGS = -f board/st_nucleo_f0.cfg
 
-export TARGET := bare.armv6m
+export TARGET := freertos.armv6m
 
 include $(OPENMRNPATH)/etc/prog.mk
 
@@ -32,10 +29,6 @@ DEFAULT_ADDRESS=0xff
 endif
 
 include $(OPENMRNPATH)/etc/node_id.mk
-
-SYSLIB_SUBDIRS=
-OBJEXTRA=
-LDFLAGSEXTRA += -nostartfiles 
 
 all: $(EXECUTABLE).bin
 

--- a/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/Makefile
+++ b/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/Makefile
@@ -37,6 +37,8 @@ all: $(EXECUTABLE).bin
 multibin:
 	for i in $$(seq 1 $(NUM)) ; do $(MAKE) $(EXECUTABLE).bin ADDRESS=$$(printf 0x%02x $$(($(ADDRESS)+$$i))) ; cp $(EXECUTABLE).bin $(EXECUTABLE).$(MCU_SHORT).$$(printf %02x%02x $(ADDRHIGH) $$(($(ADDRESS)+$$i-1))).bin ; done
 
+startup.o: CFLAGS+= -DHAL_RCC_GetSysClockFreq=OBSOLETEClock
+
 ifeq ($(call find_missing_deps,OPENOCDPATH OPENOCDSCRIPTSPATH),)
 
 flash: $(EXECUTABLE)$(EXTENTION) $(EXECUTABLE).bin $(EXECUTABLE).lst

--- a/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/find-emulator.mk
+++ b/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/find-emulator.mk
@@ -1,0 +1,1 @@
+../../../../boards/st-stm32f0x1_x2_x8-generic/find-emulator.mk

--- a/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/hardware.hxx
+++ b/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/hardware.hxx
@@ -1,0 +1,15 @@
+
+#include "Stm32Gpio.hxx"
+#include "utils/GpioInitializer.hxx"
+
+GPIO_PIN(LED_ORA, LedPin, C, 8);
+GPIO_PIN(LED_GREEN, LedPin, C, 9);
+GPIO_PIN(LED_RED_RAW, LedPin, C, 6);
+GPIO_PIN(LED_BLUE, LedPin, C, 7);
+
+GPIO_PIN(SW_USER, GpioInputPD, A, 0);
+
+typedef GpioInitializer<                          //
+    LED_RED_RAW_Pin, LED_GREEN_Pin, LED_ORA_Pin, LED_BLUE_Pin> GpioInit;
+
+typedef LED_RED_RAW_Pin BLINKER_RAW_Pin;

--- a/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/hardware.hxx
+++ b/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/hardware.hxx
@@ -7,7 +7,8 @@ using LED_GREEN_Pin = ::InvertedGpio<LED_GREEN_RAW_Pin>;
 GPIO_PIN(LED_OTHER_RAW, LedPin, F, 1);
 using LED_OTHER_Pin = ::InvertedGpio<LED_OTHER_RAW_Pin>;
 
-typedef GpioInitializer<                          //
-    LED_GREEN_RAW_Pin, LED_OTHER_RAW_Pin> GpioInit;
+typedef GpioInitializer< //
+    LED_GREEN_RAW_Pin, LED_OTHER_RAW_Pin>
+    GpioInit;
 
 typedef LED_GREEN_Pin BLINKER_RAW_Pin;

--- a/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/hardware.hxx
+++ b/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/hardware.hxx
@@ -2,14 +2,12 @@
 #include "Stm32Gpio.hxx"
 #include "utils/GpioInitializer.hxx"
 
-GPIO_PIN(LED_ORA, LedPin, C, 8);
-GPIO_PIN(LED_GREEN, LedPin, C, 9);
-GPIO_PIN(LED_RED_RAW, LedPin, C, 6);
-GPIO_PIN(LED_BLUE, LedPin, C, 7);
-
-GPIO_PIN(SW_USER, GpioInputPD, A, 0);
+GPIO_PIN(LED_GREEN_RAW, LedPin, F, 0);
+using LED_GREEN_Pin = ::InvertedGpio<LED_GREEN_RAW_Pin>;
+GPIO_PIN(LED_OTHER_RAW, LedPin, F, 1);
+using LED_OTHER_Pin = ::InvertedGpio<LED_OTHER_RAW_Pin>;
 
 typedef GpioInitializer<                          //
-    LED_RED_RAW_Pin, LED_GREEN_Pin, LED_ORA_Pin, LED_BLUE_Pin> GpioInit;
+    LED_GREEN_RAW_Pin, LED_OTHER_RAW_Pin> GpioInit;
 
-typedef LED_RED_RAW_Pin BLINKER_RAW_Pin;
+typedef LED_GREEN_Pin BLINKER_RAW_Pin;

--- a/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/memory_map.ld
+++ b/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/memory_map.ld
@@ -1,0 +1,1 @@
+../../../../boards/st-stm32f072b-discovery/memory_map.ld

--- a/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/startup.c
+++ b/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/startup.c
@@ -1,0 +1,1 @@
+../../../../boards/st-stm32f0x1_x2_x8-generic/startup.c

--- a/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/target.ld
+++ b/applications/usb_can/targets/freertos.armv6m.stm32f072cb-gol/target.ld
@@ -1,0 +1,1 @@
+../../../../boards/st-stm32f0x1_x2_x8-generic/target.ld

--- a/boards/st-stm32f0x1_x2_x8-generic/find-emulator.mk
+++ b/boards/st-stm32f0x1_x2_x8-generic/find-emulator.mk
@@ -1,0 +1,21 @@
+# Searches the connected USB devices for a known emulator for the
+# STM32F0. Exports the OPENOCDARGS variable when found.
+# All emulators here are configured to use 2-wire SWD mode.
+
+USBLIST=$(shell lsusb)
+
+ifneq ($(findstring 0483:374b,$(USBLIST)),)
+$(info emulator ST-Link V2.1 or nucleo)
+OPENOCDARGS = -f board/st_nucleo_f0.cfg
+else ifneq ($(findstring 0451:bef3,$(USBLIST)),)
+$(info emulator TI CC3220SF launchpad CMSIS-DAP)
+OPENOCDARGS = -f interface/xds110.cfg -c 'transport select swd' -c 'adapter_khz 950' -f target/stm32f0x.cfg -c 'reset_config srst_only' -c 'adapter_khz 950'
+else ifneq ($(findstring 15ba:002a,$(USBLIST)),)
+$(info emulator Olimex arm-usb-tiny-H)
+OPENOCDARGS = -f interface/ftdi/olimex-arm-usb-tiny-h.cfg -f interface/ftdi/swd-resistor-hack.cfg -f target/stm32f0x.cfg
+else ifneq ($(findstring 15ba:002b,$(USBLIST)),)
+$(info emulator Olimex arm-usb-ocd-H)
+OPENOCDARGS = -f interface/ftdi/olimex-arm-usb-ocd-h.cfg -f interface/ftdi/swd-resistor-hack.cfg -f target/stm32f0x.cfg
+else
+OPENOCDARGS = " -emulator-not-found-add-your-usb-device-to-boards_st-stm32f0x_find-emulator.mk "
+endif

--- a/etc/path.mk
+++ b/etc/path.mk
@@ -718,6 +718,18 @@ SXMLCPATH:=$(TRYPATH)
 endif
 endif #SXMLCPATH
 
+################ TinyUSB ##################
+ifndef TINYUSBPATH
+SEARCHPATH := \
+  /opt/tinyusb/default \
+  /opt/tinyusb/tinyusb \
+
+TRYPATH:=$(call findfirst,src/tusb.c,$(SEARCHPATH))
+ifneq ($(TRYPATH),)
+TINYUSBPATH:=$(TRYPATH)
+endif
+endif #TINYUSBPATH
+
 
 endif # ifndef OPENMRN_EXPLICIT_DEPS_ONLY
 endif # if  $(OS)  != Windows_NT

--- a/etc/tinyusb.mk
+++ b/etc/tinyusb.mk
@@ -1,0 +1,14 @@
+include $(OPENMRNPATH)/etc/path.mk
+
+ifdef TINYUSBPATH
+INCLUDES += -I$(TINYUSBPATH)/src \
+	-I$(OPENMRNPATH)/src/freertos_drivers/tinyusb
+
+TUSB_VPATH = $(TINYUSBPATH)/src \
+        $(TINYUSBPATH)/src/class/cdc \
+        $(TINYUSBPATH)/src/common \
+        $(TINYUSBPATH)/src/device \
+
+endif
+
+DEPS += TINYUSBPATH

--- a/src/freertos_drivers/sources
+++ b/src/freertos_drivers/sources
@@ -87,7 +87,8 @@ SUBDIRS += drivers_lpc2368
 endif
 
 ifeq ($(TARGET),freertos.armv6m)
-SUBDIRS += drivers_lpc11cxx stm32cubef071xb_2xb stm32cubef091xc
+SUBDIRS += drivers_lpc11cxx stm32cubef071xb_2xb stm32cubef091xc \
+        tinyusb_stm32f072xb
 # Avoids exception handling from operator new.
 CXXSRCS += c++_operators.cxx
 # Implementations for the __atomic_* "builtins" for GCC.

--- a/src/freertos_drivers/st/Stm32UsbCdc.cxx
+++ b/src/freertos_drivers/st/Stm32UsbCdc.cxx
@@ -4,7 +4,7 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are  permitted provided that the following conditions are met:
- * 
+ *
  *  - Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  *
@@ -34,5 +34,3 @@
 #include "freertos_drivers/st/Stm32UsbCdc.hxx"
 
 #include "freertos_drivers/tinyusb/TinyUsbCdcImpl.hxx"
-
-

--- a/src/freertos_drivers/st/Stm32UsbCdc.cxx
+++ b/src/freertos_drivers/st/Stm32UsbCdc.cxx
@@ -24,14 +24,14 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * \file Stm32CdcUsb.cxx
+ * \file Stm32UsbCdc.cxx
  * Device driver for the STM32 devices using the TinyUsb stack.
  *
  * @author Balazs Racz
  * @date 13 Nov 2023
  */
 
-#include "freertos_drivers/st/Stm32CdcUsb.hxx"
+#include "freertos_drivers/st/Stm32UsbCdc.hxx"
 
 #include "freertos_drivers/tinyusb/TinyUsbCdcImpl.hxx"
 

--- a/src/freertos_drivers/st/Stm32UsbCdc.cxx
+++ b/src/freertos_drivers/st/Stm32UsbCdc.cxx
@@ -1,0 +1,38 @@
+/** \copyright
+ * Copyright (c) 2023, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ * 
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file Stm32CdcUsb.cxx
+ * Device driver for the STM32 devices using the TinyUsb stack.
+ *
+ * @author Balazs Racz
+ * @date 13 Nov 2023
+ */
+
+#include "freertos_drivers/st/Stm32CdcUsb.hxx"
+
+#include "freertos_drivers/tinyusb/TinyUsbCdcImpl.hxx"
+
+

--- a/src/freertos_drivers/st/Stm32UsbCdc.hxx
+++ b/src/freertos_drivers/st/Stm32UsbCdc.hxx
@@ -4,7 +4,7 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are  permitted provided that the following conditions are met:
- * 
+ *
  *  - Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  *
@@ -45,9 +45,13 @@
 // Make sure that the USB clock is set up in `hw_preinit()`. Use the Clock
 // Recovery System if there is no crystal. Set up the USB pin map in
 // hw_preinit.
-class Stm32UsbCdc : public TinyUsbCdc {
+class Stm32UsbCdc : public TinyUsbCdc
+{
 public:
-    Stm32UsbCdc(const char* name) : TinyUsbCdc(name) {}
+    Stm32UsbCdc(const char *name)
+        : TinyUsbCdc(name)
+    {
+    }
 };
 
 #endif // _FREERTOS_DRIVERS_ST_STM32CDCUSB_HXX_

--- a/src/freertos_drivers/st/Stm32UsbCdc.hxx
+++ b/src/freertos_drivers/st/Stm32UsbCdc.hxx
@@ -24,7 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * \file Stm32CdcUsb.hxx
+ * \file Stm32UsbCdc.hxx
  * Device driver for the STM32 devices using the TinyUsb stack.
  *
  * @author Balazs Racz

--- a/src/freertos_drivers/st/Stm32UsbCdc.hxx
+++ b/src/freertos_drivers/st/Stm32UsbCdc.hxx
@@ -1,0 +1,53 @@
+/** \copyright
+ * Copyright (c) 2023, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ * 
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file Stm32CdcUsb.hxx
+ * Device driver for the STM32 devices using the TinyUsb stack.
+ *
+ * @author Balazs Racz
+ * @date 13 Nov 2023
+ */
+
+#ifndef _FREERTOS_DRIVERS_ST_STM32CDCUSB_HXX_
+#define _FREERTOS_DRIVERS_ST_STM32CDCUSB_HXX_
+
+#include "freertos_drivers/tinyusb/TinyUsbCdc.hxx"
+
+// Usage:
+//
+// Define an instance in HwInit.cxx.
+// `Stm32UsbCdc serialUsb("/dev/serialusb");`
+// in `hw_postinit()`, call `serialUsb.hw_postinit();`
+//
+// Make sure that the USB clock is set up in `hw_preinit()`. Use the Clock
+// Recovery System if there is no crystal. Set up the USB pin map in
+// hw_preinit.
+class Stm32UsbCdc : public TinyUsbCdc {
+public:
+    Stm32UsbCdc(const char* name) : TinyUsbCdc(name) {}
+};
+
+#endif // _FREERTOS_DRIVERS_ST_STM32CDCUSB_HXX_

--- a/src/freertos_drivers/tinyusb/TinyUsbCdc.hxx
+++ b/src/freertos_drivers/tinyusb/TinyUsbCdc.hxx
@@ -4,7 +4,7 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are  permitted provided that the following conditions are met:
- * 
+ *
  *  - Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  *
@@ -38,37 +38,47 @@
 #include "os/OS.hxx"
 #include "utils/Singleton.hxx"
 
-class TinyUsbCdc : public Node, public Singleton<TinyUsbCdc> {
+class TinyUsbCdc : public Node, public Singleton<TinyUsbCdc>
+{
 public:
-    TinyUsbCdc(const char* name)
-        : Node(name) {}
+    TinyUsbCdc(const char *name)
+        : Node(name)
+    {
+    }
     ~TinyUsbCdc();
-    
+
     // Call this function once from hw_postinit.
     void hw_postinit();
 
     // Called from static C callback functions.
     inline void rx_available();
     inline void tx_complete();
-    
+
 private:
-    void enable() override {}
-    void disable() override {}
-    void flush_buffers() override {}
-    
+    void enable() override
+    {
+    }
+    void disable() override
+    {
+    }
+    void flush_buffers() override
+    {
+    }
+
     /** Device select method. Default impementation returns true.
      * @param file reference to the file
      * @param mode FREAD for read active, FWRITE for write active, 0 for
      *        exceptions
      * @return true if active, false if inactive
      */
-    bool select(File* file, int mode) override;
-    
+    bool select(File *file, int mode) override;
+
     /** Read from a file or device.
      * @param file file reference for this device
      * @param buf location to place read data
      * @param count number of bytes to read
-     * @return number of bytes read upon success, -1 upon failure with errno containing the cause
+     * @return number of bytes read upon success, -1 upon failure with errno
+     * containing the cause
      */
     ssize_t read(File *file, void *buf, size_t count) override;
 
@@ -76,14 +86,16 @@ private:
      * @param file file reference for this device
      * @param buf location to find write data
      * @param count number of bytes to write
-     * @return number of bytes written upon success, -1 upon failure with errno containing the cause
+     * @return number of bytes written upon success, -1 upon failure with errno
+     * containing the cause
      */
     ssize_t write(File *file, const void *buf, size_t count) override;
-    
+
     /// Thread for running the tiny usb device stack.
-    class UsbDeviceThread : public OSThread {
+    class UsbDeviceThread : public OSThread
+    {
     public:
-        void* entry() override;
+        void *entry() override;
     } usbdThread_;
 
     /// Handles the select for incoming data (read).
@@ -92,8 +104,5 @@ private:
     /// Handles the select for outgoing data (write).
     Device::SelectInfo selectInfoWrite_;
 };
-
-
-
 
 #endif // _FREERTOS_DRIVERS_TINYUSB_TINYUSBCDC_HXX_

--- a/src/freertos_drivers/tinyusb/TinyUsbCdc.hxx
+++ b/src/freertos_drivers/tinyusb/TinyUsbCdc.hxx
@@ -1,0 +1,82 @@
+/** \copyright
+ * Copyright (c) 2023, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ * 
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file TinyUsbCdc.hxx
+ * Base class for implementing a CDC Device driver using the TinyUsb stack.
+ *
+ * @author Balazs Racz
+ * @date 13 Nov 2023
+ */
+
+#ifndef _FREERTOS_DRIVERS_TINYUSB_TINYUSBCDC_HXX_
+#define _FREERTOS_DRIVERS_TINYUSB_TINYUSBCDC_HXX_
+
+#include "Serial.hxx"
+#include "os/OS.hxx"
+
+class TinyUsbCdc : public Serial, public Singleton<TinyUsbCdc> {
+public:
+    TinyUsbCdc(const char* name)
+        : Serial(name, 128 /* tx buffer size */, 0 /* no rx buffer */) {}
+
+    // Call this function once from hw_postinit.
+    void hw_postinit();
+    
+private:
+
+    /** Function to try and transmit a character.
+     */
+    void tx_char() override;
+
+    /** Device select method. Default impementation returns true.
+     * @param file reference to the file
+     * @param mode FREAD for read active, FWRITE for write active, 0 for
+     *        exceptions
+     * @return true if active, false if inactive
+     */
+    bool select(File* file, int mode) override;
+    
+    /** Read from a file or device.
+     * @param file file reference for this device
+     * @param buf location to place read data
+     * @param count number of bytes to read
+     * @return number of bytes read upon success, -1 upon failure with errno containing the cause
+     */
+    ssize_t read(File *file, void *buf, size_t count) override;
+
+    /// Thread for running the tiny usb device stack.
+    class UsbDeviceThread : public OSThread {
+    public:
+        UsbDeviceThread();
+        
+        void entry() override;
+    } usbdThread_;
+};
+
+
+
+
+#endif // _FREERTOS_DRIVERS_TINYUSB_TINYUSBCDC_HXX_

--- a/src/freertos_drivers/tinyusb/TinyUsbCdc.hxx
+++ b/src/freertos_drivers/tinyusb/TinyUsbCdc.hxx
@@ -46,10 +46,15 @@ public:
     
     // Call this function once from hw_postinit.
     void hw_postinit();
+
+    // Called from static C callback functions.
+    inline void rx_available();
+    inline void tx_complete();
     
 private:
     void enable() override {}
     void disable() override {}
+    void flush_buffers() override {}
     
     /** Device select method. Default impementation returns true.
      * @param file reference to the file

--- a/src/freertos_drivers/tinyusb/TinyUsbCdcImpl.hxx
+++ b/src/freertos_drivers/tinyusb/TinyUsbCdcImpl.hxx
@@ -45,7 +45,7 @@
 #include "tusb.h"
 
 #ifndef USBD_STACK_SIZE
-#define USBD_STACK_SIZE 2048
+#define USBD_STACK_SIZE 768
 #endif
 
 #ifndef USBD_TASK_PRIO
@@ -160,6 +160,11 @@ ssize_t TinyUsbCdc::write(File *file, const void *buf, size_t count) {
     if (!result && (file->flags & O_NONBLOCK))
     {
         return -EAGAIN;
+    }
+
+    if (result)
+    {
+        tud_cdc_write_flush();
     }
 
     return result;

--- a/src/freertos_drivers/tinyusb/TinyUsbCdcImpl.hxx
+++ b/src/freertos_drivers/tinyusb/TinyUsbCdcImpl.hxx
@@ -4,7 +4,7 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are  permitted provided that the following conditions are met:
- * 
+ *
  *  - Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  *
@@ -38,8 +38,8 @@
 
 #include "freertos_drivers/tinyusb/TinyUsbCdc.hxx"
 
-#include "os/OS.hxx"
 #include "freertos_drivers/common/DeviceBuffer.hxx"
+#include "os/OS.hxx"
 #include <fcntl.h>
 
 #include "tusb.h"
@@ -52,14 +52,16 @@
 #define USBD_TASK_PRIO 3
 #endif
 
-TinyUsbCdc::~TinyUsbCdc() {}
+TinyUsbCdc::~TinyUsbCdc()
+{
+}
 
 void TinyUsbCdc::hw_postinit()
 {
     usbdThread_.start("tinyusb_device", USBD_TASK_PRIO, USBD_STACK_SIZE);
 }
 
-void* TinyUsbCdc::UsbDeviceThread::entry()
+void *TinyUsbCdc::UsbDeviceThread::entry()
 {
     // init device stack on configured roothub port
     // This should be called after scheduler/kernel is started.
@@ -122,7 +124,8 @@ ssize_t TinyUsbCdc::read(File *file, void *buf, size_t count)
     return result;
 }
 
-ssize_t TinyUsbCdc::write(File *file, const void *buf, size_t count) {
+ssize_t TinyUsbCdc::write(File *file, const void *buf, size_t count)
+{
     const unsigned char *data = (const unsigned char *)buf;
     ssize_t result = 0;
 
@@ -213,11 +216,13 @@ bool TinyUsbCdc::select(File *file, int mode)
     return retval;
 }
 
-inline void TinyUsbCdc::rx_available() {
+inline void TinyUsbCdc::rx_available()
+{
     Device::select_wakeup(&selectInfoRead_);
 }
 
-inline void TinyUsbCdc::tx_complete() {
+inline void TinyUsbCdc::tx_complete()
+{
     Device::select_wakeup(&selectInfoWrite_);
 }
 
@@ -226,64 +231,72 @@ extern "C" {
 // Invoked when CDC interface received data from host
 void tud_cdc_rx_cb(uint8_t itf)
 {
-  (void) itf;
-  Singleton<TinyUsbCdc>::instance()->rx_available();
+    (void)itf;
+    Singleton<TinyUsbCdc>::instance()->rx_available();
 }
 
-// Invoked when a TX is complete and therefore space becomes available in TX buffer
+// Invoked when a TX is complete and therefore space becomes available in TX
+// buffer
 void tud_cdc_tx_complete_cb(uint8_t itf)
 {
-  (void) itf;
-  Singleton<TinyUsbCdc>::instance()->tx_complete();
+    (void)itf;
+    Singleton<TinyUsbCdc>::instance()->tx_complete();
 }
-
 
 // ===================== USB DESCRIPTORS =============================
 
-/* A combination of interfaces must have a unique product id, since PC will save device driver after the first plug.
- * Same VID/PID with different interface e.g MSC (first), then CDC (later) will possibly cause system error on PC.
+/* A combination of interfaces must have a unique product id, since PC will save
+ * device driver after the first plug. Same VID/PID with different interface e.g
+ * MSC (first), then CDC (later) will possibly cause system error on PC.
  *
  * Auto ProductID layout's Bitmap:
  *   [MSB]         HID | MSC | CDC          [LSB]
  */
-#define _PID_MAP(itf, n)  ( (CFG_TUD_##itf) << (n) )
-#define USB_PID           (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
-                           _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )
+#define _PID_MAP(itf, n) ((CFG_TUD_##itf) << (n))
+#define USB_PID                                                                \
+    (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) |         \
+        _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4))
 
-#define USB_VID   0xCAFE
-#define USB_BCD   0x0200
+#define USB_VID 0xCAFE
+#define USB_BCD 0x0200
 
 // Invoked when received GET DEVICE DESCRIPTOR
 // Application return pointer to descriptor
-uint8_t const *tud_descriptor_device_cb(void) {
-  static tusb_desc_device_t const desc_device = {
-      .bLength = sizeof(tusb_desc_device_t),
-      .bDescriptorType = TUSB_DESC_DEVICE,
-      .bcdUSB = USB_BCD,
+uint8_t const *tud_descriptor_device_cb(void)
+{
+    static tusb_desc_device_t const desc_device = {
+        .bLength = sizeof(tusb_desc_device_t),
+        .bDescriptorType = TUSB_DESC_DEVICE,
+        .bcdUSB = USB_BCD,
 
-      // Use Interface Association Descriptor (IAD) for CDC
-      // As required by USB Specs IAD's subclass must be common class (2) and
-      // protocol must be IAD (1)
-      .bDeviceClass = TUSB_CLASS_MISC,
-      .bDeviceSubClass = MISC_SUBCLASS_COMMON,
-      .bDeviceProtocol = MISC_PROTOCOL_IAD,
+        // Use Interface Association Descriptor (IAD) for CDC
+        // As required by USB Specs IAD's subclass must be common class (2) and
+        // protocol must be IAD (1)
+        .bDeviceClass = TUSB_CLASS_MISC,
+        .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+        .bDeviceProtocol = MISC_PROTOCOL_IAD,
 
-      .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+        .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
 
-      .idVendor = USB_VID,
-      .idProduct = USB_PID,
-      .bcdDevice = 0x0100,
+        .idVendor = USB_VID,
+        .idProduct = USB_PID,
+        .bcdDevice = 0x0100,
 
-      .iManufacturer = 0x01,
-      .iProduct = 0x02,
-      .iSerialNumber = 0x03,
+        .iManufacturer = 0x01,
+        .iProduct = 0x02,
+        .iSerialNumber = 0x03,
 
-      .bNumConfigurations = 0x01};
+        .bNumConfigurations = 0x01};
 
-  return (uint8_t const *)&desc_device;
+    return (uint8_t const *)&desc_device;
 }
 
-enum { ITF_NUM_CDC = 0, ITF_NUM_CDC_DATA, ITF_NUM_TOTAL };
+enum
+{
+    ITF_NUM_CDC = 0,
+    ITF_NUM_CDC_DATA,
+    ITF_NUM_TOTAL
+};
 
 #define EPNUM_CDC_NOTIF 0x81
 #define EPNUM_CDC_OUT 0x02
@@ -299,8 +312,8 @@ uint8_t const desc_fs_configuration[] = {
 
     // Interface number, string index, EP notification address and size, EP data
     // address (out, in) and size.
-    TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT,
-                       EPNUM_CDC_IN, 64),
+    TUD_CDC_DESCRIPTOR(
+        ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 64),
 };
 
 #if TUD_OPT_HIGH_SPEED
@@ -315,8 +328,8 @@ uint8_t const desc_hs_configuration[] = {
 
     // Interface number, string index, EP notification address and size, EP data
     // address (out, in) and size.
-    TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT,
-                       EPNUM_CDC_IN, 512),
+    TUD_CDC_DESCRIPTOR(
+        ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 512),
 };
 
 // other speed configuration
@@ -343,27 +356,29 @@ tusb_desc_device_qualifier_t const desc_device_qualifier = {
 // information about a high-speed capable device that would change if the device
 // were operating at the other speed. If not highspeed capable stall this
 // request.
-uint8_t const *tud_descriptor_device_qualifier_cb(void) {
-  return (uint8_t const *)&desc_device_qualifier;
+uint8_t const *tud_descriptor_device_qualifier_cb(void)
+{
+    return (uint8_t const *)&desc_device_qualifier;
 }
 
 // Invoked when received GET OTHER SEED CONFIGURATION DESCRIPTOR request
 // Application return pointer to descriptor, whose contents must exist long
 // enough for transfer to complete Configuration descriptor in the other speed
 // e.g if high speed then this is for full speed and vice versa
-uint8_t const *tud_descriptor_other_speed_configuration_cb(uint8_t index) {
-  (void)index; // for multiple configurations
+uint8_t const *tud_descriptor_other_speed_configuration_cb(uint8_t index)
+{
+    (void)index; // for multiple configurations
 
-  // if link speed is high return fullspeed config, and vice versa
-  // Note: the descriptor type is OHER_SPEED_CONFIG instead of CONFIG
-  memcpy(desc_other_speed_config,
-         (tud_speed_get() == TUSB_SPEED_HIGH) ? desc_fs_configuration
-                                              : desc_hs_configuration,
-         CONFIG_TOTAL_LEN);
+    // if link speed is high return fullspeed config, and vice versa
+    // Note: the descriptor type is OHER_SPEED_CONFIG instead of CONFIG
+    memcpy(desc_other_speed_config,
+        (tud_speed_get() == TUSB_SPEED_HIGH) ? desc_fs_configuration
+                                             : desc_hs_configuration,
+        CONFIG_TOTAL_LEN);
 
-  desc_other_speed_config[1] = TUSB_DESC_OTHER_SPEED_CONFIG;
+    desc_other_speed_config[1] = TUSB_DESC_OTHER_SPEED_CONFIG;
 
-  return desc_other_speed_config;
+    return desc_other_speed_config;
 }
 
 #endif // highspeed
@@ -371,25 +386,26 @@ uint8_t const *tud_descriptor_other_speed_configuration_cb(uint8_t index) {
 // Invoked when received GET CONFIGURATION DESCRIPTOR
 // Application return pointer to descriptor
 // Descriptor contents must exist long enough for transfer to complete
-uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
-  (void)index; // for multiple configurations
+uint8_t const *tud_descriptor_configuration_cb(uint8_t index)
+{
+    (void)index; // for multiple configurations
 
 #if TUD_OPT_HIGH_SPEED
-  // Although we are highspeed, host may be fullspeed.
-  return (tud_speed_get() == TUSB_SPEED_HIGH) ? desc_hs_configuration
-                                              : desc_fs_configuration;
+    // Although we are highspeed, host may be fullspeed.
+    return (tud_speed_get() == TUSB_SPEED_HIGH) ? desc_hs_configuration
+                                                : desc_fs_configuration;
 #else
-  return desc_fs_configuration;
+    return desc_fs_configuration;
 #endif
 }
 
 // array of pointer to string descriptors
 char const *string_desc_arr[] = {
-    (const char[]){0x09, 0x04}, // 0: is supported language is English (0x0409)
-    "TinyUSB",                  // 1: Manufacturer
-    "TinyUSB Device",           // 2: Product
-    "123456789012",             // 3: Serials, should use chip ID
-    "TinyUSB CDC",              // 4: CDC Interface
+    (const char[]) {0x09, 0x04}, // 0: is supported language is English (0x0409)
+    "TinyUSB",                   // 1: Manufacturer
+    "TinyUSB Device",            // 2: Product
+    "123456789012",              // 3: Serials, should use chip ID
+    "TinyUSB CDC",               // 4: CDC Interface
 };
 
 static uint16_t _desc_str[32];
@@ -397,38 +413,43 @@ static uint16_t _desc_str[32];
 // Invoked when received GET STRING DESCRIPTOR request
 // Application return pointer to descriptor, whose contents must exist long
 // enough for transfer to complete
-uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
-  (void)langid;
+uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
+{
+    (void)langid;
 
-  uint8_t chr_count;
+    uint8_t chr_count;
 
-  if (index == 0) {
-    memcpy(&_desc_str[1], string_desc_arr[0], 2);
-    chr_count = 1;
-  } else {
-    // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
-    // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
-
-    if (!(index < sizeof(string_desc_arr) / sizeof(string_desc_arr[0])))
-      return NULL;
-
-    const char *str = string_desc_arr[index];
-
-    // Cap at max char
-    chr_count = (uint8_t)strlen(str);
-    if (chr_count > 31)
-      chr_count = 31;
-
-    // Convert ASCII string into UTF-16
-    for (uint8_t i = 0; i < chr_count; i++) {
-      _desc_str[1 + i] = str[i];
+    if (index == 0)
+    {
+        memcpy(&_desc_str[1], string_desc_arr[0], 2);
+        chr_count = 1;
     }
-  }
+    else
+    {
+        // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
+        // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
 
-  // first byte is length (including header), second byte is string type
-  _desc_str[0] = (uint16_t)((TUSB_DESC_STRING << 8) | (2 * chr_count + 2));
+        if (!(index < sizeof(string_desc_arr) / sizeof(string_desc_arr[0])))
+            return NULL;
 
-  return _desc_str;
+        const char *str = string_desc_arr[index];
+
+        // Cap at max char
+        chr_count = (uint8_t)strlen(str);
+        if (chr_count > 31)
+            chr_count = 31;
+
+        // Convert ASCII string into UTF-16
+        for (uint8_t i = 0; i < chr_count; i++)
+        {
+            _desc_str[1 + i] = str[i];
+        }
+    }
+
+    // first byte is length (including header), second byte is string type
+    _desc_str[0] = (uint16_t)((TUSB_DESC_STRING << 8) | (2 * chr_count + 2));
+
+    return _desc_str;
 }
 
 } // extern "C"

--- a/src/freertos_drivers/tinyusb/TinyUsbCdcImpl.hxx
+++ b/src/freertos_drivers/tinyusb/TinyUsbCdcImpl.hxx
@@ -250,7 +250,7 @@ void tud_cdc_tx_complete_cb(uint8_t itf)
 #define USB_PID           (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
                            _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )
 
-#define USB_VID   0xCafe
+#define USB_VID   0xCAFE
 #define USB_BCD   0x0200
 
 // Invoked when received GET DEVICE DESCRIPTOR

--- a/src/freertos_drivers/tinyusb/TinyUsbCdcImpl.hxx
+++ b/src/freertos_drivers/tinyusb/TinyUsbCdcImpl.hxx
@@ -1,0 +1,282 @@
+/** \copyright
+ * Copyright (c) 2023, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ * 
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file TinyUsbCdcImpl.hxx
+ * Base class for implementing a CDC Device driver using the TinyUsb stack.
+ *
+ * @author Balazs Racz
+ * @date 13 Nov 2023
+ */
+
+// This file does not compile standalone, instead it has to be included in the
+// board-speciofic Cdc driver implementation cxx file.
+#ifndef _FREERTOS_DRIVERS_TINYUSB_TINYUSBCDCIMPL_HXX_
+#define _FREERTOS_DRIVERS_TINYUSB_TINYUSBCDCIMPL_HXX_
+
+#include "freertos_drivers/tinyusb/TinyUsbCdc.hxx"
+
+#include "os/OS.hxx"
+
+#include "tusb.h"
+
+#ifndef USBD_STACK_SIZE
+#define USBD_STACK_SIZE 2048
+#endif
+
+#ifndef USBD_TASK_PRIO
+#define USBD_TASK_PRIO 3
+#endif
+
+void TinyUsbCdc::hw_postinit()
+{
+    usbdThread_.start("tinyusb_device", USBD_TASK_PRIO, USBD_STACK_SIZE);
+}
+
+void TinyUsbCdc::UsbDeviceThread::entry()
+{
+    // init device stack on configured roothub port
+    // This should be called after scheduler/kernel is started.
+    // Otherwise it could cause kernel issue since USB IRQ handler does use RTOS
+    // queue API.
+    tud_init(BOARD_TUD_RHPORT);
+
+    // RTOS forever loop
+    while (1)
+    {
+        // put this thread to waiting state until there is new events
+        tud_task();
+
+        // following code only run if tud_task() process at least 1 event
+        tud_cdc_write_flush();
+    }
+}
+
+
+extern "C" {
+
+// Invoked when CDC interface received data from host
+void tud_cdc_rx_cb(uint8_t itf)
+{
+  (void) itf;
+}
+
+
+// ===================== USB DESCRIPTORS =============================
+
+/* A combination of interfaces must have a unique product id, since PC will save device driver after the first plug.
+ * Same VID/PID with different interface e.g MSC (first), then CDC (later) will possibly cause system error on PC.
+ *
+ * Auto ProductID layout's Bitmap:
+ *   [MSB]         HID | MSC | CDC          [LSB]
+ */
+#define _PID_MAP(itf, n)  ( (CFG_TUD_##itf) << (n) )
+#define USB_PID           (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
+                           _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )
+
+#define USB_VID   0xCafe
+#define USB_BCD   0x0200
+
+// Invoked when received GET DEVICE DESCRIPTOR
+// Application return pointer to descriptor
+uint8_t const *tud_descriptor_device_cb(void) {
+  static tusb_desc_device_t const desc_device = {
+      .bLength = sizeof(tusb_desc_device_t),
+      .bDescriptorType = TUSB_DESC_DEVICE,
+      .bcdUSB = USB_BCD,
+
+      // Use Interface Association Descriptor (IAD) for CDC
+      // As required by USB Specs IAD's subclass must be common class (2) and
+      // protocol must be IAD (1)
+      .bDeviceClass = TUSB_CLASS_MISC,
+      .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+      .bDeviceProtocol = MISC_PROTOCOL_IAD,
+
+      .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+
+      .idVendor = USB_VID,
+      .idProduct = USB_PID,
+      .bcdDevice = 0x0100,
+
+      .iManufacturer = 0x01,
+      .iProduct = 0x02,
+      .iSerialNumber = 0x03,
+
+      .bNumConfigurations = 0x01};
+
+  return (uint8_t const *)&desc_device;
+}
+
+enum { ITF_NUM_CDC = 0, ITF_NUM_CDC_DATA, ITF_NUM_TOTAL };
+
+#define EPNUM_CDC_NOTIF 0x81
+#define EPNUM_CDC_OUT 0x02
+#define EPNUM_CDC_IN 0x82
+
+#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN)
+
+// full speed configuration
+uint8_t const desc_fs_configuration[] = {
+    // Config number, interface count, string index, total length, attribute,
+    // power in mA
+    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, 100),
+
+    // Interface number, string index, EP notification address and size, EP data
+    // address (out, in) and size.
+    TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT,
+                       EPNUM_CDC_IN, 64),
+};
+
+#if TUD_OPT_HIGH_SPEED
+// Per USB specs: high speed capable device must report device_qualifier and
+// other_speed_configuration
+
+// high speed configuration
+uint8_t const desc_hs_configuration[] = {
+    // Config number, interface count, string index, total length, attribute,
+    // power in mA
+    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, 100),
+
+    // Interface number, string index, EP notification address and size, EP data
+    // address (out, in) and size.
+    TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT,
+                       EPNUM_CDC_IN, 512),
+};
+
+// other speed configuration
+uint8_t desc_other_speed_config[CONFIG_TOTAL_LEN];
+
+// device qualifier is mostly similar to device descriptor since we don't change
+// configuration based on speed
+tusb_desc_device_qualifier_t const desc_device_qualifier = {
+    .bLength = sizeof(tusb_desc_device_qualifier_t),
+    .bDescriptorType = TUSB_DESC_DEVICE_QUALIFIER,
+    .bcdUSB = USB_BCD,
+
+    .bDeviceClass = TUSB_CLASS_MISC,
+    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+    .bDeviceProtocol = MISC_PROTOCOL_IAD,
+
+    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+    .bNumConfigurations = 0x01,
+    .bReserved = 0x00};
+
+// Invoked when received GET DEVICE QUALIFIER DESCRIPTOR request
+// Application return pointer to descriptor, whose contents must exist long
+// enough for transfer to complete. device_qualifier descriptor describes
+// information about a high-speed capable device that would change if the device
+// were operating at the other speed. If not highspeed capable stall this
+// request.
+uint8_t const *tud_descriptor_device_qualifier_cb(void) {
+  return (uint8_t const *)&desc_device_qualifier;
+}
+
+// Invoked when received GET OTHER SEED CONFIGURATION DESCRIPTOR request
+// Application return pointer to descriptor, whose contents must exist long
+// enough for transfer to complete Configuration descriptor in the other speed
+// e.g if high speed then this is for full speed and vice versa
+uint8_t const *tud_descriptor_other_speed_configuration_cb(uint8_t index) {
+  (void)index; // for multiple configurations
+
+  // if link speed is high return fullspeed config, and vice versa
+  // Note: the descriptor type is OHER_SPEED_CONFIG instead of CONFIG
+  memcpy(desc_other_speed_config,
+         (tud_speed_get() == TUSB_SPEED_HIGH) ? desc_fs_configuration
+                                              : desc_hs_configuration,
+         CONFIG_TOTAL_LEN);
+
+  desc_other_speed_config[1] = TUSB_DESC_OTHER_SPEED_CONFIG;
+
+  return desc_other_speed_config;
+}
+
+#endif // highspeed
+
+// Invoked when received GET CONFIGURATION DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
+  (void)index; // for multiple configurations
+
+#if TUD_OPT_HIGH_SPEED
+  // Although we are highspeed, host may be fullspeed.
+  return (tud_speed_get() == TUSB_SPEED_HIGH) ? desc_hs_configuration
+                                              : desc_fs_configuration;
+#else
+  return desc_fs_configuration;
+#endif
+}
+
+// array of pointer to string descriptors
+char const *string_desc_arr[] = {
+    (const char[]){0x09, 0x04}, // 0: is supported language is English (0x0409)
+    "TinyUSB",                  // 1: Manufacturer
+    "TinyUSB Device",           // 2: Product
+    "123456789012",             // 3: Serials, should use chip ID
+    "TinyUSB CDC",              // 4: CDC Interface
+};
+
+static uint16_t _desc_str[32];
+
+// Invoked when received GET STRING DESCRIPTOR request
+// Application return pointer to descriptor, whose contents must exist long
+// enough for transfer to complete
+uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
+  (void)langid;
+
+  uint8_t chr_count;
+
+  if (index == 0) {
+    memcpy(&_desc_str[1], string_desc_arr[0], 2);
+    chr_count = 1;
+  } else {
+    // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
+    // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
+
+    if (!(index < sizeof(string_desc_arr) / sizeof(string_desc_arr[0])))
+      return NULL;
+
+    const char *str = string_desc_arr[index];
+
+    // Cap at max char
+    chr_count = (uint8_t)strlen(str);
+    if (chr_count > 31)
+      chr_count = 31;
+
+    // Convert ASCII string into UTF-16
+    for (uint8_t i = 0; i < chr_count; i++) {
+      _desc_str[1 + i] = str[i];
+    }
+  }
+
+  // first byte is length (including header), second byte is string type
+  _desc_str[0] = (uint16_t)((TUSB_DESC_STRING << 8) | (2 * chr_count + 2));
+
+  return _desc_str;
+}
+
+} // extern "C"
+
+#endif // _FREERTOS_DRIVERS_TINYUSB_TINYUSBCDCIMPL_HXX_

--- a/src/freertos_drivers/tinyusb/tusb_config.h
+++ b/src/freertos_drivers/tinyusb/tusb_config.h
@@ -27,7 +27,7 @@
 #define _TUSB_CONFIG_H_
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 //--------------------------------------------------------------------+
@@ -36,12 +36,12 @@
 
 // RHPort number used for device can be defined by board.mk, default to port 0
 #ifndef BOARD_TUD_RHPORT
-#define BOARD_TUD_RHPORT      0
+#define BOARD_TUD_RHPORT 0
 #endif
 
 // RHPort max operational speed can defined by board.mk
 #ifndef BOARD_TUD_MAX_SPEED
-#define BOARD_TUD_MAX_SPEED   OPT_MODE_DEFAULT_SPEED
+#define BOARD_TUD_MAX_SPEED OPT_MODE_DEFAULT_SPEED
 #endif
 
 //--------------------------------------------------------------------
@@ -54,23 +54,22 @@
 #endif
 
 #ifndef CFG_TUSB_OS
-#define CFG_TUSB_OS           OPT_OS_FREERTOS
+#define CFG_TUSB_OS OPT_OS_FREERTOS
 #endif
 
 #ifndef CFG_TUSB_DEBUG
-#define CFG_TUSB_DEBUG        0
+#define CFG_TUSB_DEBUG 0
 #endif
 
 // Enable Device stack
-#define CFG_TUD_ENABLED       1
+#define CFG_TUD_ENABLED 1
 
 // Default is max speed that hardware controller could support with on-chip PHY
-#define CFG_TUD_MAX_SPEED     BOARD_TUD_MAX_SPEED
+#define CFG_TUD_MAX_SPEED BOARD_TUD_MAX_SPEED
 
-/* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.
- * Tinyusb use follows macros to declare transferring memory so that they can be put
- * into those specific section.
- * e.g
+/* USB DMA on some MCUs can only access a specific SRAM region with restriction
+ * on alignment. Tinyusb use follows macros to declare transferring memory so
+ * that they can be put into those specific section. e.g
  * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
  * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
  */
@@ -79,7 +78,7 @@
 #endif
 
 #ifndef CFG_TUSB_MEM_ALIGN
-#define CFG_TUSB_MEM_ALIGN    __attribute__ ((aligned(4)))
+#define CFG_TUSB_MEM_ALIGN __attribute__((aligned(4)))
 #endif
 
 //--------------------------------------------------------------------
@@ -87,28 +86,28 @@
 //--------------------------------------------------------------------
 
 #ifndef CFG_TUD_ENDPOINT0_SIZE
-#define CFG_TUD_ENDPOINT0_SIZE    64
+#define CFG_TUD_ENDPOINT0_SIZE 64
 #endif
 
 //------------- CLASS -------------//
-#define CFG_TUD_CDC              1
-#define CFG_TUD_MSC              0
-#define CFG_TUD_HID              0
-#define CFG_TUD_MIDI             0
-#define CFG_TUD_VENDOR           0
+#define CFG_TUD_CDC 1
+#define CFG_TUD_MSC 0
+#define CFG_TUD_HID 0
+#define CFG_TUD_MIDI 0
+#define CFG_TUD_VENDOR 0
 
 // CDC FIFO size of TX and RX
-#define CFG_TUD_CDC_RX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
-#define CFG_TUD_CDC_TX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#define CFG_TUD_CDC_RX_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#define CFG_TUD_CDC_TX_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
 
 // CDC Endpoint transfer buffer size, more is faster
-#define CFG_TUD_CDC_EP_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#define CFG_TUD_CDC_EP_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
 
 // MSC Buffer size of Device Mass storage
-#define CFG_TUD_MSC_EP_BUFSIZE   512
+#define CFG_TUD_MSC_EP_BUFSIZE 512
 
 #ifdef __cplusplus
- }
+}
 #endif
 
 #endif /* _TUSB_CONFIG_H_ */

--- a/src/freertos_drivers/tinyusb/tusb_config.h
+++ b/src/freertos_drivers/tinyusb/tusb_config.h
@@ -1,0 +1,114 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Nathaniel Brough
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef _TUSB_CONFIG_H_
+#define _TUSB_CONFIG_H_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+//--------------------------------------------------------------------+
+// Board Specific Configuration
+//--------------------------------------------------------------------+
+
+// RHPort number used for device can be defined by board.mk, default to port 0
+#ifndef BOARD_TUD_RHPORT
+#define BOARD_TUD_RHPORT      0
+#endif
+
+// RHPort max operational speed can defined by board.mk
+#ifndef BOARD_TUD_MAX_SPEED
+#define BOARD_TUD_MAX_SPEED   OPT_MODE_DEFAULT_SPEED
+#endif
+
+//--------------------------------------------------------------------
+// Common Configuration
+//--------------------------------------------------------------------
+
+// defined by compiler flags for flexibility
+#ifndef CFG_TUSB_MCU
+#error CFG_TUSB_MCU must be defined
+#endif
+
+#ifndef CFG_TUSB_OS
+#define CFG_TUSB_OS           OPT_OS_FREERTOS
+#endif
+
+#ifndef CFG_TUSB_DEBUG
+#define CFG_TUSB_DEBUG        0
+#endif
+
+// Enable Device stack
+#define CFG_TUD_ENABLED       1
+
+// Default is max speed that hardware controller could support with on-chip PHY
+#define CFG_TUD_MAX_SPEED     BOARD_TUD_MAX_SPEED
+
+/* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.
+ * Tinyusb use follows macros to declare transferring memory so that they can be put
+ * into those specific section.
+ * e.g
+ * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
+ * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
+ */
+#ifndef CFG_TUSB_MEM_SECTION
+#define CFG_TUSB_MEM_SECTION
+#endif
+
+#ifndef CFG_TUSB_MEM_ALIGN
+#define CFG_TUSB_MEM_ALIGN    __attribute__ ((aligned(4)))
+#endif
+
+//--------------------------------------------------------------------
+// DEVICE CONFIGURATION
+//--------------------------------------------------------------------
+
+#ifndef CFG_TUD_ENDPOINT0_SIZE
+#define CFG_TUD_ENDPOINT0_SIZE    64
+#endif
+
+//------------- CLASS -------------//
+#define CFG_TUD_CDC              1
+#define CFG_TUD_MSC              0
+#define CFG_TUD_HID              0
+#define CFG_TUD_MIDI             0
+#define CFG_TUD_VENDOR           0
+
+// CDC FIFO size of TX and RX
+#define CFG_TUD_CDC_RX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#define CFG_TUD_CDC_TX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+
+// CDC Endpoint transfer buffer size, more is faster
+#define CFG_TUD_CDC_EP_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+
+// MSC Buffer size of Device Mass storage
+#define CFG_TUD_MSC_EP_BUFSIZE   512
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* _TUSB_CONFIG_H_ */

--- a/src/utils/HubDeviceSelect.cxx
+++ b/src/utils/HubDeviceSelect.cxx
@@ -1,2 +1,10 @@
 
 #include "utils/HubDeviceSelect.hxx"
+
+#include "nmranet_config.h"
+
+/// @return the number of packets to limit read input if we are throttling.
+int hubdevice_incoming_packet_limit()
+{
+    return config_gridconnect_port_max_incoming_packets();
+}

--- a/targets/freertos.armv6m/freertos_drivers/tinyusb_stm32f072xb/Makefile
+++ b/targets/freertos.armv6m/freertos_drivers/tinyusb_stm32f072xb/Makefile
@@ -1,0 +1,2 @@
+OPENMRNPATH ?= $(realpath ../../../..)
+include $(OPENMRNPATH)/etc/lib.mk

--- a/targets/freertos.armv6m/freertos_drivers/tinyusb_stm32f072xb/sources
+++ b/targets/freertos.armv6m/freertos_drivers/tinyusb_stm32f072xb/sources
@@ -1,0 +1,25 @@
+include $(OPENMRNPATH)/etc/stm32cubef0.mk
+include $(OPENMRNPATH)/etc/tinyusb.mk
+
+VPATH = $(OPENMRNPATH)/src/freertos_drivers/st \
+        $(TUSB_VPATH) \
+        $(TINYUSBPATH)/src/portable/st/stm32_fsdev \
+
+
+CFLAGS += -DSTM32F072xB -DCFG_TUSB_MCU=OPT_MCU_STM32F0
+CXXFLAGS += -DSTM32F072xB  -DCFG_TUSB_MCU=OPT_MCU_STM32F0
+
+CSRCS += usbd.c \
+         usbd_control.c \
+         tusb_fifo.c \
+         cdc_device.c \
+         tusb.c \
+         dcd_stm32_fsdev.c \
+
+
+CXXSRCS += Stm32UsbCdc.cxx
+
+# This is needed because we are compiling with a C standard, and GCC's builtin
+#  assembler can only be reached using the internal format.
+
+dcd_stm32_fsdev.o: CFLAGS+=-Dasm=__asm__


### PR DESCRIPTION
- Adds TinyUsb to path.mk
- Adds a target directory to compile it for the stm32f072xb MCU
- Adds a common base class for a TinyUsb based USB stack with CDC device driver
- Instantiates this for STM32
- Adds a CAN-USB application target for the STM32F072xB.

The TinyUSBCdc driver is select-enabled. It does not use a Serial base class, because the read and write fifo's are provided by the TinyUsb codebase. We are exercising the application reads and writes directly from those fifos; this saves one unnecessary copy of the data in memory. (There are still two memcpy's; one in the interrupt to the fifo, one in the application code to the application buffer.)