### PR TITLE
Optimize the RAM needs for the CAN-USB application

### DIFF
--- a/src/utils/HubDeviceSelect.cxx
+++ b/src/utils/HubDeviceSelect.cxx
@@ -1,2 +1,10 @@
 
 #include "utils/HubDeviceSelect.hxx"
+
+#include "nmranet_config.h"
+
+/// @return the number of packets to limit read input if we are throttling.
+int hubdevice_incoming_packet_limit()
+{
+    return config_gridconnect_port_max_incoming_packets();
+}


### PR DESCRIPTION
The canusb application could not run in 16kbyte MCU's because it was running out of heap. This PR optimizes it, and handles some long standing work items in the buffering capabilities of openmrn.

- switches can-usb app to use select() based implementation.
- Removes five tasks:
  - CAN-bus read/write threads
  - Serial port read/write tasks
  - merges the main thread and the main executor thread
- Fixes traffic throttling on HubDeviceSelect. It was not on par with HubDevice, as the input data was consumed at an infinite rate. Adds support for the linker option config_gridconnect_port_max_incoming_packets().