### PR TITLE
Ensures that 'make clean' empties lib directory of symlinks.

### DIFF
--- a/etc/core_target.mk
+++ b/etc/core_target.mk
@@ -28,3 +28,8 @@ include $(OPENMRNPATH)/etc/recurse.mk
 # re-run. Otherwise you need to run tests twice to actually execute them.
 lib/timestamp: $(BUILDDIRS)
 	true
+
+clean: clean-lib
+
+clean-lib:
+	rm -f lib/lib*.a

--- a/etc/prog.mk
+++ b/etc/prog.mk
@@ -291,6 +291,7 @@ clean: clean-local
 clean-local:
 	rm -f $(wildcard *.o *.d *.a *.so *.output *.cout *.cxxout *.hxxout *.stripped lib/*.stripped lib/*.lst) $(TESTOBJS:.o=) $(EXECUTABLE)$(EXTENTION) $(EXECUTABLE).bin $(EXECUTABLE).lst $(EXECUTABLE).map cg.debug.txt cg.dot cg.svg gmon.out $(OBJS) demangled.txt $(EXECUTABLE).ndlst objcopy.params
 	rm -rf $(XMLSRCS:.xml=.c)
+	rm -f lib/lib*.a
 
 veryclean: clean-local clean
 


### PR DESCRIPTION
Previously we had recursed into the lib directory. That did take care of clean, but also created a liblib.a which was unnecessary. Now we clean the lib dir separately.