### PR TITLE
Fixes build_bootloader_img.py.

### DIFF
--- a/applications/reflash_bootloader/targets/bare.armv7m.ek-tm4c123gxl/Makefile
+++ b/applications/reflash_bootloader/targets/bare.armv7m.ek-tm4c123gxl/Makefile
@@ -19,7 +19,7 @@ LDFLAGSEXTRA+= --specs=nano.specs
 bootloader_bin/bootloader.bin: FORCE
 	$(MAKE) -C $(realpath bootloader_bin) bootloader.bin
 
-payload.cxxout: bootloader_bin/bootloader.bin
+payload.cxxout: bootloader_bin/bootloader.bin $(OPENMRNPATH)/bin/build_bootloader_img.py
 	$(OPENMRNPATH)/bin/build_bootloader_img.py -i bootloader_bin/bootloader.bin -o $@
 
 .cxxout.o:

--- a/bin/build_bootloader_img.py
+++ b/bin/build_bootloader_img.py
@@ -85,8 +85,9 @@ bin_file = []
 ofs = 0
 while True :
     c = file_in.read(1)
-    if c == "" :
-        break
+    if len(c) == 0:
+      print("eof at", ofs)
+      break
     bin_file.append(c)
     ofs = ofs + 1
     if options.maxsize is not None and ofs >= options.maxsize:

--- a/bin/build_bootloader_img.py
+++ b/bin/build_bootloader_img.py
@@ -105,6 +105,7 @@ if options.cname is None:
 
   outputblocks = []
 
+  print("Blocks:", end=" ")
   for k, block in enumerate(blocks):
     if k == 0:
       b = Block()
@@ -112,19 +113,24 @@ if options.cname is None:
       b.data = block
       b.end_ofs = 0
       outputblocks.append(b)
+      print("b", end="")
       continue
-    if block.count('\0') == len(block):  # all zeros
+    if block.count(b'\x00') == len(block):  # all zeros
+      print("o", end="")
       continue
     if outputblocks[-1].end_ofs == k - 1:
       outputblocks[-1].data += block
       outputblocks[-1].end_ofs = k
+      print("x", end="")
     else:
       b = Block()
       b.ofs = k
       b.data = block
       b.end_ofs = k
       outputblocks.append(b)
+      print("b", end="")
 
+  print("")
   segmenttable = ''
   for b in outputblocks:
     print_c_array(file_out, "payload_%d" % b.ofs, b.data);


### PR DESCRIPTION
This was probably broken since python3.

Binary and string objects do not compare as equal it seems.