### PR TITLE
Adds local loopback to TractionThrottle.

### DIFF
--- a/src/openlcb/TractionClient.hxx
+++ b/src/openlcb/TractionClient.hxx
@@ -153,16 +153,16 @@ private:
 
     Action entry() OVERRIDE
     {
-        LOG_ERROR("response came");
+        LOG(VERBOSE, "response came");
 
         if (!trigger_)
         {
             // We already matched -- drop all packets to the floor.
-            LOG_ERROR("no trigger");
+            LOG(VERBOSE, "no trigger");
             return release_and_exit();
         }
         if (nmsg()->dstNode != expectedDst_) {
-            LOG_ERROR("dst not match");
+            LOG(VERBOSE, "dst not match");
             return release_and_exit();
         }
         /// @TODO(balazs.racz) factor out this code into a helper function that
@@ -172,7 +172,7 @@ private:
         {
             if (expectedSrc_.id != nmsg()->src.id)
             {
-                LOG_ERROR("src.id not match");
+                LOG(VERBOSE, "src.id not match");
                 return release_and_exit();
             }
         }
@@ -180,7 +180,7 @@ private:
         {
             if (expectedSrc_.alias != nmsg()->src.alias)
             {
-                LOG_ERROR("src.alias not match");
+                LOG(VERBOSE, "src.alias not match");
                 return release_and_exit();
             }
         }
@@ -194,11 +194,11 @@ private:
         // Now: message is from the right source node, to the right destination
         // node.
         if (nmsg()->payload.size() < 1) {
-            LOG_ERROR("no payload");
+            LOG(VERBOSE, "no payload");
             return release_and_exit();
         }
         if (nmsg()->payload[0] != expectedType_) {
-            LOG_ERROR("payload type no match");
+            LOG(VERBOSE, "payload type no match");
             return release_and_exit();
         }
         // Now: we matched!

--- a/src/openlcb/TractionThrottle.cxxtest
+++ b/src/openlcb/TractionThrottle.cxxtest
@@ -720,6 +720,8 @@ TEST_F(ThrottleClientTest, MultiListener)
     Mock::VerifyAndClear(&l2);
     Mock::VerifyAndClear(&lr);
 
+    EXPECT_EQ(2, trainNode_->query_consist_length());
+    EXPECT_EQ(1, trainNode2_->query_consist_length());
     
     // =================
     LOG(INFO, "switching throttle2 back but no listener.");
@@ -727,6 +729,9 @@ TEST_F(ThrottleClientTest, MultiListener)
     b = invoke_flow(&throttle2, TractionThrottleCommands::ASSIGN_TRAIN,
         TRAIN_NODE_ID, false);
     ASSERT_EQ(0, b->data()->resultCode);    
+
+    EXPECT_EQ(2, trainNode_->query_consist_length());
+    EXPECT_EQ(0, trainNode2_->query_consist_length());
     
     // Local1 calls go to the remote throttle, not to local2.
     EXPECT_CALL(lr, update(11));
@@ -761,6 +766,15 @@ TEST_F(ThrottleClientTest, MultiListener)
     Mock::VerifyAndClear(&l);
     Mock::VerifyAndClear(&l2);
     Mock::VerifyAndClear(&lr);
+
+    EXPECT_EQ(2, trainNode_->query_consist_length());
+
+    // Local first throttle reassigned to the second train.
+    b = invoke_flow(&throttle_, TractionThrottleCommands::ASSIGN_TRAIN,
+        TRAIN_NODE_ID + 1, false);
+    ASSERT_EQ(0, b->data()->resultCode);    
+    // removed listener.
+    EXPECT_EQ(1, trainNode_->query_consist_length());
 }
 
 } // namespace openlcb

--- a/src/openlcb/TractionThrottle.cxxtest
+++ b/src/openlcb/TractionThrottle.cxxtest
@@ -8,6 +8,7 @@ namespace openlcb
 {
 
 static constexpr NodeID TRAIN_NODE_ID = 0x06010000C000 | 1372;
+static constexpr NodeID REMOTE_NODE_ID = 0x0501010118F3ull;
 
 class ThrottleTest : public AsyncNodeTest
 {
@@ -15,14 +16,28 @@ protected:
     ThrottleTest()
     {
         print_all_packets();
-        run_x(
-            [this]() { otherIf_.local_aliases()->add(TRAIN_NODE_ID, 0x771); });
+        run_x([this]() {
+            otherIf_.local_aliases()->add(TRAIN_NODE_ID, 0x771);
+            otherIf_.local_aliases()->add(TRAIN_NODE_ID+1, 0x772);
+            otherIf_.local_aliases()->add(REMOTE_NODE_ID, 0x553);
+        });
         trainNode_.reset(new TrainNodeForProxy(&trainService_, &trainImpl_));
+        trainNode2_.reset(new TrainNodeForProxy(&trainService_, &trainImpl2_));
+        remoteNode_.reset(new DefaultNode(&otherIf_, REMOTE_NODE_ID, true));
+        wait();
+        // This will re-fill all the alias caches.
+        send_packet(":X19490559N;");
+        send_packet(":X10702559N;");
         wait();
     }
 
     LoggingTrain trainImpl_{1372};
     std::unique_ptr<TrainNode> trainNode_;
+
+    LoggingTrain trainImpl2_{1373};
+    std::unique_ptr<TrainNode> trainNode2_;
+
+    std::unique_ptr<DefaultNode> remoteNode_;
 
     IfCan otherIf_{&g_executor, &can_hub0, 5, 5, 5};
     TrainService trainService_{&otherIf_};
@@ -423,22 +438,16 @@ TEST_F(ThrottleClientTest, ReassignWithListener)
     EXPECT_EQ(1, trainNode_->query_consist_length());
     EXPECT_QRYCONSIST(node_->node_id(), 0x8C, 0);
 
-    static auto TRAIN_NODE_ID2 = TRAIN_NODE_ID + 1;
-    run_x([this]() { otherIf_.local_aliases()->add(TRAIN_NODE_ID2, 0x772); });
-    LoggingTrain train_impl2{1373};
-    TrainNodeForProxy node2(&trainService_, &train_impl2);
-    wait();
-
     b = invoke_flow(&throttle_, TractionThrottleCommands::ASSIGN_TRAIN,
-        TRAIN_NODE_ID2, true);
+        TRAIN_NODE_ID + 1, true);
     ASSERT_EQ(0, b->data()->resultCode);
     EXPECT_EQ(0, trainNode_->query_consist_length());
-    EXPECT_EQ(1, node2.query_consist_length());
+    EXPECT_EQ(1, trainNode2_->query_consist_length());
 
     b = invoke_flow(&throttle_, TractionThrottleCommands::RELEASE_TRAIN);
     ASSERT_EQ(0, b->data()->resultCode);
     EXPECT_EQ(0, trainNode_->query_consist_length());
-    EXPECT_EQ(0, node2.query_consist_length());
+    EXPECT_EQ(0, trainNode2_->query_consist_length());
 
     wait();
 }
@@ -453,17 +462,11 @@ TEST_F(ThrottleClientTest, ReassignWithoutListener)
 
     EXPECT_EQ(1, trainNode_->query_consist_length());
 
-    static auto TRAIN_NODE_ID2 = TRAIN_NODE_ID + 1;
-    run_x([this]() { otherIf_.local_aliases()->add(TRAIN_NODE_ID2, 0x772); });
-    LoggingTrain train_impl2{1373};
-    TrainNodeForProxy node2(&trainService_, &train_impl2);
-    wait();
-
     b = invoke_flow(&throttle_, TractionThrottleCommands::ASSIGN_TRAIN,
-        TRAIN_NODE_ID2, false);
+        TRAIN_NODE_ID + 1, false);
     ASSERT_EQ(0, b->data()->resultCode);
     EXPECT_EQ(0, trainNode_->query_consist_length());
-    EXPECT_EQ(0, node2.query_consist_length());
+    EXPECT_EQ(0, trainNode2_->query_consist_length());
 
     wait();
 }
@@ -521,12 +524,6 @@ TEST_F(ThrottleClientTest, HeartbeatWrongTrain)
         TRAIN_NODE_ID, false);
     ASSERT_EQ(0, b->data()->resultCode);
 
-    static auto TRAIN_NODE_ID2 = TRAIN_NODE_ID + 1;
-    run_x([this]() { otherIf_.local_aliases()->add(TRAIN_NODE_ID2, 0x772); });
-    LoggingTrain train_impl2{1373};
-    TrainNodeForProxy node2(&trainService_, &train_impl2);
-    wait();
-
     // Primes the caches.
     openlcb::send_message(trainNode_.get(), Defs::MTI_TRACTION_CONTROL_COMMAND,
         NodeHandle(node_->node_id()), TractionDefs::fn_set_payload(13, 1));
@@ -536,7 +533,7 @@ TEST_F(ThrottleClientTest, HeartbeatWrongTrain)
     // heartbeat request is sent from wrong train to throttle
     expect_packet(":X191E9772N022A400303;");
     // no response from the throttle.
-    openlcb::send_message(&node2, Defs::MTI_TRACTION_CONTROL_REPLY,
+    openlcb::send_message(trainNode2_.get(), Defs::MTI_TRACTION_CONTROL_REPLY,
         NodeHandle(node_->node_id()),
         TractionDefs::heartbeat_request_payload());
     wait();

--- a/src/openlcb/TractionThrottle.cxxtest
+++ b/src/openlcb/TractionThrottle.cxxtest
@@ -624,4 +624,76 @@ TEST_F(ThrottleClientTest, ListenerCallback)
     EXPECT_FALSE(throttle_.get_emergencystop());
 }
 
+
+TEST_F(ThrottleClientTest, MultiListener)
+{
+    TractionThrottle throttle2{node_};
+    TractionThrottle throttler{remoteNode_.get()};
+    StrictMock<MockListener> l, l2, lr;
+    
+    throttle_.set_throttle_listener(
+        std::bind(&ListenerInterface::update, &l, std::placeholders::_1));
+    throttle2.set_throttle_listener(
+        std::bind(&ListenerInterface::update, &l2, std::placeholders::_1));
+    throttler.set_throttle_listener(
+        std::bind(&ListenerInterface::update, &lr, std::placeholders::_1));
+
+    auto b = invoke_flow(&throttle_, TractionThrottleCommands::ASSIGN_TRAIN,
+        TRAIN_NODE_ID, true);
+    ASSERT_EQ(0, b->data()->resultCode);
+    b = invoke_flow(&throttle2, TractionThrottleCommands::ASSIGN_TRAIN,
+        TRAIN_NODE_ID, true);
+    ASSERT_EQ(0, b->data()->resultCode);    
+    b = invoke_flow(&throttler, TractionThrottleCommands::ASSIGN_TRAIN,
+        TRAIN_NODE_ID, true);
+    ASSERT_EQ(0, b->data()->resultCode);    
+
+    wait();
+
+    // This message will trigger no callback on the bus, but the local feedback
+    // will make it appear. The remote node will get its own feedback.
+    EXPECT_CALL(l, update(23));
+    EXPECT_CALL(lr, update(23));
+    throttle2.set_fn(23, 1);
+    wait();
+    Mock::VerifyAndClear(&l);
+    Mock::VerifyAndClear(&l2);
+    Mock::VerifyAndClear(&lr);
+
+    // If the remote node calls, one message will come on the bus but both
+    // throttles will call update.
+    EXPECT_CALL(l, update(22));
+    EXPECT_CALL(l2, update(22));
+    throttler.set_fn(22, 1);
+    wait();
+    Mock::VerifyAndClear(&l);
+    Mock::VerifyAndClear(&l2);
+    Mock::VerifyAndClear(&lr);
+
+    // If a third node calls, all three will call update.
+    EXPECT_CALL(l, update(15));
+    EXPECT_CALL(l2, update(15));
+    EXPECT_CALL(lr, update(15));
+    send_packet(":X195EB330N07710100000f0001;"); // fn 15 = 1
+    wait();
+    Mock::VerifyAndClear(&l);
+    Mock::VerifyAndClear(&l2);
+    Mock::VerifyAndClear(&lr);
+
+    // Local second throttle will be switched over to a different train.
+    b = invoke_flow(&throttle2, TractionThrottleCommands::ASSIGN_TRAIN,
+        TRAIN_NODE_ID + 1, true);
+    ASSERT_EQ(0, b->data()->resultCode);    
+
+    // Now a third node calls, two shall call update.
+    EXPECT_CALL(l, update(14));
+    EXPECT_CALL(lr, update(14));
+    send_packet(":X195EB330N07710100000e0001;"); // fn 14 = 1
+    wait();
+    Mock::VerifyAndClear(&l);
+    Mock::VerifyAndClear(&l2);
+    Mock::VerifyAndClear(&lr);
+    
+}
+
 } // namespace openlcb

--- a/src/openlcb/TractionThrottle.cxxtest
+++ b/src/openlcb/TractionThrottle.cxxtest
@@ -680,6 +680,9 @@ TEST_F(ThrottleClientTest, MultiListener)
     Mock::VerifyAndClear(&l2);
     Mock::VerifyAndClear(&lr);
 
+    LOG(INFO, "switching throttle2 to other train.");
+
+    // =================
     // Local second throttle will be switched over to a different train.
     b = invoke_flow(&throttle2, TractionThrottleCommands::ASSIGN_TRAIN,
         TRAIN_NODE_ID + 1, true);
@@ -693,7 +696,71 @@ TEST_F(ThrottleClientTest, MultiListener)
     Mock::VerifyAndClear(&l);
     Mock::VerifyAndClear(&l2);
     Mock::VerifyAndClear(&lr);
+
+    // When the remote node calls, the local shall update.
+    EXPECT_CALL(l, update(13));
+    throttler.set_fn(13, 1);
+    wait();
+    Mock::VerifyAndClear(&l);
+    Mock::VerifyAndClear(&l2);
+    Mock::VerifyAndClear(&lr);
+
+    // Local2 calls go to a different train, no update callbacks.
+    throttle2.set_fn(13, 1);
+    wait();
+    Mock::VerifyAndClear(&l);
+    Mock::VerifyAndClear(&l2);
+    Mock::VerifyAndClear(&lr);
+
+    // Local1 calls go to the remote throttle, not to local2.
+    EXPECT_CALL(lr, update(12));
+    throttle_.set_fn(12, 1);
+    wait();
+    Mock::VerifyAndClear(&l);
+    Mock::VerifyAndClear(&l2);
+    Mock::VerifyAndClear(&lr);
+
     
+    // =================
+    LOG(INFO, "switching throttle2 back but no listener.");
+    // Local second throttle reassigned to the same train but without listener.
+    b = invoke_flow(&throttle2, TractionThrottleCommands::ASSIGN_TRAIN,
+        TRAIN_NODE_ID, false);
+    ASSERT_EQ(0, b->data()->resultCode);    
+    
+    // Local1 calls go to the remote throttle, not to local2.
+    EXPECT_CALL(lr, update(11));
+    throttle_.set_fn(11, 1);
+    wait();
+    Mock::VerifyAndClear(&l);
+    Mock::VerifyAndClear(&l2);
+    Mock::VerifyAndClear(&lr);
+
+    // Local2 goes to local1 and remote
+    EXPECT_CALL(l, update(23));
+    EXPECT_CALL(lr, update(23));
+    throttle2.set_fn(23, 1);
+    wait();
+    Mock::VerifyAndClear(&l);
+    Mock::VerifyAndClear(&l2);
+    Mock::VerifyAndClear(&lr);
+
+    // If the remote node calls, only local1 will get it.
+    EXPECT_CALL(l, update(22));
+    throttler.set_fn(22, 1);
+    wait();
+    Mock::VerifyAndClear(&l);
+    Mock::VerifyAndClear(&l2);
+    Mock::VerifyAndClear(&lr);
+
+    // If a third node calls, all local1 and remote will get it.
+    EXPECT_CALL(l, update(15));
+    EXPECT_CALL(lr, update(15));
+    send_packet(":X195EB330N07710100000f0001;"); // fn 15 = 1
+    wait();
+    Mock::VerifyAndClear(&l);
+    Mock::VerifyAndClear(&l2);
+    Mock::VerifyAndClear(&lr);
 }
 
 } // namespace openlcb

--- a/src/openlcb/TractionThrottle.hxx
+++ b/src/openlcb/TractionThrottle.hxx
@@ -40,6 +40,7 @@
 #include "openlcb/TractionDefs.hxx"
 #include "openlcb/TractionThrottleInterface.hxx"
 #include "openlcb/TrainInterface.hxx"
+#include "utils/LinkedObject.hxx"
 
 namespace openlcb
 {
@@ -47,7 +48,8 @@ namespace openlcb
 /** Interface for a single throttle for running a train node.
  *
  */
-class TractionThrottle : public TractionThrottleBase
+class TractionThrottle : public TractionThrottleBase,
+                         public LinkedObject<TractionThrottle>
 {
 public:
     /// @param node is the openlcb node from which this throttle will be
@@ -79,7 +81,8 @@ public:
 
     void set_speed(SpeedType speed) override
     {
-        send_traction_message(TractionDefs::speed_set_payload(speed));
+        send_traction_message_with_loopback(
+            TractionDefs::speed_set_payload(speed));
         lastSetSpeed_ = speed;
         estopActive_ = false;
     }
@@ -93,7 +96,7 @@ public:
 
     void set_emergencystop() override
     {
-        send_traction_message(TractionDefs::estop_set_payload());
+        send_traction_message_with_loopback(TractionDefs::estop_set_payload());
         estopActive_ = true;
         lastSetSpeed_.set_mph(0);
     }
@@ -107,7 +110,8 @@ public:
 
     void set_fn(uint32_t address, uint16_t value) override
     {
-        send_traction_message(TractionDefs::fn_set_payload(address, value));
+        send_traction_message_with_loopback(
+            TractionDefs::fn_set_payload(address, value));
         lastKnownFn_[address] = value;
     }
 
@@ -429,6 +433,8 @@ private:
         return false;
     }
 
+    /// Invoked for TRACTION_CONTROL_REPLY messages coming in via the
+    /// dispatcher.
     void speed_reply(Buffer<GenMessage> *msg)
     {
         AutoReleaseBuffer<GenMessage> rb(msg);
@@ -594,6 +600,9 @@ private:
         return return_ok();
     }
 
+    /// Invoked for TRACTION_CONTROL_COMMAND messages coming in via the
+    /// dispatcher. These are generally update commands coming on when another
+    /// throttle is controlling the same loco or consist via another member.
     void listen_reply(Buffer<GenMessage> *msg)
     {
         AutoReleaseBuffer<GenMessage> rb(msg);
@@ -606,7 +615,15 @@ private:
         {
             return;
         }
-        const Payload &p = msg->data()->payload;
+        listen_reply_process(msg->data()->payload);
+    }
+
+    /// Business logic for interpreting a proxied traction command payload. The
+    /// command may be coming back as a consist forward message due to throttle
+    /// listener, or may be one that went out from another TractionThrottle
+    /// instance to the same train.
+    void listen_reply_process(const Payload &p)
+    {
         if (p.size() < 1)
             return;
         switch (p[0] & TractionDefs::REQ_MASK)
@@ -653,16 +670,103 @@ private:
         }
     }
 
-    /** Allocates (synchronously) an outgoing openlcb buffer with traction
-     * request MTI and the given payload and sends off the message to the bus
-     * for dst_. */
-    void send_traction_message(const Payload &payload)
+    /// Allocates (synchronously) an outgoing openlcb buffer with traction
+    /// request MTI and the given payload and sends off the message to the bus
+    /// for dst_.
+    ///
+    /// Performs loopback to other traction throttles that might be assigned to
+    /// the same train.
+    ///
+    /// @param payload is the data contents of the message
+    /// (e.g. TractionDefs::speed_set_payload(...).
+    void send_traction_message_with_loopback(Payload payload)
+    {
+        auto b = send_traction_message_helper(std::move(payload));
+        std::function<void()> f = std::bind(
+            &TractionThrottle::loopback_traction_message, this, b.release());
+        iface()->executor()->add(new CallbackExecutable(std::move(f)));
+    }
+
+    /// Performs loopback processing of an outgoing traction message. Run on
+    /// the iface()'s executor.
+    ///
+    /// @param b the message that was sent out. Will be unreffed.
+    void loopback_traction_message(Buffer<GenMessage>* b)
+    {
+        auto rb = get_buffer_deleter(b);
+        // Walks all TractionThrottle objects.
+        TractionThrottle *p = nullptr;
+        do
+        {
+            {
+                // finds next instance that's interesting
+                AtomicHolder h(LinkedObject<TractionThrottle>::head_mu());
+                while (true)
+                {
+                    if (!p)
+                    {
+                        p = LinkedObject<TractionThrottle>::link_head();
+                    }
+                    else
+                    {
+                        p = p->LinkedObject<TractionThrottle>::link_next();
+                    }
+                    if (!p)
+                    {
+                        break;
+                    }
+                    if (p == this)
+                    {
+                        // self, ignore
+                        continue;
+                    }
+                    if (p->node_ != node_)
+                    {
+                        // Differnet virtual node, will get regular
+                        // feedback
+                        continue;
+                    }
+                    if (p->dst_ != dst_)
+                    {
+                        // Target node ID is different.
+                        continue;
+                    }
+                    // Will call p, but we need to get out of the
+                    // atomic first.
+                    break;
+                }
+            } // atomic
+            if (p)
+            {
+                p->listen_reply_process(b->data()->payload);
+            }
+        } while (p != nullptr);
+    }
+
+    /// Allocates (synchronously) an outgoing openlcb buffer with traction
+    /// request MTI and the given payload and sends off the message to the bus
+    /// for dst_.
+    ///
+    /// @param payload is the data contents of the message
+    /// (e.g. TractionDefs::speed_set_payload(...).
+    void send_traction_message(Payload payload)
+    {
+        send_traction_message_helper(std::move(payload));
+    }
+    
+    /// Allocates (synchronously) an outgoing openlcb buffer with traction
+    /// request MTI and the given payload and sends off the message to the bus
+    /// for dst_.
+    ///
+    /// Returns a reference to the buffer.
+    BufferPtr<GenMessage> send_traction_message_helper(Payload payload)
     {
         HASSERT(dst_ != 0);
         auto *b = iface()->addressed_message_write_flow()->alloc();
         b->data()->reset(Defs::MTI_TRACTION_CONTROL_COMMAND, node_->node_id(),
-            NodeHandle(dst_), payload);
+            NodeHandle(dst_), std::move(payload));
         iface()->addressed_message_write_flow()->send(b);
+        return get_buffer_deleter(b->ref());
     }
 
     void set_listening()

--- a/src/openlcb/TractionThrottle.hxx
+++ b/src/openlcb/TractionThrottle.hxx
@@ -811,8 +811,8 @@ private:
         auto *b = iface()->addressed_message_write_flow()->alloc();
         b->data()->reset(Defs::MTI_TRACTION_CONTROL_COMMAND, node_->node_id(),
             NodeHandle(dst_), std::move(payload));
-        iface()->addressed_message_write_flow()->send(b);
-        return get_buffer_deleter(b->ref());
+        iface()->addressed_message_write_flow()->send(b->ref());
+        return get_buffer_deleter(b);
     }
 
     void set_listening()


### PR DESCRIPTION
This PR improves behavior when there is more than one TractionThrottle in the same openlcb::node_. Specifically, when these are assigned to the same dst_ locomotive, the Train Node will never send back echoes of the packets. This means that the simultaneous updates are missing.

This PR makes all TractionThrottle objects lined up in a linked list upon creation. When a locomotive control commands (speed, estop, fn) is sent out, a local loopback will walk the linked list and identify if there are any other tractionthrottle objects assigned to the same loco. If so, the message will be handed over to it for update callbacks.