### PR TITLE
Ensures that an executor thread can not be created twice.

### DIFF
--- a/src/os/OS.hxx
+++ b/src/os/OS.hxx
@@ -77,6 +77,7 @@ public:
     */
     void start(const char *name, int priority, size_t stack_size)
     {
+        HASSERT(!is_created());
         os_thread_create(&handle, name, priority, stack_size, start, this);
     }
 


### PR DESCRIPTION
Executors are by definition one thread each.
When accidentally more than one thread is created, all of our threading assumptions are broken.
This PR adds an assert to prevent this from happening.