### PR TITLE
Avoids rendering hidden segments.

### DIFF
--- a/src/openlcb/ConfigRenderer.cxxtest
+++ b/src/openlcb/ConfigRenderer.cxxtest
@@ -351,5 +351,26 @@ TEST(CdiRender, RenderIdent)
     EXPECT_EQ(34u, cfg.testseg().e2().offset());
 }
 
+
+CDI_GROUP(TestCdi3, MainCdi());
+CDI_GROUP_ENTRY(acdi, Acdi);
+CDI_GROUP_ENTRY(testseg, OtherSegment, Hidden(true));
+CDI_GROUP_END();
+
+TEST(CdiRender, NoRenderHiddenSegment)
+{
+    string s;
+    TestCdi3 cfg(0);
+    cfg.config_renderer().render_cdi(&s);
+    const char kExpectedTestNodeCdi[] = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" R"data(
+<cdi xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://openlcb.org/schema/cdi/1/1/cdi.xsd">
+<acdi/>
+</cdi>
+)data";
+    EXPECT_EQ(kExpectedTestNodeCdi, s);
+    EXPECT_EQ(34u, cfg.testseg().e2().offset());
+}
+
+
 } // namespace
 } // namespace openlcb

--- a/src/openlcb/ConfigRenderer.hxx
+++ b/src/openlcb/ConfigRenderer.hxx
@@ -406,7 +406,11 @@ public:
         GroupConfigOptions opts(args..., Body::group_opts());
         if (opts.hidden())
         {
-            EmptyGroupConfigRenderer(Body::size() * replication_).render_cdi(s);
+            if (!opts.is_segment())
+            {
+                EmptyGroupConfigRenderer(Body::size() * replication_)
+                    .render_cdi(s);
+            }
             return;
         }
         const char *tag = nullptr;


### PR DESCRIPTION
Previously a hidden segment created incompliant XML, putting a group with an offset at the toplevel CDI. With this PR, the hidden segment will not be rendered at all.