### PR TITLE
Fix incorrect consumer identified message being emitted by dcc accy producer.

### DIFF
--- a/src/openlcb/DccAccyConsumer.cxxtest
+++ b/src/openlcb/DccAccyConsumer.cxxtest
@@ -80,7 +80,7 @@ TEST_F(DccAccyTest, identify_boot_invalid)
 TEST_F(DccAccyTest, global_identify)
 {
     clear_expect(true);
-    // Consumer range for two 4096 long tanges.
+    // Consumer range for two 4096 long ranges.
     expect_packet(":X194A422AN0101020000FF0FFF;");
     expect_packet(":X194A422AN0101020000FE0FFF;");
     

--- a/src/openlcb/DccAccyConsumer.cxxtest
+++ b/src/openlcb/DccAccyConsumer.cxxtest
@@ -58,6 +58,11 @@ public:
 class DccAccyTest : public AsyncNodeTest
 {
 protected:
+    DccAccyTest()
+    {
+        wait();
+    }
+
     StrictMock<MockPacketQueue> trackSendQueue_;
     DccAccyConsumer consumer_{node_, &trackSendQueue_};
 };
@@ -71,6 +76,19 @@ TEST_F(DccAccyTest, identify_boot_invalid)
     send_packet_and_expect_response(
         ":X198F4111N0101020000FF01F0;", ":X194C722AN0101020000FF01F0;");
 }
+
+TEST_F(DccAccyTest, global_identify)
+{
+    clear_expect(true);
+    // Consumer range for two 4096 long tanges.
+    expect_packet(":X194A422AN0101020000FF0FFF;");
+    expect_packet(":X194A422AN0101020000FE0FFF;");
+    
+    // identify events addressed.
+    send_packet(":X19968111N022A;");
+    wait();
+}
+
 
 TEST_F(DccAccyTest, identify_throw_identify)
 {

--- a/src/openlcb/DccAccyConsumer.hxx
+++ b/src/openlcb/DccAccyConsumer.hxx
@@ -81,12 +81,12 @@ protected:
         event->event_write_helper<1>()->WriteAsync(node_,
             Defs::MTI_CONSUMER_IDENTIFIED_RANGE, WriteHelper::global(),
             eventid_to_buffer(EncodeRange(
-                TractionDefs::ACTIVATE_BASIC_DCC_ACCESSORY_EVENT_BASE, 2044)),
+                TractionDefs::ACTIVATE_BASIC_DCC_ACCESSORY_EVENT_BASE, 4095)),
             done->new_child());
         event->event_write_helper<2>()->WriteAsync(node_,
             Defs::MTI_CONSUMER_IDENTIFIED_RANGE, WriteHelper::global(),
             eventid_to_buffer(EncodeRange(
-                TractionDefs::INACTIVATE_BASIC_DCC_ACCESSORY_EVENT_BASE, 2044)),
+                TractionDefs::INACTIVATE_BASIC_DCC_ACCESSORY_EVENT_BASE, 4095)),
             done->new_child());
         done->notify();
     }

--- a/src/openlcb/DccAccyConsumer.hxx
+++ b/src/openlcb/DccAccyConsumer.hxx
@@ -74,21 +74,31 @@ protected:
     void handle_identify_global(const EventRegistryEntry &registry_entry,
         EventReport *event, BarrierNotifiable *done) OVERRIDE
     {
+        AutoNotify an(done);
         if (event->dst_node && event->dst_node != node_)
         {
-            return done->notify();
+            return;
         }
-        event->event_write_helper<1>()->WriteAsync(node_,
-            Defs::MTI_CONSUMER_IDENTIFIED_RANGE, WriteHelper::global(),
-            eventid_to_buffer(EncodeRange(
-                TractionDefs::ACTIVATE_BASIC_DCC_ACCESSORY_EVENT_BASE, 4095)),
-            done->new_child());
-        event->event_write_helper<2>()->WriteAsync(node_,
-            Defs::MTI_CONSUMER_IDENTIFIED_RANGE, WriteHelper::global(),
-            eventid_to_buffer(EncodeRange(
-                TractionDefs::INACTIVATE_BASIC_DCC_ACCESSORY_EVENT_BASE, 4095)),
-            done->new_child());
-        done->notify();
+        if (registry_entry.event ==
+            TractionDefs::ACTIVATE_BASIC_DCC_ACCESSORY_EVENT_BASE)
+        {
+            event->event_write_helper<1>()->WriteAsync(node_,
+                Defs::MTI_CONSUMER_IDENTIFIED_RANGE, WriteHelper::global(),
+                eventid_to_buffer(EncodeRange(
+                    TractionDefs::ACTIVATE_BASIC_DCC_ACCESSORY_EVENT_BASE,
+                    4095)),
+                done->new_child());
+        }
+        if (registry_entry.event ==
+            TractionDefs::INACTIVATE_BASIC_DCC_ACCESSORY_EVENT_BASE)
+        {
+            event->event_write_helper<2>()->WriteAsync(node_,
+                Defs::MTI_CONSUMER_IDENTIFIED_RANGE, WriteHelper::global(),
+                eventid_to_buffer(EncodeRange(
+                    TractionDefs::INACTIVATE_BASIC_DCC_ACCESSORY_EVENT_BASE,
+                    4095)),
+                done->new_child());
+        }
     }
 
     void handle_event_report(const EventRegistryEntry &registry_entry,


### PR DESCRIPTION
The range was not set properly, we use two ranges of 4095, but we only identified two ranges of about 2048.

Fixes unintentional repetition of the range identify messages. We have two registrations in the event handler tree.