### PR TITLE
Fix hub_test targets subdir name

### DIFF
--- a/applications/hub_test/targets/Makefile
+++ b/applications/hub_test/targets/Makefile
@@ -1,4 +1,4 @@
 SUBDIRS = \
-          linux.86 \
+          linux.x86 \
 
 include $(OPENMRNPATH)/etc/recurse.mk


### PR DESCRIPTION
Fixing the target subdirectory name to match the directory name.