### PR TITLE
Fixes in file memory space

### DIFF
--- a/src/openlcb/MemoryConfig.cxx
+++ b/src/openlcb/MemoryConfig.cxx
@@ -209,6 +209,12 @@ size_t FileMemorySpace::read(address_t destination, uint8_t *dst, size_t len,
         *error = Defs::ERROR_PERMANENT;
         return 0;
     }
+    else if (ret == 0)
+    {
+        // EOF
+        *error = MemoryConfigDefs::ERROR_OUT_OF_BOUNDS;
+        return 0;
+    }
     else if ((size_t)ret < len)
     {
 #ifdef __FreeRTOS__

--- a/src/openlcb/MemoryConfig.hxx
+++ b/src/openlcb/MemoryConfig.hxx
@@ -245,6 +245,7 @@ class FileMemorySpace : public MemorySpace
 {
 public:
     static const address_t AUTO_LEN = (address_t) - 1;
+    static const address_t UNLIMITED_LEN = (address_t) - 2;
 
     /** Creates a memory space based on an fd.
      *


### PR DESCRIPTION
- adds a constant to support "unlimited" length for writing into variable-sized files.
- ensures that when ::read returns EOF, we stop spinning and return ERROR_OUT_OF_BOUNDS to the openlcb message. This is needed when the file contents change during the lifetime of the binary.