### PR TITLE
Fixes detecting EOF in the memory config protocol handler.

### DIFF
--- a/src/openlcb/MemoryConfig.cxx
+++ b/src/openlcb/MemoryConfig.cxx
@@ -209,6 +209,12 @@ size_t FileMemorySpace::read(address_t destination, uint8_t *dst, size_t len,
         *error = Defs::ERROR_PERMANENT;
         return 0;
     }
+    else if (ret == 0)
+    {
+        // EOF
+        *error = MemoryConfigDefs::ERROR_OUT_OF_BOUNDS;
+        return 0;
+    }
     else if ((size_t)ret < len)
     {
 #ifdef __FreeRTOS__


### PR DESCRIPTION
When the posix file read returns an EOF, reports that correctly to the openlcb protocol caller method. 