### PR TITLE
Bug fixes in DataBuffer

### DIFF
--- a/src/utils/DataBuffer.cxxtest
+++ b/src/utils/DataBuffer.cxxtest
@@ -398,14 +398,19 @@ protected:
     DataBufferFuzzTest()
     {
         for (int i = 0; i < NUM_OP; ++i) {
-            freq_[i] = 1;
+            freq_[i] = 0;
         }
+        freq_[0] = 1;
         freq_[NUM_OP] = 0;
     }
 
     enum Op {
         OP_APPEND,
         OP_READ,
+        OP_XFERMID,
+        OP_READMID,
+        OP_XFEREND,
+        OP_READEND,
         NUM_OP
     };
 
@@ -419,6 +424,21 @@ protected:
         return rand_r(&randSeed_) % max;
     }
 
+    /// Setup a fuzz test scenario where we append a given LinkedDataBufferPtr
+    /// and then read from the same one.
+    void setup_basic_readwrite() {
+        freq_[OP_APPEND] = 1;
+        freq_[OP_READ] = 1;
+    }
+
+    /// Setup a fuzz test scenario where we append one LinkedDataBufferPtr,
+    /// then move data to a middle one, then read that middle one.
+    void setup_write_transfer_read() {
+        freq_[OP_APPEND] = 1;
+        freq_[OP_XFERMID] = 1;
+        freq_[OP_READMID] = 1;
+    }
+    
     void prep_fuzz() {
         int sum = 0;
         for (int i = 0; i <= NUM_OP; ++i) {
@@ -446,45 +466,32 @@ protected:
         switch(op) {
             case OP_APPEND: {
                 int len = get_random_uni(22);
-                while(len) {
-                    int free = lnk_.free();
-                    if (!free) {
-                        DataBuffer *c;
-                        g_pool10.alloc(&c);
-                        lnk_.append_empty_buffer(c);
-                        continue;
-                    }
-                    auto* p = lnk_.data_write_pointer();
-                    int count = 0;
-                    while (free > 0 && len > 0) {
-                        *p++ = nextByte_++;
-                        --free;
-                        --len;
-                        ++count;
-                    }
-                    lnk_.data_write_advance(count);
-                }
+                append_helper(&lnk_, len);
                 break;
             }
             case OP_READ: {
                 int len = get_random_uni(22);
-                while(len > 0 && lnk_.size() > 0) {
-                    size_t avail;
-                    const uint8_t* ptr = lnk_.data_read_pointer(&avail);
-                    if ((int)avail > len) {
-                        avail = len;
-                    }
-                    int count = 0;
-                    while (avail) {
-                        EXPECT_EQ(nextByteRead_, *ptr);
-                        ++nextByteRead_;
-                        ++ptr;
-                        ++count;
-                        --avail;
-                        --len;
-                    }
-                    lnk_.data_read_advance(count);
-                }                
+                consume_helper(&lnk_, len);
+                break;
+            }
+            case OP_XFERMID: {
+                int len = get_random_uni(22);
+                xfer_helper(&lnk_, &mid_, len);
+                break;
+            }
+            case OP_READMID: {
+                int len = get_random_uni(22);
+                consume_helper(&mid_, len);
+                break;
+            }
+            case OP_XFEREND: {
+                int len = get_random_uni(22);
+                xfer_helper(&mid_, &end_, len);
+                break;
+            }
+            case OP_READEND: {
+                int len = get_random_uni(22);
+                consume_helper(&end_, len);
                 break;
             }
             default:
@@ -499,6 +506,81 @@ protected:
         return ret;
     }
 
+    /// Appends a certain number of characters to a ptr. Characters are always
+    /// taken in the input sequence.
+    void append_helper(LinkedDataBufferPtr *p, size_t len)
+    {
+        while (len)
+        {
+            int free = p->free();
+            if (!free)
+            {
+                DataBuffer *c;
+                g_pool10.alloc(&c);
+                p->append_empty_buffer(c);
+                continue;
+            }
+            auto *rp = p->data_write_pointer();
+            int count = 0;
+            while (free > 0 && len > 0)
+            {
+                *rp++ = generate();
+                --free;
+                --len;
+                ++count;
+            }
+            p->data_write_advance(count);
+        }
+    }
+
+    /// Appends a certain number of characters to a ptr. Characters are always
+    /// taken in the input sequence.
+    void xfer_helper(
+        LinkedDataBufferPtr *from, LinkedDataBufferPtr *to, size_t len)
+    {
+        LinkedDataBufferPtr tmp;
+        len = std::min(len, (size_t)from->size());
+        tmp.reset(*from, len);
+        from->data_read_advance(len);
+        ASSERT_TRUE(to->try_append_from(tmp));
+    }
+    
+    /// Consumes (reads) a certain number of characters from a ptr. Characters
+    /// are compared to the expected output sequence.
+    void consume_helper(LinkedDataBufferPtr *p, size_t len)
+    {
+        while (len > 0 && p->size() > 0)
+        {
+            size_t avail;
+            const uint8_t *ptr = p->data_read_pointer(&avail);
+            if (avail > len)
+            {
+                avail = len;
+            }
+            int count = 0;
+            while (avail)
+            {
+                consume(*(ptr++));
+                ++count;
+                --avail;
+                --len;
+            }
+            p->data_read_advance(count);
+        }
+    }
+
+    /// @return the next byte of the generated sequence.
+    uint8_t generate() {
+        return nextByte_++;
+    }
+
+    /// Take in the next byte that came out at the end. Verifies that it is the
+    /// correct byte value.
+    void consume(uint8_t next_byte) {
+        EXPECT_EQ(nextByteRead_, next_byte);
+        ++nextByteRead_;
+    }
+    
     DataBuffer *b_;
     unsigned lastFree_;
     unsigned int randSeed_{83012475};
@@ -508,22 +590,33 @@ protected:
     BarrierNotifiable bn_;
     BarrierNotifiable bn2_;
     LinkedDataBufferPtr lnk_;
+    LinkedDataBufferPtr mid_;
+    LinkedDataBufferPtr end_;
     std::vector<std::unique_ptr<BarrierNotifiable> > bns_;
 };
 
 TEST_F(DataBufferFuzzTest, small_fuzz) {
+    setup_basic_readwrite();
     run_fuzz(10);
 }
 
 TEST_F(DataBufferFuzzTest, medium_fuzz) {
+    setup_basic_readwrite();
     run_fuzz(1000);
 }
 
 TEST_F(DataBufferFuzzTest, large_fuzz) {
+    setup_basic_readwrite();
     run_fuzz(100000);
 }
 
-TEST_F(DataBufferFuzzTest, xl_fuzz) {
-    run_fuzz(1000000);
+TEST_F(DataBufferFuzzTest, small_duo) {
+    setup_write_transfer_read();
+    run_fuzz(10);
+}
+
+TEST_F(DataBufferFuzzTest, medium_duo) {
+    setup_write_transfer_read();
+    run_fuzz(1000);
 }
 

--- a/src/utils/DataBuffer.cxxtest
+++ b/src/utils/DataBuffer.cxxtest
@@ -449,13 +449,15 @@ protected:
 
     void run_fuzz(unsigned iter) {
         prep_fuzz();
-
+        size_t idx = 0;
         while (--iter && !HasFatalFailure())
         {
             int oper = get_random_uni(freq_[NUM_OP]);
             for (int i = 0; i < NUM_OP; ++i) {
                 if (freq_[i] > oper) {
+                    SCOPED_TRACE(idx);
                     run_op((Op)i);
+                    ++idx;
                     break;
                 }
             }
@@ -542,7 +544,7 @@ protected:
         len = std::min(len, (size_t)from->size());
         tmp.reset(*from, len);
         from->data_read_advance(len);
-        ASSERT_TRUE(to->try_append_from(tmp));
+        ASSERT_TRUE(to->try_append_from(tmp, true));
     }
     
     /// Consumes (reads) a certain number of characters from a ptr. Characters

--- a/src/utils/DataBuffer.cxxtest
+++ b/src/utils/DataBuffer.cxxtest
@@ -438,7 +438,17 @@ protected:
         freq_[OP_XFERMID] = 1;
         freq_[OP_READMID] = 1;
     }
-    
+
+    /// Setup a fuzz test scenario where we append one LinkedDataBufferPtr,
+    /// then move data to a middle one, then move data to a third one, then
+    /// read that last.
+    void setup_write_transfer_read_transfer_read() {
+        freq_[OP_APPEND] = 1;
+        freq_[OP_XFERMID] = 1;
+        freq_[OP_XFEREND] = 1;
+        freq_[OP_READEND] = 1;
+    }
+
     void prep_fuzz() {
         int sum = 0;
         for (int i = 0; i <= NUM_OP; ++i) {
@@ -622,3 +632,22 @@ TEST_F(DataBufferFuzzTest, medium_duo) {
     run_fuzz(1000);
 }
 
+TEST_F(DataBufferFuzzTest, large_duo) {
+    setup_write_transfer_read();
+    run_fuzz(100000);
+}
+
+TEST_F(DataBufferFuzzTest, small_tri) {
+    setup_write_transfer_read_transfer_read();
+    run_fuzz(10);
+}
+
+TEST_F(DataBufferFuzzTest, medium_tri) {
+    setup_write_transfer_read_transfer_read();
+    run_fuzz(1000);
+}
+
+TEST_F(DataBufferFuzzTest, large_tri) {
+    setup_write_transfer_read_transfer_read();
+    run_fuzz(100000);
+}

--- a/src/utils/DataBuffer.cxxtest
+++ b/src/utils/DataBuffer.cxxtest
@@ -3,6 +3,7 @@
 #include "utils/test_main.hxx"
 
 DataBufferPool g_pool(64);
+DataBufferPool g_pool10(10);
 
 class DataBufferTest : public ::testing::Test
 {
@@ -390,3 +391,139 @@ TEST_F(DataBufferTest, lnk_multi)
     // The barriers will verify upon destruction time that they were correctly
     // notified.
 }
+
+class DataBufferFuzzTest : public ::testing::Test
+{
+protected:
+    DataBufferFuzzTest()
+    {
+        for (int i = 0; i < NUM_OP; ++i) {
+            freq_[i] = 1;
+        }
+        freq_[NUM_OP] = 0;
+    }
+
+    enum Op {
+        OP_APPEND,
+        OP_READ,
+        NUM_OP
+    };
+
+    int freq_[NUM_OP + 1];
+    
+    /// @return a pseudorandom number uniformly distributed between 0 and max -
+    /// 1.
+    /// @param max distribution parameter.
+    unsigned get_random_uni(unsigned max)
+    {
+        return rand_r(&randSeed_) % max;
+    }
+
+    void prep_fuzz() {
+        int sum = 0;
+        for (int i = 0; i <= NUM_OP; ++i) {
+            sum += freq_[i];
+            freq_[i] = sum;
+        }
+    }
+
+    void run_fuzz(unsigned iter) {
+        prep_fuzz();
+
+        while (--iter && !HasFatalFailure())
+        {
+            int oper = get_random_uni(freq_[NUM_OP]);
+            for (int i = 0; i < NUM_OP; ++i) {
+                if (freq_[i] > oper) {
+                    run_op((Op)i);
+                    break;
+                }
+            }
+        }
+    }
+
+    void run_op(Op op) {
+        switch(op) {
+            case OP_APPEND: {
+                int len = get_random_uni(22);
+                while(len) {
+                    int free = lnk_.free();
+                    if (!free) {
+                        DataBuffer *c;
+                        g_pool10.alloc(&c);
+                        lnk_.append_empty_buffer(c);
+                        continue;
+                    }
+                    auto* p = lnk_.data_write_pointer();
+                    int count = 0;
+                    while (free > 0 && len > 0) {
+                        *p++ = nextByte_++;
+                        --free;
+                        --len;
+                        ++count;
+                    }
+                    lnk_.data_write_advance(count);
+                }
+                break;
+            }
+            case OP_READ: {
+                int len = get_random_uni(22);
+                while(len > 0 && lnk_.size() > 0) {
+                    size_t avail;
+                    const uint8_t* ptr = lnk_.data_read_pointer(&avail);
+                    if ((int)avail > len) {
+                        avail = len;
+                    }
+                    int count = 0;
+                    while (avail) {
+                        EXPECT_EQ(nextByteRead_, *ptr);
+                        ++nextByteRead_;
+                        ++ptr;
+                        ++count;
+                        --avail;
+                        --len;
+                    }
+                    lnk_.data_read_advance(count);
+                }                
+                break;
+            }
+            default:
+                return;
+        }
+    }
+    
+    std::string flatten(const LinkedDataBufferPtr &p)
+    {
+        std::string ret;
+        p.append_to(&ret);
+        return ret;
+    }
+
+    DataBuffer *b_;
+    unsigned lastFree_;
+    unsigned int randSeed_{83012475};
+    uint8_t nextByte_{0};
+    uint8_t nextByteRead_{0};
+
+    BarrierNotifiable bn_;
+    BarrierNotifiable bn2_;
+    LinkedDataBufferPtr lnk_;
+    std::vector<std::unique_ptr<BarrierNotifiable> > bns_;
+};
+
+TEST_F(DataBufferFuzzTest, small_fuzz) {
+    run_fuzz(10);
+}
+
+TEST_F(DataBufferFuzzTest, medium_fuzz) {
+    run_fuzz(1000);
+}
+
+TEST_F(DataBufferFuzzTest, large_fuzz) {
+    run_fuzz(100000);
+}
+
+TEST_F(DataBufferFuzzTest, xl_fuzz) {
+    run_fuzz(1000000);
+}
+

--- a/src/utils/DataBuffer.cxxtest
+++ b/src/utils/DataBuffer.cxxtest
@@ -397,14 +397,16 @@ class DataBufferFuzzTest : public ::testing::Test
 protected:
     DataBufferFuzzTest()
     {
-        for (int i = 0; i < NUM_OP; ++i) {
+        for (int i = 0; i < NUM_OP; ++i)
+        {
             freq_[i] = 0;
         }
         freq_[0] = 1;
         freq_[NUM_OP] = 0;
     }
 
-    enum Op {
+    enum Op
+    {
         OP_APPEND,
         OP_READ,
         OP_XFERMID,
@@ -415,7 +417,7 @@ protected:
     };
 
     int freq_[NUM_OP + 1];
-    
+
     /// @return a pseudorandom number uniformly distributed between 0 and max -
     /// 1.
     /// @param max distribution parameter.
@@ -426,14 +428,16 @@ protected:
 
     /// Setup a fuzz test scenario where we append a given LinkedDataBufferPtr
     /// and then read from the same one.
-    void setup_basic_readwrite() {
+    void setup_basic_readwrite()
+    {
         freq_[OP_APPEND] = 1;
         freq_[OP_READ] = 1;
     }
 
     /// Setup a fuzz test scenario where we append one LinkedDataBufferPtr,
     /// then move data to a middle one, then read that middle one.
-    void setup_write_transfer_read() {
+    void setup_write_transfer_read()
+    {
         freq_[OP_APPEND] = 1;
         freq_[OP_XFERMID] = 1;
         freq_[OP_READMID] = 1;
@@ -442,29 +446,35 @@ protected:
     /// Setup a fuzz test scenario where we append one LinkedDataBufferPtr,
     /// then move data to a middle one, then move data to a third one, then
     /// read that last.
-    void setup_write_transfer_read_transfer_read() {
+    void setup_write_transfer_read_transfer_read()
+    {
         freq_[OP_APPEND] = 1;
         freq_[OP_XFERMID] = 1;
         freq_[OP_XFEREND] = 1;
         freq_[OP_READEND] = 1;
     }
 
-    void prep_fuzz() {
+    void prep_fuzz()
+    {
         int sum = 0;
-        for (int i = 0; i <= NUM_OP; ++i) {
+        for (int i = 0; i <= NUM_OP; ++i)
+        {
             sum += freq_[i];
             freq_[i] = sum;
         }
     }
 
-    void run_fuzz(unsigned iter) {
+    void run_fuzz(unsigned iter)
+    {
         prep_fuzz();
         size_t idx = 0;
         while (--iter && !HasFatalFailure())
         {
             int oper = get_random_uni(freq_[NUM_OP]);
-            for (int i = 0; i < NUM_OP; ++i) {
-                if (freq_[i] > oper) {
+            for (int i = 0; i < NUM_OP; ++i)
+            {
+                if (freq_[i] > oper)
+                {
                     SCOPED_TRACE(idx);
                     run_op((Op)i);
                     ++idx;
@@ -474,34 +484,42 @@ protected:
         }
     }
 
-    void run_op(Op op) {
-        switch(op) {
-            case OP_APPEND: {
+    void run_op(Op op)
+    {
+        switch (op)
+        {
+            case OP_APPEND:
+            {
                 int len = get_random_uni(22);
                 append_helper(&lnk_, len);
                 break;
             }
-            case OP_READ: {
+            case OP_READ:
+            {
                 int len = get_random_uni(22);
                 consume_helper(&lnk_, len);
                 break;
             }
-            case OP_XFERMID: {
+            case OP_XFERMID:
+            {
                 int len = get_random_uni(22);
                 xfer_helper(&lnk_, &mid_, len);
                 break;
             }
-            case OP_READMID: {
+            case OP_READMID:
+            {
                 int len = get_random_uni(22);
                 consume_helper(&mid_, len);
                 break;
             }
-            case OP_XFEREND: {
+            case OP_XFEREND:
+            {
                 int len = get_random_uni(22);
                 xfer_helper(&mid_, &end_, len);
                 break;
             }
-            case OP_READEND: {
+            case OP_READEND:
+            {
                 int len = get_random_uni(22);
                 consume_helper(&end_, len);
                 break;
@@ -510,7 +528,7 @@ protected:
                 return;
         }
     }
-    
+
     std::string flatten(const LinkedDataBufferPtr &p)
     {
         std::string ret;
@@ -556,7 +574,7 @@ protected:
         from->data_read_advance(len);
         ASSERT_TRUE(to->try_append_from(tmp, true));
     }
-    
+
     /// Consumes (reads) a certain number of characters from a ptr. Characters
     /// are compared to the expected output sequence.
     void consume_helper(LinkedDataBufferPtr *p, size_t len)
@@ -582,72 +600,83 @@ protected:
     }
 
     /// @return the next byte of the generated sequence.
-    uint8_t generate() {
+    uint8_t generate()
+    {
         return nextByte_++;
     }
 
     /// Take in the next byte that came out at the end. Verifies that it is the
     /// correct byte value.
-    void consume(uint8_t next_byte) {
+    void consume(uint8_t next_byte)
+    {
         EXPECT_EQ(nextByteRead_, next_byte);
         ++nextByteRead_;
     }
-    
+
     DataBuffer *b_;
     unsigned lastFree_;
-    unsigned int randSeed_{83012475};
-    uint8_t nextByte_{0};
-    uint8_t nextByteRead_{0};
+    unsigned int randSeed_ {83012475};
+    uint8_t nextByte_ {0};
+    uint8_t nextByteRead_ {0};
 
     BarrierNotifiable bn_;
     BarrierNotifiable bn2_;
     LinkedDataBufferPtr lnk_;
     LinkedDataBufferPtr mid_;
     LinkedDataBufferPtr end_;
-    std::vector<std::unique_ptr<BarrierNotifiable> > bns_;
+    std::vector<std::unique_ptr<BarrierNotifiable>> bns_;
 };
 
-TEST_F(DataBufferFuzzTest, small_fuzz) {
+TEST_F(DataBufferFuzzTest, small_fuzz)
+{
     setup_basic_readwrite();
     run_fuzz(10);
 }
 
-TEST_F(DataBufferFuzzTest, medium_fuzz) {
+TEST_F(DataBufferFuzzTest, medium_fuzz)
+{
     setup_basic_readwrite();
     run_fuzz(1000);
 }
 
-TEST_F(DataBufferFuzzTest, large_fuzz) {
+TEST_F(DataBufferFuzzTest, large_fuzz)
+{
     setup_basic_readwrite();
     run_fuzz(100000);
 }
 
-TEST_F(DataBufferFuzzTest, small_duo) {
+TEST_F(DataBufferFuzzTest, small_duo)
+{
     setup_write_transfer_read();
     run_fuzz(10);
 }
 
-TEST_F(DataBufferFuzzTest, medium_duo) {
+TEST_F(DataBufferFuzzTest, medium_duo)
+{
     setup_write_transfer_read();
     run_fuzz(1000);
 }
 
-TEST_F(DataBufferFuzzTest, large_duo) {
+TEST_F(DataBufferFuzzTest, large_duo)
+{
     setup_write_transfer_read();
     run_fuzz(100000);
 }
 
-TEST_F(DataBufferFuzzTest, small_tri) {
+TEST_F(DataBufferFuzzTest, small_tri)
+{
     setup_write_transfer_read_transfer_read();
     run_fuzz(10);
 }
 
-TEST_F(DataBufferFuzzTest, medium_tri) {
+TEST_F(DataBufferFuzzTest, medium_tri)
+{
     setup_write_transfer_read_transfer_read();
     run_fuzz(1000);
 }
 
-TEST_F(DataBufferFuzzTest, large_tri) {
+TEST_F(DataBufferFuzzTest, large_tri)
+{
     setup_write_transfer_read_transfer_read();
     run_fuzz(100000);
 }

--- a/src/utils/DataBuffer.hxx
+++ b/src/utils/DataBuffer.hxx
@@ -40,17 +40,15 @@
 #include "utils/LinkedObject.hxx"
 #include "utils/macros.h"
 
-
 #ifdef GTEST
-//#define DEBUG_DATA_BUFFER_FREE
+// #define DEBUG_DATA_BUFFER_FREE
 #endif
 
 class DataBufferPool;
 
-
 #ifdef DEBUG_DATA_BUFFER_FREE
 class DataBuffer;
-static void check_db_ownership(DataBuffer* p);
+static void check_db_ownership(DataBuffer *p);
 #endif
 
 /// Specialization of the Buffer class that is designed for storing untyped
@@ -179,15 +177,17 @@ public:
         return curr->next();
     }
 
-#ifdef DEBUG_DATA_BUFFER_FREE    
-    void unref() {
-        if (references() == 1) {
+#ifdef DEBUG_DATA_BUFFER_FREE
+    void unref()
+    {
+        if (references() == 1)
+        {
             check_db_ownership(this);
         }
         Buffer::unref();
     }
-#endif    
-    
+#endif
+
 private:
     friend class DataBufferPool;
 
@@ -371,7 +371,7 @@ public:
     /// at this point.
     /// @return the read pointer, or nullptr if there is no data in this
     /// buffer.
-    const uint8_t* data_read_pointer(size_t* len)
+    const uint8_t *data_read_pointer(size_t *len)
     {
         if (!head_ || !size_)
         {
@@ -539,7 +539,8 @@ public:
         {
             return true; // zero bytes, nothing to do.
         }
-        if (!size_) {
+        if (!size_)
+        {
             // We are empty, so anything can be appended.
             reset(o);
             return true;
@@ -559,12 +560,18 @@ public:
             // means that we don't depend on the value of free_ anymore for
             // correctness. We also check that o starts at the beginning of the
             // head buffer.
-            if (tail_->size() == (size_t)-free_ && o.skip() == 0) {
-                if (tail_->next() == o.head()) {
+            if (tail_->size() == (size_t)-free_ && o.skip() == 0)
+            {
+                if (tail_->next() == o.head())
+                {
                     // link already exists
-                } else if (add_link && tail_->next() == nullptr) {
+                }
+                else if (add_link && tail_->next() == nullptr)
+                {
                     tail_->set_next(o.head());
-                } else {
+                }
+                else
+                {
                     return false;
                 }
             }
@@ -581,15 +588,19 @@ public:
         // Now we're good, so take over the extra buffers.
         // Acquire extra references
         o.head_->ref_all(o.skip() + o.size());
-        if (tail_ == o.head()) {
+        if (tail_ == o.head())
+        {
             HASSERT(o.head_->references() > 1);
             // Release duplicate reference between the two chains.
             o.head_->unref();
         }
         tail_ = o.tail_;
-        if (o.free_ < 0) {
+        if (o.free_ < 0)
+        {
             free_ = o.free_;
-        } else {
+        }
+        else
+        {
             free_ = -tail_->size();
         }
         size_ += o.size_;
@@ -623,11 +634,15 @@ private:
 };
 
 #ifdef DEBUG_DATA_BUFFER_FREE
-void check_db_ownership(DataBuffer* b) {
+void check_db_ownership(DataBuffer *b)
+{
     AtomicHolder h(LinkedDataBufferPtr::head_mu());
-    for (LinkedDataBufferPtr* l = LinkedDataBufferPtr::link_head(); l; l = l->link_next()) {
+    for (LinkedDataBufferPtr *l = LinkedDataBufferPtr::link_head(); l;
+         l = l->link_next())
+    {
         ssize_t total = l->skip() + l->size();
-        for (DataBuffer* curr = l->head(); total > 0;) {
+        for (DataBuffer *curr = l->head(); total > 0;)
+        {
             HASSERT(curr != b);
             total -= curr->size();
             curr = curr->next();

--- a/src/utils/DataBuffer.hxx
+++ b/src/utils/DataBuffer.hxx
@@ -324,6 +324,29 @@ public:
         size_ += len;
     }
 
+    /// Retrieves a pointer where data can be read out of the buffer.
+    /// @param len will be filled in with the number of available bytes to read
+    /// at this point.
+    /// @return the read pointer, or nullptr if there is no data in this
+    /// buffer.
+    const uint8_t* data_read_pointer(size_t* len)
+    {
+        if (!head_ || !size_)
+        {
+            *len = 0;
+            return nullptr;
+        }
+        unsigned avail = 0;
+        uint8_t *p;
+        head_->get_read_pointer(skip_, &p, &avail);
+        if (avail > size_)
+        {
+            avail = size_;
+        }
+        *len = avail;
+        return p;
+    }
+
     /// Advances the head pointer. Typically used after a successful read
     /// happened.
     /// @param len how many bytes to advance the read pointer.
@@ -334,6 +357,7 @@ public:
         {
             uint8_t *p;
             unsigned available;
+            HASSERT(skip_ < head_->size());
             DataBuffer *next_head =
                 head_->get_read_pointer(skip_, &p, &available);
             if ((len > available) || (len == available && len < size_))
@@ -346,6 +370,7 @@ public:
             }
             else
             {
+                // now: len < available || len == available == size_
                 skip_ += len;
                 size_ -= len;
                 len = 0;

--- a/src/utils/DataBuffer.hxx
+++ b/src/utils/DataBuffer.hxx
@@ -231,6 +231,15 @@ public:
         {
             size = o.size_;
         }
+        if ((size_t)size > o.size_)
+        {
+            size = o.size_;
+        }
+        if (!size)
+        {
+            // Nothing to copy, this will be an empty buffer.
+            return;
+        }
         skip_ = o.skip_;
         size_ = size;
         // Takes references, keeping the tail and tail size.

--- a/src/utils/DataBuffer.hxx
+++ b/src/utils/DataBuffer.hxx
@@ -38,6 +38,8 @@
 
 #include "utils/Buffer.hxx"
 #include "utils/LinkedObject.hxx"
+#include "utils/macros.h"
+
 
 #ifdef GTEST
 //#define DEBUG_DATA_BUFFER_FREE
@@ -587,7 +589,11 @@ public:
             o.head_->unref();
         }
         tail_ = o.tail_;
-        free_ = o.free_;
+        if (o.free_ < 0) {
+            free_ = o.free_;
+        } else {
+            free_ = -tail_->size();
+        }
         size_ += o.size_;
         return true;
     }

--- a/src/utils/DataBuffer.hxx
+++ b/src/utils/DataBuffer.hxx
@@ -504,6 +504,11 @@ public:
             return false;
         }
         HASSERT(o.head());
+        if (!size_) {
+            // We are empty, so anything can be appended.
+            reset(o);
+            return true;
+        }
         if (o.head() != tail_)
         {
             // Buffer does not start in the same chain where we end.

--- a/src/utils/DataBuffer.hxx
+++ b/src/utils/DataBuffer.hxx
@@ -199,8 +199,6 @@ private:
 
 using DataBufferPtr = std::unique_ptr<DataBuffer, BufferDelete<uint8_t[]>>;
 
-class LinkedDataBufferPtr;
-
 /// A class that keeps ownership of a chain of linked DataBuffer references.
 class LinkedDataBufferPtr
 #ifdef DEBUG_DATA_BUFFER_FREE


### PR DESCRIPTION
There were several corner cases in appending to a Datauffer that were incorrectly handled and causing crashes in DirectHub.
This PR fixes bugs and adds tests including several fuzz tests for databuffers.