### PR TITLE
Fixes a standards compliance issue with the alias conflict handler.

### DIFF
--- a/src/openlcb/AliasAllocator.cxxtest
+++ b/src/openlcb/AliasAllocator.cxxtest
@@ -259,10 +259,24 @@ TEST_F(AsyncAliasAllocatorTest, AllocateMultiple)
     expect_packet(":X14003AAAN;");
     expect_packet(":X10700AAAN;");
 
+    run_x([this]() {
+        EXPECT_EQ(
+            0x02010D000005u, ifCan_->local_aliases()->lookup(NodeAlias(0x555)));
+        EXPECT_EQ(
+            0x555u, ifCan_->local_aliases()->lookup(NodeID(0x02010D000005u)));
+    });
     /* Conflicts with the previous alias to be tested. That's not a problem at
      * this point however, because that alias has already left the
-     * allocator. */
+     * allocator. The conflict will generate an AMR frame. */
+    expect_packet(":X10703555N02010D000005;");
     send_packet(":X10700555N;");
+    twait();
+    run_x([this]() {
+        // This mapping should be removed.
+        EXPECT_EQ(0U, ifCan_->local_aliases()->lookup(NodeAlias(0x555)));
+        EXPECT_EQ(0U, ifCan_->local_aliases()->lookup(NodeID(0x02010D000005u)));
+    });
+        
 
     get_next_alias();
     EXPECT_EQ(0xAAAU, b_->data()->alias);
@@ -297,6 +311,7 @@ TEST_F(AsyncAliasAllocatorTest, AllocationConflict)
             ifCan_->local_aliases()->lookup(NodeAlias(0xAA5)));
         // This one should be unknown.
         EXPECT_EQ(0U, ifCan_->local_aliases()->lookup(NodeAlias(0x555)));
+        EXPECT_EQ(0U, ifCan_->local_aliases()->lookup(NodeID(0x02010D000005u)));
     });
 
     get_next_alias();

--- a/src/openlcb/AliasCache.cxx
+++ b/src/openlcb/AliasCache.cxx
@@ -311,12 +311,13 @@ void AliasCache::add(NodeID id, NodeAlias alias)
     {
         /* we already have a mapping for this alias, so lets remove it */
         insert = it->deref(this);
+        auto nid = insert->get_node_id();
         remove(insert->alias_);
 
         if (removeCallback)
         {
             /* tell the interface layer that we removed this mapping */
-            (*removeCallback)(insert->get_node_id(), insert->alias_, context);
+            (*removeCallback)(nid, insert->alias_, context);
         }
     }
     auto nit = idMap.find(id);
@@ -324,12 +325,13 @@ void AliasCache::add(NodeID id, NodeAlias alias)
     {
         /* we already have a mapping for this id, so lets remove it */
         insert = nit->deref(this);
+        auto nid = insert->get_node_id();
         remove(insert->alias_);
 
         if (removeCallback)
         {
             /* tell the interface layer that we removed this mapping */
-            (*removeCallback)(insert->get_node_id(), insert->alias_, context);
+            (*removeCallback)(nid, insert->alias_, context);
         }
     }
 
@@ -420,7 +422,10 @@ void AliasCache::remove(NodeAlias alias)
         Metadata *metadata = it->deref(this);
         aliasMap.erase(it);
         idMap.erase(idMap.find(metadata->get_node_id()));
+        // Ensures that the AME query handler does not find this metadata.
+        metadata->set_node_id(0);
 
+        // Removes metadata from the linked lists.
         if (!metadata->newer_.empty())
         {
             metadata->newer_.deref(this)->older_ = metadata->older_;
@@ -438,6 +443,7 @@ void AliasCache::remove(NodeAlias alias)
             oldest = metadata->newer_;
         }
 
+        // Adds metadata to the freelist.
         metadata->older_ = freeList;
         freeList.idx_ = metadata - pool;
     }

--- a/src/openlcb/AliasCache.cxxtest
+++ b/src/openlcb/AliasCache.cxxtest
@@ -298,8 +298,8 @@ static void remove_callback(NodeID node_id, NodeAlias alias, void *context)
 {
     EXPECT_TRUE(context == (void*)0xABCD0123);
     
-    EXPECT_TRUE(10 == alias);
-    EXPECT_TRUE(101 == node_id);
+    EXPECT_EQ(10u, alias);
+    EXPECT_EQ(101u, node_id);
 }
 
 TEST(AliasCacheTest, kick_out_duplicate_alias_callback)

--- a/src/openlcb/IfCan.cxxtest
+++ b/src/openlcb/IfCan.cxxtest
@@ -400,11 +400,21 @@ TEST_F(AsyncMessageCanTests, AliasConflictAllocatedNode)
     // This alias is in the cache since the setup routine.
     RX(EXPECT_EQ(
         TEST_NODE_ID, ifCan_->local_aliases()->lookup(NodeAlias(0x22A))));
-    // If someone else uses it (not for CID frame)
-    send_packet(":X1800022AN;");
+
+    // AME will find it.
+    send_packet_and_expect_response(":X10702999N;", ":X1070122AN02010D000003;");
+    
+    // If someone else uses it (not for CID frame), then an RID gets generated
+    // and
+    send_packet_and_expect_response(":X1800022AN;", ":X1070322AN02010D000003;");
     wait();
-    // Then it disappears from there.
+    // Then it disappears from the cache.
     RX(EXPECT_EQ(0U, ifCan_->local_aliases()->lookup(NodeAlias(0x22A))));
+    RX(EXPECT_EQ(0U, ifCan_->local_aliases()->lookup(NodeID(TEST_NODE_ID))));
+    clear_expect(true);
+    // AME returns nothing.
+    send_packet(":X10702999N;");
+    clear_expect(true);
 }
 
 TEST_F(AsyncMessageCanTests, AliasConflictCIDReply)


### PR DESCRIPTION
The standard requires that at the time when an alias conflict is detected, the device to issue an AMR frame with the conflicted alias.

This PR adds the missing AMR frame. Adjusts tests to heck for this frame. Fixes a bug in the Global AME handler that was unexpectedly emitting AMD frames for removed aliases, because the cache entry was not correctly wiped when the remove was processed, and the iteration also picked up such deleted entries.