### PR TITLE
Fixes flaky IfCanStress.test.

### DIFF
--- a/src/openlcb/IfCanStress.cxxtest
+++ b/src/openlcb/IfCanStress.cxxtest
@@ -174,8 +174,10 @@ protected:
 
     ~AsyncIfStressTest()
     {
-        while (!(g1_executor.empty() && g2_executor.empty() &&
-                 g3_executor.empty() && g4_executor.empty() &&
+        while (!(g1_executor.empty() && g1_executor.active_timers()->empty() &&
+                 g2_executor.empty() && g2_executor.active_timers()->empty() &&
+                 g3_executor.empty() && g3_executor.active_timers()->empty() &&
+                 g4_executor.empty() && g4_executor.active_timers()->empty() &&
                  g_executor.empty()))
         {
             usleep(100);


### PR DESCRIPTION
Sometimes the test would fail with the error "pure virtual method executed" or "assertion fail !this->is_empty()", caused by too early destruction of the objects under test. This PR fixes how long we wait before we deem the test fixture to be ready for destruction.