### PR TITLE
Fixes missing translation of enums when reading the security mode from a simplelink profile.

### DIFF
--- a/src/freertos_drivers/net_cc32xx/CC32xxWiFi.cxx
+++ b/src/freertos_drivers/net_cc32xx/CC32xxWiFi.cxx
@@ -805,18 +805,18 @@ void CC32xxWiFi::wlan_wps_pbc_initiate()
 void CC32xxWiFi::wlan_setup_ap(const char *ssid, const char *security_key,
                                SecurityType security_type)
 {
-    HASSERT(strlen(ssid) <= 32);
-    HASSERT(strlen(security_key) <= 64);
+    if (ssid)
+    {
+        HASSERT(strlen(ssid) <= 32);
+        sl_WlanSet(SL_WLAN_CFG_AP_ID, SL_WLAN_AP_OPT_SSID, strlen(ssid),
+            (uint8_t *)ssid);
+        if (wlanRole == WlanRole::AP)
+        {
+            str_populate(this->ssid, ssid);
+        }
+    }
 
     uint8_t sec_type = security_type_to_simplelink(security_type);
-
-    sl_WlanSet(SL_WLAN_CFG_AP_ID, SL_WLAN_AP_OPT_SSID, strlen(ssid),
-               (uint8_t*)ssid);
-    if (wlanRole == WlanRole::AP)
-    {
-        str_populate(this->ssid, ssid);
-    }
-    
     sl_WlanSet(SL_WLAN_CFG_AP_ID, SL_WLAN_AP_OPT_SECURITY_TYPE, 1,
                (uint8_t*)&sec_type);
 
@@ -826,6 +826,7 @@ void CC32xxWiFi::wlan_setup_ap(const char *ssid, const char *security_key,
         return;
     }
 
+    HASSERT(strlen(security_key) <= 64);
     sl_WlanSet(SL_WLAN_CFG_AP_ID, SL_WLAN_AP_OPT_PASSWORD,
                strlen(security_key), (uint8_t*)security_key);
 }

--- a/src/freertos_drivers/net_cc32xx/CC32xxWiFi.cxx
+++ b/src/freertos_drivers/net_cc32xx/CC32xxWiFi.cxx
@@ -849,7 +849,9 @@ void CC32xxWiFi::wlan_get_ap_config(string *ssid, SecurityType *security_type)
     {
         uint16_t len = sizeof(*security_type);
         uint16_t config_opt = SL_WLAN_AP_OPT_SECURITY_TYPE;
-        sl_WlanGet(SL_WLAN_CFG_AP_ID, &config_opt, &len, (_u8*) security_type);
+        uint8_t sl_sec_type = 0;
+        sl_WlanGet(SL_WLAN_CFG_AP_ID, &config_opt, &len, &sl_sec_type);
+        *security_type = security_type_from_simplelink(sl_sec_type);
     }
 }
 

--- a/src/freertos_drivers/net_cc32xx/CC32xxWiFi.hxx
+++ b/src/freertos_drivers/net_cc32xx/CC32xxWiFi.hxx
@@ -67,10 +67,12 @@ protected:
     {
     }
 
-    /** Setup access point role credentials.
-     * @param ssid access point ssid
-     * @param security_key access point security key
-     * @param security_type specifies security type
+    /** Setup access point role credentials. It is OK to leave ssid as nullptr
+     * or password as nullptr, in which case those properties will not be
+     * changed.
+     * @param ssid access point ssid (name)
+     * @param security_key access point security key (password)
+     * @param security_type specifies security type. Required.
      */
     virtual void wlan_setup_ap(const char *ssid, const char *security_key,
                                SecurityType security_type) = 0;


### PR DESCRIPTION
The external enum is not the same as the internal enum. We have translation functions `security_type_from_simplelink` and `security_type_to_simplelink`. We forgot to call this function on one of the codepaths.

Updates the setup_ap function to be able to be called with nullptr as ssid and security key, to just update the security type.