### PR TITLE
Adds factory reset handler to linux:io_board.

### DIFF
--- a/applications/io_board/targets/linux.x86/main.cxx
+++ b/applications/io_board/targets/linux.x86/main.cxx
@@ -125,6 +125,23 @@ openlcb::ConfiguredProducer producer_sw2(
 openlcb::RefreshLoop loop(
     stack.node(), {&consumer_pulse1, &consumer_pulse2});
 
+class FactoryResetHelper : public DefaultConfigUpdateListener
+{
+public:
+    UpdateAction apply_configuration(
+        int fd, bool initial_load, BarrierNotifiable *done) OVERRIDE
+    {
+        AutoNotify n(done);
+        return UPDATED;
+    }
+
+    void factory_reset(int fd) override
+    {
+        cfg.userinfo().name().write(fd, "IO Board");
+        cfg.userinfo().description().write(fd, "User description");
+    }
+} reset_helper;
+
 /** Entry point to application.
  * @param argc number of command line arguments
  * @param argv array of command line arguments


### PR DESCRIPTION
This is necessary to initialize the username and user description fields. Without the initialization these are filled by 0xFF bytes without null termination, which is not standards compliant.