### PR TITLE
Handles unhandled-addressed-messages by generating an OIR reply.

### DIFF
--- a/src/executor/Dispatcher.cxxtest
+++ b/src/executor/Dispatcher.cxxtest
@@ -194,6 +194,27 @@ TEST_F(DispatcherTest, TestMultiplehandlers)
     wait();
 }
 
+TEST_F(DispatcherTest, TestFallbackHandler)
+{
+    StrictMock<MockCanMessageHandler> h1;
+    f_.register_handler(&h1, 1, 0xFFUL);
+    StrictMock<MockCanMessageHandler> h2;
+    f_.register_handler(&h2, 257, 0x1FFFFFFFUL);
+    StrictMock<MockCanMessageHandler> hfb;
+    f_.register_fallback_handler(&hfb);
+
+    EXPECT_CALL(h1, handle_message(257, _));
+    EXPECT_CALL(h1, handle_message(1, _));
+    EXPECT_CALL(h2, handle_message(257, _));
+    send_message(257);
+    send_message(1);
+    wait();
+
+    EXPECT_CALL(hfb, handle_message(2, _));
+    send_message(2);
+    wait();
+}
+
 /*TEST_F(DispatcherTest, TestAsync)
 {
     StrictMock<MockCanMessageHandler> h1;

--- a/src/openlcb/Convert.hxx
+++ b/src/openlcb/Convert.hxx
@@ -114,6 +114,12 @@ extern void append_error_to_buffer(uint16_t error_code, Payload *p);
 extern void buffer_to_error(const Payload &payload, uint16_t *error_code,
     uint16_t *mti, string *error_message);
 
+/// Generates the payload for an OIR or TDE message.
+/// @param error_code the 16-bit ErrorCodes value.
+/// @param incoming_mti the MTI of the message that this error should refer
+/// to.
+extern Payload error_payload(uint16_t error_code, Defs::MTI incoming_mti);
+
 /** A global class / variable for empty or not-yet-initialized payloads. */
 extern string EMPTY_PAYLOAD;
 

--- a/src/openlcb/DatagramCan.cxxtest
+++ b/src/openlcb/DatagramCan.cxxtest
@@ -407,10 +407,13 @@ TEST_F(AsyncDatagramTest, DoubleReply)
     wait();
     wait();
     send_packet(":X19A2877CN022A00;"); // Received OK
-    send_packet(":X19A2877CN022A00;"); // Received OK dup
+    wait(); // will unregister handlers
+    send_packet_and_expect_response(
+        ":X19A2877CN022A00;", ":X1906822AN077C10400A28;"); // Received OK dup
     wait_for_notification();
     // Releases client.
-    send_packet(":X19A2877CN022A00;"); // Received OK dup
+    send_packet_and_expect_response(
+        ":X19A2877CN022A00;", ":X1906822AN077C10400A28;"); // Received OK dup
     wait();
     datagram_support_.client_allocator()->insert(c);
 }

--- a/src/openlcb/DatagramTcp.cxxtest
+++ b/src/openlcb/DatagramTcp.cxxtest
@@ -13,11 +13,17 @@ class TcpDatagramTestBase : public MultiTcpIfTest
 protected:
     TcpDatagramTestBase()
     {
+        LOG(INFO, "Add client 0");
         add_client(REMOTE_NODE_ID + 0);
+        LOG(INFO, "Add client 1");
         add_client(REMOTE_NODE_ID + 1);
+        LOG(INFO, "Add node nc");
         create_new_node(&nc_, TEST_NODE_ID, &ifTcp_);
+        LOG(INFO, "Add node nc2");
         create_new_node(&nc2_, TEST_NODE_ID + 1, &ifTcp_);
+        LOG(INFO, "Add node n0");
         create_new_node(&n0_, REMOTE_NODE_ID + 0, &clients_[0]->ifTcp_);
+        LOG(INFO, "Add node n1");
         create_new_node(&n1_, REMOTE_NODE_ID + 1, &clients_[1]->ifTcp_);
     }
 

--- a/src/openlcb/If.cxx
+++ b/src/openlcb/If.cxx
@@ -33,6 +33,7 @@
  */
 
 #include "openlcb/If.hxx"
+#include "openlcb/Convert.hxx"
 
 /// Ensures that the largest bucket in the main buffer pool is exactly the size
 /// of a GenMessage.
@@ -129,6 +130,14 @@ void buffer_to_error(const Payload &payload, uint16_t *error_code,
     {
         error_message->assign(&payload[4], payload.size() - 4);
     }
+}
+
+Payload error_payload(uint16_t error_code, Defs::MTI incoming_mti)
+{
+    Payload p(4, 0);
+    error_to_data(error_code, &p[0]);
+    error_to_data(incoming_mti, &p[2]);
+    return p;
 }
 
 void send_event(Node* src_node, uint64_t event_id)

--- a/src/openlcb/IfCan.cxx
+++ b/src/openlcb/IfCan.cxx
@@ -721,6 +721,7 @@ IfCan::IfCan(ExecutorBase *executor, CanHubFlow *device,
     add_owned_flow(new FrameToGlobalMessageParser(this));
     add_owned_flow(new VerifyNodeIdHandler(this));
     add_owned_flow(new UnhandledAddressedMessageHandler(this));
+    add_owned_flow(new NullErrorHandler(this));
     add_owned_flow(new RemoteAliasCacheUpdater(this));
     add_owned_flow(new AMEQueryHandler(this));
     add_owned_flow(new AMEGlobalQueryHandler(this));

--- a/src/openlcb/IfCan.cxx
+++ b/src/openlcb/IfCan.cxx
@@ -685,6 +685,7 @@ IfCan::IfCan(ExecutorBase *executor, CanHubFlow *device,
     add_owned_flow(new AliasConflictHandler(this));
     add_owned_flow(new FrameToGlobalMessageParser(this));
     add_owned_flow(new VerifyNodeIdHandler(this));
+    add_owned_flow(new UnhandledAddressedMessageHandler(this));
     add_owned_flow(new RemoteAliasCacheUpdater(this));
     add_owned_flow(new AMEQueryHandler(this));
     add_owned_flow(new AMEGlobalQueryHandler(this));

--- a/src/openlcb/IfCan.cxx
+++ b/src/openlcb/IfCan.cxx
@@ -721,7 +721,6 @@ IfCan::IfCan(ExecutorBase *executor, CanHubFlow *device,
     add_owned_flow(new FrameToGlobalMessageParser(this));
     add_owned_flow(new VerifyNodeIdHandler(this));
     add_owned_flow(new UnhandledAddressedMessageHandler(this));
-    add_owned_flow(new NullErrorHandler(this));
     add_owned_flow(new RemoteAliasCacheUpdater(this));
     add_owned_flow(new AMEQueryHandler(this));
     add_owned_flow(new AMEGlobalQueryHandler(this));

--- a/src/openlcb/IfCan.cxxtest
+++ b/src/openlcb/IfCan.cxxtest
@@ -781,6 +781,13 @@ TEST_F(AsyncNodeTest, PassAddressedMessageToIfWithPayloadUnknownSource)
     wait();
 }
 
+TEST_F(AsyncNodeTest, OIROnUnknownMTI)
+{
+    send_packet_and_expect_response(":X19948210N022A;",
+                                    ":X1906822AN021010400948;");
+    wait();
+}
+
 TEST_F(AsyncNodeTest, SendAddressedMessageToAlias)
 {
     static const NodeAlias alias = 0x210U;

--- a/src/openlcb/IfImpl.hxx
+++ b/src/openlcb/IfImpl.hxx
@@ -267,6 +267,15 @@ private:
 #endif
 };
 
+/// Message handler that is registered as a fallback handler in the interface's
+/// message dispatcher. This means that all incoming messages that were not
+/// matching the MTI / mask of any existing instantiated handler will end up
+/// here.
+///
+/// THe standard requires that when an addressed message is not handled by a
+/// node (e.g. because it does not know about the MTI at all), then an Optional
+/// Interaction Rejected reply be sent to the originator. This flow generates
+/// that OIR reply.
 class UnhandledAddressedMessageHandler : public IncomingMessageStateFlow
 {
 public:

--- a/src/openlcb/IfImpl.hxx
+++ b/src/openlcb/IfImpl.hxx
@@ -272,7 +272,7 @@ private:
 /// matching the MTI / mask of any existing instantiated handler will end up
 /// here.
 ///
-/// THe standard requires that when an addressed message is not handled by a
+/// The standard requires that when an addressed message is not handled by a
 /// node (e.g. because it does not know about the MTI at all), then an Optional
 /// Interaction Rejected reply be sent to the originator. This flow generates
 /// that OIR reply.
@@ -305,6 +305,9 @@ public:
             iface()->addressed_message_write_flow(), STATE(fill_oir));
     }
 
+    /// Called after the message buffer allocation is complete. Fills in the
+    /// outgoing Optional Interaction Rejected message and sends it off to the
+    /// write flow.
     Action fill_oir()
     {
         auto rb = get_buffer_deleter(

--- a/src/openlcb/IfImpl.hxx
+++ b/src/openlcb/IfImpl.hxx
@@ -302,6 +302,33 @@ public:
     }
 };
 
+/// This is an addressed message handler that catches errors (OIR and TDE) but
+/// ignores them. While this sounds not super useful, it ensures that these
+/// messages never trigger the UnhandledAddressedMessageHandler.
+class NullErrorHandler : public IncomingMessageStateFlow
+{
+public:
+    NullErrorHandler(If *service)
+        : IncomingMessageStateFlow(service)
+    {
+        service->dispatcher()->register_handler(
+            this, Defs::MTI_OPTIONAL_INTERACTION_REJECTED, Defs::MTI_EXACT);
+        service->dispatcher()->register_handler(
+            this, Defs::MTI_TERMINATE_DUE_TO_ERROR, Defs::MTI_EXACT);
+    }
+
+    void send(Buffer<GenMessage> *b, unsigned) override
+    {
+        b->unref();
+    }
+
+    Action entry() override
+    {
+        DIE("should not get here");
+        return release_and_exit();
+    }
+};
+
 } // namespace openlcb
 
 #endif // _OPENLCB_IFIMPL_HXX_

--- a/src/openlcb/IfTcp.cxx
+++ b/src/openlcb/IfTcp.cxx
@@ -188,6 +188,7 @@ IfTcp::IfTcp(NodeID gateway_node_id, HubFlow *device, int local_nodes_count)
     , device_(device)
 {
     add_owned_flow(new VerifyNodeIdHandler(this));
+    add_owned_flow(new UnhandledAddressedMessageHandler(this));
     seq_ = new ClockBaseSequenceNumberGenerator;
     add_owned_flow(seq_);
     auto filter = new LocalMessageFilter(this);

--- a/src/openlcb/IfTcp.cxx
+++ b/src/openlcb/IfTcp.cxx
@@ -188,6 +188,7 @@ IfTcp::IfTcp(NodeID gateway_node_id, HubFlow *device, int local_nodes_count)
     , device_(device)
 {
     add_owned_flow(new VerifyNodeIdHandler(this));
+    add_owned_flow(new NullErrorHandler(this));
     add_owned_flow(new UnhandledAddressedMessageHandler(this));
     seq_ = new ClockBaseSequenceNumberGenerator;
     add_owned_flow(seq_);

--- a/src/openlcb/IfTcp.cxx
+++ b/src/openlcb/IfTcp.cxx
@@ -188,7 +188,6 @@ IfTcp::IfTcp(NodeID gateway_node_id, HubFlow *device, int local_nodes_count)
     , device_(device)
 {
     add_owned_flow(new VerifyNodeIdHandler(this));
-    add_owned_flow(new NullErrorHandler(this));
     add_owned_flow(new UnhandledAddressedMessageHandler(this));
     seq_ = new ClockBaseSequenceNumberGenerator;
     add_owned_flow(seq_);

--- a/src/openlcb/IfTcpImpl.hxx
+++ b/src/openlcb/IfTcpImpl.hxx
@@ -127,6 +127,7 @@ public:
         {
             return false;
         }
+        tgt->clear();
         HASSERT((flags & FLAGS_CHAINING) == 0);
         tgt->flagsDst = 0;
         tgt->flagsSrc = 0;

--- a/src/openlcb/MemoryConfigStream.cxxtest
+++ b/src/openlcb/MemoryConfigStream.cxxtest
@@ -16,7 +16,6 @@ ReadOnlyMemoryBlock smallBlock {
 /// Stream ID used for the receiver on the second interface.
 static constexpr uint8_t STREAM_DST_ID = 0x43;
 
-
 class MemoryConfigTest : public StreamTestBase
 {
 public:
@@ -266,13 +265,12 @@ TEST_F(MemoryConfigTest, two_node)
 
     StrictMock<MockMessageHandler> handler;
 
-    
     expect_packet(":X1B22A225N20600000000228FF;");
     expect_packet(":X1D22A225N43FFFFFFFF;");
 
     otherIfCan_->dispatcher()->register_handler(
         &handler, Defs::MTI_STREAM_INITIATE_REQUEST, Defs::MTI_EXACT);
-    
+
     // stream initiate request, SID 0x02 DID 0x43 buffer infinite
     EXPECT_CALL(handler,
         handle_message(Pointee(AllOf(Field(&GenMessage::mti,
@@ -322,12 +320,12 @@ TEST_F(MemoryConfigTest, two_node)
 
     // stream complete, SID 02 DID 43 sent bytes 13
     EXPECT_CALL(handler,
-        handle_message(Pointee(AllOf(Field(&GenMessage::mti,
-                                         Defs::MTI_STREAM_COMPLETE),
-                           Field(&GenMessage::dstNode, otherNode_.get()),
-                           Field(&GenMessage::payload,
-                               IsBufferNodeValueString(0x02430000000D)) //,
-                           )),
+        handle_message(
+            Pointee(AllOf(Field(&GenMessage::mti, Defs::MTI_STREAM_COMPLETE),
+                Field(&GenMessage::dstNode, otherNode_.get()),
+                Field(&GenMessage::payload,
+                    IsBufferNodeValueString(0x02430000000D)) //,
+                )),
             _));
     expect_packet(":X198A822AN022502430000000D;");
 
@@ -400,12 +398,12 @@ TEST_F(MemoryConfigTest, length_limit)
         &handler, Defs::MTI_STREAM_COMPLETE, Defs::MTI_EXACT);
     // stream complete, SID 02 DID 43 sent bytes 13
     EXPECT_CALL(handler,
-        handle_message(Pointee(AllOf(Field(&GenMessage::mti,
-                                         Defs::MTI_STREAM_COMPLETE),
-                           Field(&GenMessage::dstNode, otherNode_.get()),
-                           Field(&GenMessage::payload,
-                               IsBufferNodeValueString(0x024300000009)) //,
-                           )),
+        handle_message(
+            Pointee(AllOf(Field(&GenMessage::mti, Defs::MTI_STREAM_COMPLETE),
+                Field(&GenMessage::dstNode, otherNode_.get()),
+                Field(&GenMessage::payload,
+                    IsBufferNodeValueString(0x024300000009)) //,
+                )),
             _));
     expect_packet(":X198A822AN0225024300000009;");
 

--- a/src/openlcb/MemoryConfigStream.cxxtest
+++ b/src/openlcb/MemoryConfigStream.cxxtest
@@ -16,6 +16,7 @@ ReadOnlyMemoryBlock smallBlock {
 /// Stream ID used for the receiver on the second interface.
 static constexpr uint8_t STREAM_DST_ID = 0x43;
 
+
 class MemoryConfigTest : public StreamTestBase
 {
 public:
@@ -263,9 +264,24 @@ TEST_F(MemoryConfigTest, two_node)
     twait();
     clear_expect(true);
 
+    StrictMock<MockMessageHandler> handler;
+
+    
     expect_packet(":X1B22A225N20600000000228FF;");
     expect_packet(":X1D22A225N43FFFFFFFF;");
+
+    otherIfCan_->dispatcher()->register_handler(
+        &handler, Defs::MTI_STREAM_INITIATE_REQUEST, Defs::MTI_EXACT);
+    
     // stream initiate request, SID 0x02 DID 0x43 buffer infinite
+    EXPECT_CALL(handler,
+        handle_message(Pointee(AllOf(Field(&GenMessage::mti,
+                                         Defs::MTI_STREAM_INITIATE_REQUEST),
+                           Field(&GenMessage::dstNode, otherNode_.get()),
+                           Field(&GenMessage::payload,
+                               IsBufferNodeValueString(0xFFFF00000243ULL)) //,
+                           )),
+            _));
     expect_packet(":X19CC822AN0225FFFF00000243;");
 
     // Read stream request, space 0x28, offset 2, length infinite, dst stream
@@ -274,6 +290,8 @@ TEST_F(MemoryConfigTest, two_node)
 
     wait();
     clear_expect(true);
+    Mock::VerifyAndClear(&handler);
+    otherIfCan_->dispatcher()->unregister_handler_all(&handler);
     EXPECT_FALSE(datagramDoneBn_.is_done());
 
     // stream initiate reply
@@ -299,11 +317,24 @@ TEST_F(MemoryConfigTest, two_node)
     expect_packet(":X1F22522AN4302030405060708;");
     expect_packet(":X1F22522AN43090A0B0C0D0E;");
 
+    otherIfCan_->dispatcher()->register_handler(
+        &handler, Defs::MTI_STREAM_COMPLETE, Defs::MTI_EXACT);
+
     // stream complete, SID 02 DID 43 sent bytes 13
+    EXPECT_CALL(handler,
+        handle_message(Pointee(AllOf(Field(&GenMessage::mti,
+                                         Defs::MTI_STREAM_COMPLETE),
+                           Field(&GenMessage::dstNode, otherNode_.get()),
+                           Field(&GenMessage::payload,
+                               IsBufferNodeValueString(0x02430000000D)) //,
+                           )),
+            _));
     expect_packet(":X198A822AN022502430000000D;");
 
     twait();
     clear_expect(true);
+    Mock::VerifyAndClear(&handler);
+    otherIfCan_->dispatcher()->unregister_handler_all(&handler);
     EXPECT_TRUE(datagramDoneBn_.is_done());
 }
 
@@ -314,9 +345,22 @@ TEST_F(MemoryConfigTest, length_limit)
     twait();
     clear_expect(true);
 
+    StrictMock<MockMessageHandler> handler;
+
     expect_packet(":X1B22A225N20600000000228FF;");
     expect_packet(":X1D22A225N4300000009;");
+
+    otherIfCan_->dispatcher()->register_handler(
+        &handler, Defs::MTI_STREAM_INITIATE_REQUEST, Defs::MTI_EXACT);
     // stream initiate request, SID 0x02 DID 0x43 buffer infinite
+    EXPECT_CALL(handler,
+        handle_message(Pointee(AllOf(Field(&GenMessage::mti,
+                                         Defs::MTI_STREAM_INITIATE_REQUEST),
+                           Field(&GenMessage::dstNode, otherNode_.get()),
+                           Field(&GenMessage::payload,
+                               IsBufferNodeValueString(0xFFFF00000243ULL)) //,
+                           )),
+            _));
     expect_packet(":X19CC822AN0225FFFF00000243;");
 
     // Read stream request, space 0x28, offset 2, length 9, dst stream
@@ -325,6 +369,8 @@ TEST_F(MemoryConfigTest, length_limit)
 
     wait();
     clear_expect(true);
+    Mock::VerifyAndClear(&handler);
+    otherIfCan_->dispatcher()->unregister_handler_all(&handler);
     EXPECT_FALSE(datagramDoneBn_.is_done());
 
     // stream initiate reply
@@ -350,11 +396,23 @@ TEST_F(MemoryConfigTest, length_limit)
     expect_packet(":X1F22522AN4302030405060708;");
     expect_packet(":X1F22522AN43090A;");
 
+    otherIfCan_->dispatcher()->register_handler(
+        &handler, Defs::MTI_STREAM_COMPLETE, Defs::MTI_EXACT);
     // stream complete, SID 02 DID 43 sent bytes 13
+    EXPECT_CALL(handler,
+        handle_message(Pointee(AllOf(Field(&GenMessage::mti,
+                                         Defs::MTI_STREAM_COMPLETE),
+                           Field(&GenMessage::dstNode, otherNode_.get()),
+                           Field(&GenMessage::payload,
+                               IsBufferNodeValueString(0x024300000009)) //,
+                           )),
+            _));
     expect_packet(":X198A822AN0225024300000009;");
 
     twait();
     clear_expect(true);
+    Mock::VerifyAndClear(&handler);
+    otherIfCan_->dispatcher()->unregister_handler_all(&handler);
     EXPECT_TRUE(datagramDoneBn_.is_done());
 }
 

--- a/src/openlcb/SNIPClient.cxxtest
+++ b/src/openlcb/SNIPClient.cxxtest
@@ -126,11 +126,22 @@ TEST_F(SNIPClientTest, remote)
 TEST_F(SNIPClientTest, timeout)
 {
     long long start = os_get_time_monotonic();
-    auto b = invoke_flow(&client_, &nodeTwo_, NodeHandle(nodeTwo_.node_id()));
+    auto b = invoke_flow(&client_, &nodeTwo_, NodeHandle(NodeAlias(0x123)));
     EXPECT_EQ(SNIPClientRequest::OPENMRN_TIMEOUT, b->data()->resultCode);
     EXPECT_EQ(0u, b->data()->response.size());
     long long time = os_get_time_monotonic() - start;
     EXPECT_LT(MSEC_TO_NSEC(49), time);
+    twait();
+}
+
+TEST_F(SNIPClientTest, self_reject)
+{
+    // Sending to self on nodeTwo will get an OIR rejection from the stack
+    // because there is no SNIP handler there.
+    auto b = invoke_flow(&client_, &nodeTwo_, NodeHandle(nodeTwo_.node_id()));
+    EXPECT_EQ(SNIPClientRequest::ERROR_REJECTED | Defs::ERROR_UNIMPLEMENTED,
+        b->data()->resultCode);
+    EXPECT_EQ(0u, b->data()->response.size());
 }
 
 TEST_F(SNIPClientTest, reject)

--- a/src/openlcb/TractionTestTrain.cxxtest
+++ b/src/openlcb/TractionTestTrain.cxxtest
@@ -70,13 +70,13 @@ TEST_F(LoggingTrainTest, CreateDestroy)
 
 TEST_F(LoggingTrainTest, SetSpeed)
 {
-    send_packet(":X195EA551N033A0050B0;");
+    send_packet(":X195EB551N033A0050B0;");
 }
 
 TEST_F(LoggingTrainTest, SetFn)
 {
-    send_packet(":X195EA551N033A010000050001;");
-    send_packet(":X195EA551N033A010000050000;");
+    send_packet(":X195EB551N033A010000050001;");
+    send_packet(":X195EB551N033A010000050000;");
 }
 
 } // namespace openlcb

--- a/src/utils/async_if_test_helper.hxx
+++ b/src/utils/async_if_test_helper.hxx
@@ -560,8 +560,8 @@ MATCHER_P(IsBufferNodeValue, id, "")
     uint64_t value = htobe64(id);
     if (arg->used() != 6)
         return false;
-    uint8_t *expected = reinterpret_cast<uint8_t *>(&value) + 2;
-    uint8_t *actual = static_cast<uint8_t *>(arg->start());
+    const uint8_t *expected = reinterpret_cast<const uint8_t *>(&value) + 2;
+    const uint8_t *actual = static_cast<const uint8_t *>(arg->start());
     if (memcmp(expected, actual, 6))
     {
         for (int i = 0; i < 6; ++i)
@@ -583,8 +583,8 @@ MATCHER_P(IsBufferNodeValueString, id, "")
     uint64_t value = htobe64(id);
     if (arg.size() != 6)
         return false;
-    uint8_t *expected = reinterpret_cast<uint8_t *>(&value) + 2;
-    uint8_t *actual = static_cast<uint8_t *>(arg->start());
+    const uint8_t *expected = reinterpret_cast<const uint8_t *>(&value) + 2;
+    const uint8_t *actual = reinterpret_cast<const uint8_t *>(arg.data());
     if (memcmp(expected, actual, 6))
     {
         for (int i = 0; i < 6; ++i)

--- a/src/utils/if_tcp_test_helper.hxx
+++ b/src/utils/if_tcp_test_helper.hxx
@@ -7,6 +7,7 @@
 #include "utils/FdUtils.hxx"
 #include "utils/HubDeviceSelect.hxx"
 #include "utils/async_if_test_helper.hxx"
+#include "utils/format_utils.hxx"
 
 using ::testing::_;
 using ::testing::SaveArg;
@@ -22,6 +23,15 @@ public:
 
     void send(Buffer<HubData> *b, unsigned priority) override
     {
+        {
+            GenMessage actual;
+            actual.clear();
+            EXPECT_TRUE(TcpDefs::parse_tcp_message(*b->data(), &actual));
+            LOG(INFO,
+                "[sent] 0x%012" PRIx64 " -> %012" PRIx64 " MTI %03x payload %s",
+                actual.src.id, actual.dst.id, actual.mti,
+                string_to_hex(actual.payload).c_str());
+        }
         send(*b->data(), priority);
         b->unref();
     }


### PR DESCRIPTION
This PR fixes a stadnards compliance issue. The standard requires that when an addressed message arrives for a node which is not equipped for handling said message (including any unknown but addressed MTI arriving), then an Optional IOnteraction Rejected (OIR) message has to be sent back to the originating node, identifying that this target node is not able to handle that message.

- Adds a "fallback handler" to the Dispatcher object. The fallback handler is invoked when no handler matched on the incoming message.
- Implements a handler that responds with an OIR for all local nodes. Registers this handler as the fallback handler for the MessageDIspatcher in IfCan and IfTcp. This OIR response will be suppressed for incoming OIR and TDE errors to avoid infinite loops of error messages. (In a normal setup OpenMRN does not listen to these messages. Without this case two OpenMRN nodes will have an infinite message loop chatting with each other sending OIR messages back and forth.)

Fixes some bugs exposed by this behavior.
- The TCP parser had forgotten to clear the message it was filling, causing messages to unexpectedly be marked as addressed messages.
- A number of tests had issues when OIR messages were generated, this PR fixes these issues as well. Sometimes the MTI was mistyped, sometimes a message was verified at the CAN level but not actually processed at the destination node.