### PR TITLE
Ensures that hub's output is flushed after printing. 

### DIFF
--- a/src/utils/GridConnectHub.cxx
+++ b/src/utils/GridConnectHub.cxx
@@ -367,6 +367,7 @@ struct GcPacketPrinter::Impl : public CanHubPortInterface
         {
             fprintf(stderr, "\n");
         }
+        fflush(stderr);
     }
 
     /// Which hun are we registered to.


### PR DESCRIPTION
WHile this is generally the case for terminal outputs,
stderr is still buffered when it is redirected using 
`hub 2> /tmp/log.txt`.