### PR TITLE
Add support for <hints> elements within CDI representation

### DIFF
--- a/src/openlcb/ConfigRenderer.hxx
+++ b/src/openlcb/ConfigRenderer.hxx
@@ -393,7 +393,7 @@ public:
         {
             *r +=
                 StringPrintf("<link ref=\"%s\">%s</link>\n", linkref(),
-                linktext() ? linktext() : linkref());
+                has_linktext() ? linktext() : linkref());
         }
     }
 };

--- a/src/openlcb/ConfigRenderer.hxx
+++ b/src/openlcb/ConfigRenderer.hxx
@@ -392,16 +392,8 @@ public:
         if (linkref())
         {
             *r +=
-                StringPrintf("<link ref=\"%s\"", linkref());
-            if (linktext())
-            {
-                *r +=
-                    StringPrintf(">%s</link>\n", linktext());
-            }
-            else
-            {
-                *r += " />\n";
-            }
+                StringPrintf("<link ref=\"%s\">%s</link>\n", linkref(),
+                linktext() ? linktext() : linkref());
         }
     }
 };
@@ -597,16 +589,8 @@ public:
         if (opts.linkref())
         {
             *s +=
-                StringPrintf("<link ref=\"%s\"", opts.linkref());
-            if (opts.linktext())
-            {
-                *s +=
-                    StringPrintf(">%s</link>\n", opts.linktext());
-            }
-            else
-            {
-                *s += " />\n";
-            }
+                StringPrintf("<link ref=\"%s\">%s</link>\n", opts.linkref(),
+                alt(opts.linktext(), opts.linkref()));
         }
         *s += "</identification>\n";
     }

--- a/src/openlcb/ConfigRenderer.hxx
+++ b/src/openlcb/ConfigRenderer.hxx
@@ -55,7 +55,8 @@ struct AtomConfigDefs
     DECLARE_OPTIONALARG(Hints, hints, const char *, 3, nullptr);
     DECLARE_OPTIONALARG(SkipInit, skip_init, int, 15, 0);
     DECLARE_OPTIONALARG(Offset, offset, int, 10, 0);
-    using Base = OptionalArg<AtomConfigDefs, Name, Description, MapValues, SkipInit, Offset>;
+    using Base = OptionalArg<AtomConfigDefs, Name, Description, MapValues,
+                             Hints, SkipInit, Offset>;
 };
 
 /// Configuration implementation class for CDI Atom elements (strings, events
@@ -99,7 +100,7 @@ public:
         }
         if (hints())
         {
-            *r += StringPrintf("<hints>%s</hints>\n", mapvalues());
+            *r += StringPrintf("<hints>%s</hints>\n", hints());
         }
     }
 };
@@ -190,6 +191,10 @@ public:
             *r +=
                 StringPrintf("<description>%s</description>\n", description());
         }
+        if (hints())
+        {
+            *r += StringPrintf("<hints>%s</hints>\n", hints());
+        }
         if (minvalue() != INT_MAX)
         {
             *r += StringPrintf("<min>%d</min>\n", minvalue());
@@ -205,10 +210,6 @@ public:
         if (mapvalues())
         {
             *r += StringPrintf("<map>%s</map>\n", mapvalues());
-        }
-        if (hints())
-        {
-            *r += StringPrintf("<hints>%s</hints>\n", mapvalues());
         }
     }
 
@@ -275,8 +276,12 @@ struct GroupConfigDefs : public AtomConfigDefs
     DECLARE_OPTIONALARG(RepName, repname, const char*, 12, nullptr);
     DECLARE_OPTIONALARG(FixedSize, fixed_size, unsigned, 13, 0);
     DECLARE_OPTIONALARG(Hidden, hidden, int, 14, 0);
+    // 15 is used for SkipInit
+    DECLARE_OPTIONALARG(LinkRef, linkref, const char *, 16, nullptr);
+    DECLARE_OPTIONALARG(LinkText, linktext, const char *, 17, nullptr);
     using Base = OptionalArg<GroupConfigDefs, Name, Description, Segment,
-                             Hints, Offset, RepName, FixedSize, Hidden>;
+                             Hints, LinkRef, LinkText, Offset, RepName,
+                             FixedSize, Hidden>;
 };
 
 /// Implementation class for the condifuration options of a CDI group element.
@@ -312,8 +317,14 @@ public:
     /// reserved and skipped.
     DEFINE_OPTIONALARG(Hidden, hidden, int);
 
-    /// Represents the value enclosed in the <hints> tag of the data element.
-    DEFINE_OPTIONALARG(Hints, hints, const char*);
+    /// Represent the value enclosed in the <hints> tag of the data element.
+    DEFINE_OPTIONALARG(Hints, hints, const char *);
+
+    /// Represent the <link ref=..> value.
+    DEFINE_OPTIONALARG(LinkRef, linkref, const char *);
+
+    /// Represent the value enclosed in the <link> tag of the data element.
+    DEFINE_OPTIONALARG(LinkText, linktext, const char *);
 
     /// Declares that this group is a toplevel CDI. Causes the group to render
     /// the xml header.
@@ -369,14 +380,28 @@ public:
             *r +=
                 StringPrintf("<description>%s</description>\n", description());
         }
+        if (hints())
+        {
+            *r += StringPrintf("<hints>%s</hints>\n", hints());
+        }
         if (repname())
         {
             *r +=
                 StringPrintf("<repname>%s</repname>\n", repname());
         }
-        if (hints())
+        if (linkref())
         {
-            *r += StringPrintf("<hints>%s</hints>\n", hints());
+            *r +=
+                StringPrintf("<link ref=\"%s\"", linkref());
+            if (linktext())
+            {
+                *r +=
+                    StringPrintf(">%s</link>\n", linktext());
+            }
+            else
+            {
+                *r += " />\n";
+            }
         }
     }
 };
@@ -500,8 +525,13 @@ struct IdentificationConfigDefs
     DECLARE_OPTIONALARG(Model, model, const char *, 1, nullptr);
     DECLARE_OPTIONALARG(HwVersion, hardware_version, const char *, 2, nullptr);
     DECLARE_OPTIONALARG(SwVersion, software_version, const char *, 3, nullptr);
+    // NOTE: the unique index for LinkRef and LinkText must match the values
+    // used in GroupConfigDefs otherwise complile_cdi will enter recursive loop
+    // and segfault.
+    DECLARE_OPTIONALARG(LinkRef, linkref, const char *, 16, nullptr);
+    DECLARE_OPTIONALARG(LinkText, linktext, const char *, 17, nullptr);
     using Base = OptionalArg<IdentificationConfigDefs, Manufacturer, Model,
-                             HwVersion, SwVersion>;
+                             HwVersion, SwVersion, LinkRef, LinkText>;
 };
 
 /// Configuration implementation options for rendering CDI (identification)
@@ -516,6 +546,8 @@ public:
     DEFINE_OPTIONALARG(Model, model, const char *);
     DEFINE_OPTIONALARG(HwVersion, hardware_version, const char *);
     DEFINE_OPTIONALARG(SwVersion, software_version, const char *);
+    DEFINE_OPTIONALARG(LinkRef, linkref, const char *);
+    DEFINE_OPTIONALARG(LinkText, linktext, const char *);
 
     constexpr int skip_init() const
     {
@@ -562,6 +594,20 @@ public:
             alt(opts.hardware_version(), SNIP_STATIC_DATA.hardware_version), s);
         render_tag("softwareVersion",
             alt(opts.software_version(), SNIP_STATIC_DATA.software_version), s);
+        if (opts.linkref())
+        {
+            *s +=
+                StringPrintf("<link ref=\"%s\"", opts.linkref());
+            if (opts.linktext())
+            {
+                *s +=
+                    StringPrintf(">%s</link>\n", opts.linktext());
+            }
+            else
+            {
+                *s += " />\n";
+            }
+        }
         *s += "</identification>\n";
     }
 };

--- a/src/openlcb/ConfigRenderer.hxx
+++ b/src/openlcb/ConfigRenderer.hxx
@@ -52,6 +52,7 @@ struct AtomConfigDefs
     DECLARE_OPTIONALARG(Name, name, const char *, 0, nullptr);
     DECLARE_OPTIONALARG(Description, description, const char *, 1, nullptr);
     DECLARE_OPTIONALARG(MapValues, mapvalues, const char *, 2, nullptr);
+    DECLARE_OPTIONALARG(Hints, hints, const char *, 3, nullptr);
     DECLARE_OPTIONALARG(SkipInit, skip_init, int, 15, 0);
     DECLARE_OPTIONALARG(Offset, offset, int, 10, 0);
     using Base = OptionalArg<AtomConfigDefs, Name, Description, MapValues, SkipInit, Offset>;
@@ -71,6 +72,8 @@ public:
     DEFINE_OPTIONALARG(Description, description, const char *);
     /// Represent the value enclosed in the "<map>" tag of the data element.
     DEFINE_OPTIONALARG(MapValues, mapvalues, const char *);
+    /// Represent the value enclosed in the "<hints>" tag of the data element.
+    DEFINE_OPTIONALARG(Hints, hints, const char *);
     /// When set to true, the event initializers will be skipped in this event
     /// or group.
     DEFINE_OPTIONALARG(SkipInit, skip_init, int);
@@ -93,6 +96,10 @@ public:
         if (mapvalues())
         {
             *r += StringPrintf("<map>%s</map>\n", mapvalues());
+        }
+        if (hints())
+        {
+            *r += StringPrintf("<hints>%s</hints>\n", mapvalues());
         }
     }
 };
@@ -147,7 +154,7 @@ struct NumericConfigDefs : public AtomConfigDefs
     DECLARE_OPTIONALARG(Max, maxvalue, int, 7, INT_MAX);
     DECLARE_OPTIONALARG(Default, defaultvalue, int, 8, INT_MAX);
     using Base = OptionalArg<NumericConfigDefs, Name, Description, MapValues,
-                             Min, Max, Default, SkipInit, Offset>;
+                             Hints, Min, Max, Default, SkipInit, Offset>;
 };
 
 /// Definitions for the options for numeric CDI entries.
@@ -164,6 +171,8 @@ public:
     DEFINE_OPTIONALARG(Description, description, const char *);
     /// Represent the value enclosed in the <map> tag of the data element.
     DEFINE_OPTIONALARG(MapValues, mapvalues, const char *);
+    /// Represent the value enclosed in the <hints> tag of the data element.
+    DEFINE_OPTIONALARG(Hints, hints, const char *);
     DEFINE_OPTIONALARG(Min, minvalue, int);
     DEFINE_OPTIONALARG(Max, maxvalue, int);
     DEFINE_OPTIONALARG(Default, defaultvalue, int);
@@ -196,6 +205,10 @@ public:
         if (mapvalues())
         {
             *r += StringPrintf("<map>%s</map>\n", mapvalues());
+        }
+        if (hints())
+        {
+            *r += StringPrintf("<hints>%s</hints>\n", mapvalues());
         }
     }
 
@@ -263,7 +276,7 @@ struct GroupConfigDefs : public AtomConfigDefs
     DECLARE_OPTIONALARG(FixedSize, fixed_size, unsigned, 13, 0);
     DECLARE_OPTIONALARG(Hidden, hidden, int, 14, 0);
     using Base = OptionalArg<GroupConfigDefs, Name, Description, Segment,
-                             Offset, RepName, FixedSize, Hidden>;
+                             Hints, Offset, RepName, FixedSize, Hidden>;
 };
 
 /// Implementation class for the condifuration options of a CDI group element.
@@ -298,6 +311,9 @@ public:
     /// effectively hiding hte settings from the user. The space will still be
     /// reserved and skipped.
     DEFINE_OPTIONALARG(Hidden, hidden, int);
+
+    /// Represents the value enclosed in the <hints> tag of the data element.
+    DEFINE_OPTIONALARG(Hints, hints, const char*);
 
     /// Declares that this group is a toplevel CDI. Causes the group to render
     /// the xml header.
@@ -357,6 +373,10 @@ public:
         {
             *r +=
                 StringPrintf("<repname>%s</repname>\n", repname());
+        }
+        if (hints())
+        {
+            *r += StringPrintf("<hints>%s</hints>\n", hints());
         }
     }
 };

--- a/src/openlcb/ConfigRepresentation.hxx
+++ b/src/openlcb/ConfigRepresentation.hxx
@@ -110,6 +110,8 @@ public:
     using RepName = GroupConfigOptions::RepName;
     using FixedSize = GroupConfigOptions::FixedSize;
     using Hidden = GroupConfigOptions::Hidden;
+    using LinkRef = GroupConfigOptions::LinkRef;
+    using LinkText = GroupConfigOptions::LinkText;
     using Manufacturer = IdentificationConfigOptions::Manufacturer;
     using Model = IdentificationConfigOptions::Model;
     using HwVersion = IdentificationConfigOptions::HwVersion;

--- a/src/openlcb/ConfigRepresentation.hxx
+++ b/src/openlcb/ConfigRepresentation.hxx
@@ -100,6 +100,7 @@ public:
     using Name = AtomConfigOptions::Name;
     using Description = AtomConfigOptions::Description;
     using MapValues = AtomConfigOptions::MapValues;
+    using Hints = AtomConfigOptions::Hints;
     using SkipInit = AtomConfigOptions::SkipInit;
     using Min = NumericConfigOptions::Min;
     using Max = NumericConfigOptions::Max;


### PR DESCRIPTION
As part of the new CDI 1.4 spec update [PR](https://github.com/openlcb/documents/pull/160) it is desirable to include support for modeling this within the CDI helper code in OpenMRN. 

One additional update has been included for the <group> element which has been discussed on the OpenLCB list as a means to collapse groups within a segment, this has not yet been included in the above PR but is available in a couple test builds of JMRI.