### PR TITLE
Fixes the case when there is empty CONFIG_FILENAME in simplestack. 

### DIFF
--- a/src/freertos_drivers/common/RamDisk.hxx
+++ b/src/freertos_drivers/common/RamDisk.hxx
@@ -170,6 +170,7 @@ public:
     RamDisk(const char* path, T* data, bool read_only = false)
         : RamDiskBase(path, data, sizeof(T), read_only) {
         owned_ = 0;
+        actualSize_ = sizeof(T);
     }
 
     ~RamDisk()

--- a/src/openlcb/SimpleStack.cxx
+++ b/src/openlcb/SimpleStack.cxx
@@ -118,7 +118,7 @@ void SimpleStackBase::start_stack(bool delay_start)
     // listeners. We must only call ConfigUpdateFlow::open_file() once and it
     // may have been done by an earlier call to create_config_file_if_needed()
     // or check_version_and_factory_reset().
-    if (configUpdateFlow_.get_fd() < 0)
+    if (configUpdateFlow_.get_fd() < 0 && CONFIG_FILENAME != nullptr)
     {
         configUpdateFlow_.open_file(CONFIG_FILENAME);
     }
@@ -156,8 +156,14 @@ void SimpleStackBase::default_start_node()
 #if OPENMRN_HAVE_POSIX_FD 
     if (SNIP_DYNAMIC_FILENAME != nullptr)
     {
-        auto *space = new FileMemorySpace(
-            configUpdateFlow_.get_fd(), sizeof(SimpleNodeDynamicValues));
+        FileMemorySpace* space = nullptr;
+        if (SNIP_DYNAMIC_FILENAME == CONFIG_FILENAME) {
+            space = new FileMemorySpace(
+                configUpdateFlow_.get_fd(), sizeof(SimpleNodeDynamicValues));
+        } else {
+            space = new FileMemorySpace(
+                SNIP_DYNAMIC_FILENAME, sizeof(SimpleNodeDynamicValues));
+        }
         memoryConfigHandler_.registry()->insert(
             node(), MemoryConfigDefs::SPACE_ACDI_USR, space);
         additionalComponents_.emplace_back(space);


### PR DESCRIPTION
We can build very simple nodes with no eeprom and set an empty CONFIG_FILENAME in simplestack. THere were several crashing bugs (regressions).

- The SNIP dynamic filename was not correctly taken into account.
- The SnipDynamicUserFile was not readable due to a regression in RamDisk.

===

Fixes the case when there is empty CONFIG_FILENAME in simplestack. The SNIP dynamic filename
was not correctly taken into account.

Makes a RamDisk initialized from a struct take this as the actual size 
upon construction. This means if the struct has some backing data,
that will be visible in the file. Since #677 all read-write ramdisks
were initialized as empty, which is not the correct behavior when
they are created with pre-filled backing storage.

This fixes SNIP mock user file on freertos devices.
