### PR TITLE
CAN driver for Stm32g0 FDCAN 

### DIFF
--- a/applications/io_board/targets/freertos.armv6m.st-stm32g0b1rc-railcom/main.cxx
+++ b/applications/io_board/targets/freertos.armv6m.st-stm32g0b1rc-railcom/main.cxx
@@ -47,9 +47,9 @@
 
 // These preprocessor symbols are used to select which physical connections
 // will be enabled in the main(). See @ref appl_main below.
-#define SNIFF_ON_SERIAL
+//#define SNIFF_ON_SERIAL
 //#define SNIFF_ON_USB
-//#define HAVE_PHYSICAL_CAN_PORT
+#define HAVE_PHYSICAL_CAN_PORT
 
 // Changes the default behavior by adding a newline after each gridconnect
 // packet. Makes it easier for debugging the raw device.

--- a/src/freertos_drivers/common/MCAN.cxx
+++ b/src/freertos_drivers/common/MCAN.cxx
@@ -278,7 +278,7 @@ void MCANCan<Defs, Registers>::enable()
 
     state_ = CAN_STATE_ACTIVE;
 
-    interruptEnable_();
+    interruptEnable_(interruptArg_);
 }
 
 //
@@ -289,7 +289,7 @@ void MCANCan<Defs, Registers>::disable()
 {
     // There is a mutex lock of lock_ above us, so the following sequence is
     // thread safe.
-    interruptDisable_();
+    interruptDisable_(interruptArg_);
 
     state_ = CAN_STATE_STOPPED;
 
@@ -807,7 +807,7 @@ void *MCANCan<Defs, Registers>::entry()
             register_write(Registers::IE, mcanInterruptEnable_.data);
         }
 
-        interruptEnable_();
+        interruptEnable_(interruptArg_);
     }
 
     return NULL;

--- a/src/freertos_drivers/common/MCAN.cxx
+++ b/src/freertos_drivers/common/MCAN.cxx
@@ -1,5 +1,5 @@
 /** @copyright
- * Copyright (c) 2020 Stuart W Baker
+ * Copyright (c) 2020-2025 Stuart W Baker, Balazs Racz
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @file TCAN4550Can.cxx
- * This file implements the CAN driver for the TCAN4550 CAN Controller.
+ * @file MCANCan.cxx
+ * This file implements the CAN driver for the MCAN CAN Controller.
  *
  * @author Stuart W. Baker
  * @date 26 February 2020
@@ -35,7 +35,7 @@
 #define _DEFAULT_SOURCE
 #endif
 
-#include "TCAN4550Can.hxx"
+#include "MCAN.hxx"
 
 #include <fcntl.h>
 #include <unistd.h>

--- a/src/freertos_drivers/common/MCAN.hxx
+++ b/src/freertos_drivers/common/MCAN.hxx
@@ -187,9 +187,10 @@ struct MCANCommonDefs {
 
         union
         {
-            uint64_t data64;  ///< data payload 64-bit
-            uint32_t data32[2]; ///< data payload (0 - 1 word)
-            uint16_t data16[4]; ///< data payload (0 - 3 half word)
+            uint64_t data64[DATA_BYTES/8]; ///< data payload (64-bit)
+            uint32_t data32[DATA_BYTES/4]; ///< data payload (0 - 1 word)
+            uint16_t data16[DATA_BYTES/2]; ///< data payload (0 - 3 half word)
+            uint8_t  data[DATA_BYTES]; ///< data payload (0 - 8 byte)
         };
     };
 
@@ -236,8 +237,107 @@ struct MCANCommonDefs {
     }
 };
 
+struct RegisterDefs {
+    /// RX FIFO x configuraation register definition
+    struct Rxfxc
+    {
+        /// Constructor. Sets the reset value.
+        Rxfxc()
+            : data(0x00000000)
+        {
+        }
+
+        union
+        {
+            uint32_t data; ///< raw word value
+            struct
+            {
+                uint32_t fsa : 16; ///< RX FIFO start address
+
+                uint32_t fs   : 7; ///< RX FIFO size
+                uint32_t rsvd : 1; ///< reserved
+
+                uint32_t fwm : 7; ///< RX FIFO high water mark
+                uint32_t fom : 1; ///< RX FIFO operation mode
+            };
+        };
+    };
+
+    /// TX Buffer configuration register definition
+    struct Txbc
+    {
+        /// Constructor. Sets the reset value.
+        Txbc()
+            : data(0x00000000)
+        {
+        }
+
+        union
+        {
+            uint32_t data; ///< raw word value
+            struct
+            {
+                uint32_t tbsa : 16; ///< TX buffers start address
+
+                uint32_t ndtb  : 6; ///< number of dediated transmit buffers
+                uint32_t rsvd1 : 2; ///< reserved
+
+                uint32_t tfqs  : 6; ///< TX FIFO/queue size
+                uint32_t tfqm  : 1; ///< TX FIFO/queue mode
+                uint32_t rsvd2 : 1; ///< reserved
+            };
+        };
+    };
+
+
+    /// TX buffer element size configurataion register definition
+    struct Txesc
+    {
+        /// Constructor. Sets the reset value.
+        Txesc()
+            : data(0x00000000)
+        {
+        }
+
+        union
+        {
+            uint32_t data; ///< raw word value
+            struct
+            {
+                uint32_t tbds :  3; ///< TX buffer data field size
+                uint32_t rsvd : 29; ///< reserved
+            };
+        };
+    };
+
+    /// TX event FIFO configuration register definition
+    struct Txefc
+    {
+        /// Constructor. Sets the reset value.
+        Txefc()
+            : data(0x00000000)
+        {
+        }
+
+        union
+        {
+            uint32_t data; ///< raw word value
+            struct
+            {
+                uint32_t efsa : 16; ///< event FIFO start address
+
+                uint32_t efs   : 6; ///< event FIFO size
+                uint32_t rsvd1 : 2; ///< reserved
+
+                uint32_t efwm  : 6; ///< event FIFO watermark
+                uint32_t rsvd2 : 2; ///< reserved
+            };
+        };
+    };
+};
+
 /// Static definitions and helper functions for the TCAN4550.
-struct TCAN4550Defs
+struct TCAN4550Defs : public RegisterDefs
 {
     typedef TCAN4550Registers Registers;
 
@@ -252,6 +352,58 @@ struct TCAN4550Defs
     typedef Common::MRAMTXBuffer MRAMTXBuffer;
     typedef Common::MRAMTXEventFIFOElement MRAMTXEventFIFOElement;
     
+
+    /// MCAN interrupt registers (IR, IE, and ILS) definition
+    struct MCANInterrupt
+    {
+        /// Constructor. Sets the reset value.
+        MCANInterrupt()
+            : data(0x00000000)
+        {
+        }
+
+        union
+        {
+            uint32_t data; ///< raw word value
+            struct
+            {
+                uint32_t rf0n : 1; ///< RX FIFO 0 new message
+                uint32_t rf0w : 1; ///< RX FIFO 0 watermark reached
+                uint32_t rf0f : 1; ///< RX FIFO 0 full
+                uint32_t rf0l : 1; ///< RX FIFO 0 message lost
+                uint32_t rf1n : 1; ///< RX FIFO 1 new message
+                uint32_t rf1w : 1; ///< RX FIFO 1 watermark reached
+                uint32_t rf1f : 1; ///< RX FIFO 1 full
+                uint32_t rf1l : 1; ///< RX FIFO 1 message lost
+
+                uint32_t hpm  : 1; ///< high priority message
+                uint32_t tc   : 1; ///< transmission completed
+                uint32_t tcf  : 1; ///< transmission cancellation finished
+                uint32_t tfe  : 1; ///< TX FIFO empty
+                uint32_t tefn : 1; ///< TX event FIFO new entry
+                uint32_t tefw : 1; ///< TX event FIFO watermark reached
+                uint32_t teff : 1; ///< TX event FIFO full
+                uint32_t tefl : 1; ///< TX event FIFO event lost
+
+                uint32_t tsw  : 1; ///< timestamp wraparound
+                uint32_t mraf : 1; ///< message RAM access failure
+                uint32_t too  : 1; ///< timeout occurred
+                uint32_t drx  : 1; ///< message stored to dedicated RX buffer
+                uint32_t bec  : 1; ///< bit error corrected
+                uint32_t beu  : 1; ///< bit error uncorrected
+                uint32_t elo  : 1; ///< error logging overflow
+                uint32_t ep   : 1; ///< error passive
+
+                uint32_t ew   : 1; ///< warning status
+                uint32_t bo   : 1; ///< bus-off status
+                uint32_t wdi  : 1; ///< watchdog
+                uint32_t pea  : 1; ///< protocol error in arbitration phase
+                uint32_t ped  : 1; ///< protocol error in data phase
+                uint32_t ara  : 1; ///< access to reserved address
+                uint32_t rsvd : 2; ///< reserved
+            };
+        };
+    };
     
     // ---- Memory layout ----
     //
@@ -495,11 +647,110 @@ protected:
 #endif
     }
 
+    /// This hook is called during initialization. It is meant to set up clocks
+    /// before the MCAN is configured.
+    /// @param freq clock frequency
+    void preinit_hook(uint32_t freq) {
+        // transition to "Normal" mode with sleep and watchdog disabled
+        Mode mode;
+        mode.sweDis = 1;   // disable sleep
+        mode.wdEnable = 0; // disable watchdog
+        mode.modeSel = 2;  // normal mode
+        mode.clkRef = (freq == 40000000);
+
+        register_write(Registers::MODE, mode.data);
+    }
+
+    /// This hook is called during initialization, after the MCAN core has been
+    /// switched to configuration mode.
+    void init_hook()
+    {
+        // diasable all TCAN interrupts
+        register_write(Registers::INTERRUPT_ENABLE, 0);
+
+        // clear MRAM, a bit brute force, but gets the job done
+        for (uint16_t offset = 0x0000; offset < MRAM_SIZE_WORDS; ++offset)
+        {
+            register_write((Registers)(int16_t(Registers::MRAM) + offset), 0);
+        }
+
+        {
+            // setup RX FIFO 0
+            Rxfxc rxf0c;
+            rxf0c.fsa = RX_FIFO_0_MRAM_ADDR; // FIFO start address
+            rxf0c.fs = RX_FIFO_SIZE;         // FIFO size
+            register_write(Registers::RXF0C, rxf0c.data);
+        }
+        {
+            // setup TX buffer element size
+            Txesc txesc;
+            txesc.tbds = 0; // 8 byte data field size
+            register_write(Registers::TXESC, txesc.data);
+        }
+        {
+            // setup TX event FIFO
+            Txefc txefc;
+            txefc.efsa = TX_EVENT_FIFO_MRAM_ADDR; // event FIFO start address
+            txefc.efs = TX_EVENT_FIFO_SIZE;       // event FIFO size
+            txefc.efwm = TX_EVENT_FIFO_SIZE / 2;  // event FIFO watermark
+            register_write(Registers::TXEFC, txefc.data);
+        }
+        {
+            // setup TX configuration
+            Txbc txbc;
+            txbc.tbsa = TX_BUFFERS_MRAM_ADDR; // buffers start address
+            txbc.ndtb =
+                TX_DEDICATED_BUFFER_COUNT; // dedicated transmit buffers
+            txbc.tfqs = TX_FIFO_SIZE;      // FIFO/queue size
+            register_write(Registers::TXBC, txbc.data);
+        }
+    }
+
 private:
     enum Command : uint8_t
     {
         WRITE = 0x61, ///< write one or more addresses
         READ  = 0x41, ///< read one or more addresses
+    };
+
+    /// Mode register definition
+    struct Mode
+    {
+        /// Constructor. Sets the reset value.
+        Mode()
+            : data(0xC8000468)
+        {
+        }
+
+        union
+        {
+            uint32_t data; ///< raw word value
+            struct
+            {
+                uint32_t testModeConfig : 1; ///< test mode configuration
+                uint32_t sweDis         : 1; ///< sleep wake error disable
+                uint32_t reset          : 1; ///< device reset
+                uint32_t wdEnable       : 1; ///< watchdog enable
+                uint32_t reserved1      : 2; ///< reserved
+                uint32_t modeSel        : 2; ///< mode of operation select
+                uint32_t nWkrqConfig    : 1; ///< nWKRQ pin function
+                uint32_t inhDisable     : 1; ///< INH pin disable
+                uint32_t gpio1GpoConfig : 2; ///< GPIO1 output function select
+                uint32_t reserved2      : 1; ///< reserved
+                uint32_t failSafeEnable : 1; ///< fail safe mode enable
+                uint32_t gpio1Config    : 2; ///< GPIO1 pin function select
+                uint32_t wdAction       : 2; ///< selected watchdog action
+                uint32_t wdBitSet       : 1; ///< write a '1' to reset timer
+                uint32_t nWkrqVoltage   : 1; ///< nWKRQ pin GPO buffer voltage
+                uint32_t reserved3      : 1; ///< reserved
+                uint32_t testModeEn     : 1; ///< test mode enable
+                uint32_t gpo2Config     : 2; ///< GPO2 pin configuration
+                uint32_t reserved4      : 3; ///< reserved
+                uint32_t clkRef         : 1; ///< CLKIN/crystal freq reference
+                uint32_t wdTimer        : 2; ///< watchdog timer
+                uint32_t wakeConfig     : 2; ///< Wake pin configuration
+            };
+        };
     };
 
     /// maximum SPI clock speed in Hz
@@ -578,47 +829,8 @@ public:
 private:
     typedef typename Defs::MRAMRXBuffer MRAMRXBuffer;
     typedef typename Defs::MRAMTXBuffer MRAMTXBuffer;
+    typedef typename Defs::MCANInterrupt MCANInterrupt;
     
-    /// Mode register definition
-    struct Mode
-    {
-        /// Constructor. Sets the reset value.
-        Mode()
-            : data(0xC8000468)
-        {
-        }
-
-        union
-        {
-            uint32_t data; ///< raw word value
-            struct
-            {
-                uint32_t testModeConfig : 1; ///< test mode configuration
-                uint32_t sweDis         : 1; ///< sleep wake error disable
-                uint32_t reset          : 1; ///< device reset
-                uint32_t wdEnable       : 1; ///< watchdog enable
-                uint32_t reserved1      : 2; ///< reserved
-                uint32_t modeSel        : 2; ///< mode of operation select
-                uint32_t nWkrqConfig    : 1; ///< nWKRQ pin function
-                uint32_t inhDisable     : 1; ///< INH pin disable
-                uint32_t gpio1GpoConfig : 2; ///< GPIO1 output function select
-                uint32_t reserved2      : 1; ///< reserved
-                uint32_t failSafeEnable : 1; ///< fail safe mode enable
-                uint32_t gpio1Config    : 2; ///< GPIO1 pin function select
-                uint32_t wdAction       : 2; ///< selected watchdog action
-                uint32_t wdBitSet       : 1; ///< write a '1' to reset timer
-                uint32_t nWkrqVoltage   : 1; ///< nWKRQ pin GPO buffer voltage
-                uint32_t reserved3      : 1; ///< reserved
-                uint32_t testModeEn     : 1; ///< test mode enable
-                uint32_t gpo2Config     : 2; ///< GPO2 pin configuration
-                uint32_t reserved4      : 3; ///< reserved
-                uint32_t clkRef         : 1; ///< CLKIN/crystal freq reference
-                uint32_t wdTimer        : 2; ///< watchdog timer
-                uint32_t wakeConfig     : 2; ///< Wake pin configuration
-            };
-        };
-    };
-
     /// Data bit timing and prescaler register definition
     struct Dbtp
     {
@@ -827,31 +1039,6 @@ private:
         };
     };
 
-    /// RX FIFO x configuraation register definition
-    struct Rxfxc
-    {
-        /// Constructor. Sets the reset value.
-        Rxfxc()
-            : data(0x00000000)
-        {
-        }
-
-        union
-        {
-            uint32_t data; ///< raw word value
-            struct
-            {
-                uint32_t fsa : 16; ///< RX FIFO start address
-
-                uint32_t fs   : 7; ///< RX FIFO size
-                uint32_t rsvd : 1; ///< reserved
-
-                uint32_t fwm : 7; ///< RX FIFO high water mark
-                uint32_t fom : 1; ///< RX FIFO operation mode
-            };
-        };
-    };
-
     /// RX FIFO x status register definition
     struct Rxfxs
     {
@@ -896,7 +1083,7 @@ private:
         };
     };
 
-    /// TX Buffer configuraation register definition
+    /// TX Buffer configuration register definition
     struct Txbc
     {
         /// Constructor. Sets the reset value.
@@ -941,51 +1128,6 @@ private:
                 uint32_t rsvd3 : 2; ///< reserved
 
                 uint32_t rsvd4 : 8; ///< reserved
-            };
-        };
-    };
-
-    /// TX buffer element size configurataion register definition
-    struct Txesc
-    {
-        /// Constructor. Sets the reset value.
-        Txesc()
-            : data(0x00000000)
-        {
-        }
-
-        union
-        {
-            uint32_t data; ///< raw word value
-            struct
-            {
-                uint32_t tbds :  3; ///< TX buffer data field size
-                uint32_t rsvd : 29; ///< reserved
-            };
-        };
-    };
-
-    /// TX event FIFO configuration register definition
-    struct Txefc
-    {
-        /// Constructor. Sets the reset value.
-        Txefc()
-            : data(0x00000000)
-        {
-        }
-
-        union
-        {
-            uint32_t data; ///< raw word value
-            struct
-            {
-                uint32_t efsa : 16; ///< event FIFO start address
-
-                uint32_t efs   : 6; ///< event FIFO size
-                uint32_t rsvd1 : 2; ///< reserved
-
-                uint32_t efwm  : 6; ///< event FIFO watermark
-                uint32_t rsvd2 : 2; ///< reserved
             };
         };
     };
@@ -1080,57 +1222,6 @@ private:
         };
     };
 
-    /// MCAN interrupt registers (IR, IE, and ILS) definition
-    struct MCANInterrupt
-    {
-        /// Constructor. Sets the reset value.
-        MCANInterrupt()
-            : data(0x00000000)
-        {
-        }
-
-        union
-        {
-            uint32_t data; ///< raw word value
-            struct
-            {
-                uint32_t rf0n : 1; ///< RX FIFO 0 new message
-                uint32_t rf0w : 1; ///< RX FIFO 0 watermark reached
-                uint32_t rf0f : 1; ///< RX FIFO 0 full
-                uint32_t rf0l : 1; ///< RX FIFO 0 message lost
-                uint32_t rf1n : 1; ///< RX FIFO 1 new message
-                uint32_t rf1w : 1; ///< RX FIFO 1 watermark reached
-                uint32_t rf1f : 1; ///< RX FIFO 1 full
-                uint32_t rf1l : 1; ///< RX FIFO 1 message lost
-
-                uint32_t hpm  : 1; ///< high priority message
-                uint32_t tc   : 1; ///< transmission completed
-                uint32_t tcf  : 1; ///< transmission cancellation finished
-                uint32_t tfe  : 1; ///< TX FIFO empty
-                uint32_t tefn : 1; ///< TX event FIFO new entry
-                uint32_t tefw : 1; ///< TX event FIFO watermark reached
-                uint32_t teff : 1; ///< TX event FIFO full
-                uint32_t tefl : 1; ///< TX event FIFO event lost
-
-                uint32_t tsw  : 1; ///< timestamp wraparound
-                uint32_t mraf : 1; ///< message RAM access failure
-                uint32_t too  : 1; ///< timeout occurred
-                uint32_t drx  : 1; ///< message stored to dedicated RX buffer
-                uint32_t bec  : 1; ///< bit error corrected
-                uint32_t beu  : 1; ///< bit error uncorrected
-                uint32_t elo  : 1; ///< error logging overflow
-                uint32_t ep   : 1; ///< error passive
-
-                uint32_t ew   : 1; ///< warning status
-                uint32_t bo   : 1; ///< bus-off status
-                uint32_t wdi  : 1; ///< watchdog
-                uint32_t pea  : 1; ///< protocol error in arbitration phase
-                uint32_t ped  : 1; ///< protocol error in data phase
-                uint32_t ara  : 1; ///< access to reserved address
-                uint32_t rsvd : 2; ///< reserved
-            };
-        };
-    };
 
     /// MCAN interrupt line enable register definition
     struct Ile

--- a/src/freertos_drivers/common/MCAN.hxx
+++ b/src/freertos_drivers/common/MCAN.hxx
@@ -24,15 +24,16 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @file TCAN4550Can.hxx
- * This file implements the CAN driver for the TCAN4550 CAN Controller.
+ * @file MCAN.hxx
+ * This file implements a generic CAN driver for the MCAN controller IP.
  *
  * @author Stuart W. Baker
- * @date 26 February 2020
+ * @author Balazs Racz
+ * @date 19 Jan 2025
  */
 
-#ifndef _FREERTOS_DRIVERS_COMMON_TCAN4550CAN_HXX_
-#define _FREERTOS_DRIVERS_COMMON_TCAN4550CAN_HXX_
+#ifndef _FREERTOS_DRIVERS_COMMON_MCAN_HXX_
+#define _FREERTOS_DRIVERS_COMMON_MCAN_HXX_
 
 #include "Can.hxx"
 #include "DummyGPIO.hxx"
@@ -1169,5 +1170,5 @@ private:
     DISALLOW_COPY_AND_ASSIGN(TCAN4550Can);
 };
 
-#endif // _FREERTOS_DRIVERS_COMMON_TCAN4550CAN_HXX_
+#endif // _FREERTOS_DRIVERS_COMMON_MCAN_HXX_
 

--- a/src/freertos_drivers/common/MCAN.hxx
+++ b/src/freertos_drivers/common/MCAN.hxx
@@ -212,6 +212,12 @@ struct TCAN4550Defs
 {
     typedef TCAN4550Registers Registers;
 
+    // Check alignment
+    static_assert(uint16_t(Registers::TXEFS) * 4 == 0x10F4, "register enum misaligned");
+    static_assert(uint16_t(Registers::ILE) * 4 == 0x105C, "register enum misaligned");
+    static_assert(uint16_t(Registers::MCAN_INTERRUPT_STATUS) * 4 == 0x0824,
+                  "register enum misaligned");
+    
     typedef MCANCommonDefs::MRAMRXBuffer MRAMRXBuffer;
     typedef MCANCommonDefs::MRAMTXBuffer MRAMTXBuffer;
     typedef MCANCommonDefs::MRAMTXEventFIFOElement MRAMTXEventFIFOElement;
@@ -511,7 +517,7 @@ public:
     void interrupt_handler()
     {
         int woken = false;
-        interruptDisable_();
+        interruptDisable_(interruptArg_);
         sem_.post_from_isr(&woken);
         os_isr_exit_yield_test(woken);
     }
@@ -520,12 +526,6 @@ private:
     typedef typename Defs::MRAMRXBuffer MRAMRXBuffer;
     typedef typename Defs::MRAMTXBuffer MRAMTXBuffer;
     
-    // Check alignment
-    static_assert(uint16_t(Registers::TXEFS) * 4 == 0x10F4, "register enum misaligned");
-    static_assert(uint16_t(Registers::ILE) * 4 == 0x105C, "register enum misaligned");
-    static_assert(uint16_t(Registers::MCAN_INTERRUPT_STATUS) * 4 == 0x0824,
-                  "register enum misaligned");
-
     /// Mode register definition
     struct Mode
     {

--- a/src/freertos_drivers/common/MCAN.hxx
+++ b/src/freertos_drivers/common/MCAN.hxx
@@ -464,19 +464,21 @@ public:
     /// @param name name of this device instance in the file system
     /// @param interrupt_enable callback to enable the interrupt
     /// @param interrupt_disable callback to disable the interrupt
+    /// @param intarg argument for interrupt en/dis functions
     /// @param test_pin test GPIO pin for instrumenting the code
-    MCANCan(const char *name,
-                void (*interrupt_enable)(), void (*interrupt_disable)(),
+    MCANCan(const char *name, void (*interrupt_enable)(void*),
+        void (*interrupt_disable)(void*), void *intarg,
 #if MCAN_DEBUG
-                const Gpio *test_pin = DummyPinWithRead::instance()
+        const Gpio *test_pin = DummyPinWithRead::instance()
 #else
-                const Gpio *test_pin = nullptr
+        const Gpio *test_pin = nullptr
 #endif
-               )
+            )
         : Can(name, 0, 0)
         , OSThread()
         , interruptEnable_(interrupt_enable)
         , interruptDisable_(interrupt_disable)
+        , interruptArg_(intarg)
         , sem_()
         , mcanInterruptEnable_()
         , txCompleteMask_(0)
@@ -1152,8 +1154,9 @@ private:
         // unused in this implementation
     }
 
-    void (*interruptEnable_)(); ///< enable interrupt callback
-    void (*interruptDisable_)(); ///< disable interrupt callback
+    void (*interruptEnable_)(void*); ///< enable interrupt callback
+    void (*interruptDisable_)(void*); ///< disable interrupt callback
+    void* interruptArg_; ///< parameter to interrupt en/dis
     OSSem sem_; ///< semaphore for posting events
     MCANInterrupt mcanInterruptEnable_; ///< shadow for the interrupt enable
     uint32_t txCompleteMask_; ///< shadow for the transmit complete buffer mask

--- a/src/freertos_drivers/sources
+++ b/src/freertos_drivers/sources
@@ -27,6 +27,7 @@ CXXSRCS += Fileio.cxx \
            PCA9685PWM.cxx \
            SN74HC595GPO.cxx \
            TCAN4550Can.cxx \
+           MCAN.cxx \
            SPIFlash.cxx
            
 

--- a/src/freertos_drivers/st/Stm32MCan.cxx
+++ b/src/freertos_drivers/st/Stm32MCan.cxx
@@ -36,3 +36,5 @@
 #include "freertos_drivers/st/Stm32MCan.hxx"
 // Includes implementation of templates for instantiation.
 #include "freertos_drivers/common/MCAN.cxx"
+
+template class MCANCan<Stm32FDCANDefs, Stm32FDCANRegisters>;

--- a/src/freertos_drivers/st/Stm32MCan.cxx
+++ b/src/freertos_drivers/st/Stm32MCan.cxx
@@ -1,0 +1,38 @@
+/** @copyright
+ * Copyright (c) 2025 Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file Stm32MCan.cxx
+ *
+ * This file implements the CAN driver for the FDCAN controller in newer Stm32
+ * microcontrollers, which is based on the Bosch MCAN IP.
+ *
+ * @author Balazs Racz
+ * @date 19 Jan 2025
+ */
+
+#include "freertos_drivers/st/Stm32MCan.hxx"
+// Includes implementation of templates for instantiation.
+#include "freertos_drivers/common/MCAN.cxx"

--- a/src/freertos_drivers/st/Stm32MCan.hxx
+++ b/src/freertos_drivers/st/Stm32MCan.hxx
@@ -1,0 +1,136 @@
+/** @copyright
+ * Copyright (c) 2025 Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file Stm32MCan.hxx
+ *
+ * This file implements the CAN driver for the FDCAN controller in newer Stm32
+ * microcontrollers, which is based on the Bosch MCAN IP.
+ *
+ * @author Balazs Racz
+ * @date 19 Jan 2025
+ */
+
+#ifndef _FREERTOS_DRIVERS_ST_STM32MCAN_HXX_
+#define _FREERTOS_DRIVERS_ST_STM32MCAN_HXX_
+
+#include "stm32f_hal_conf.hxx"
+
+#include "freertos_drivers/common/MCAN.hxx"
+
+/// Register addresses for the STM32 FDCAN controller. These addresses are word
+/// indexes, i.e., to access in the memory map, they must be multipled by 4.
+///
+/// These values are referenced to FDCAN1_BASE or FDCAN2_BASE.
+enum class Stm32FDCANRegisters : uint16_t
+{
+    CREL = 0, ///< core release
+    ENDN,     ///< endianess
+    RSVDx1,   ///< reserved
+    DBTP,     ///< data bit timing and prescaler
+    TEST2,    ///< test
+    RWD,      ///< RAM watchdog
+    CCCR,     ///< CC control
+    NBTP,     ///< nominal bit timing and prescaler
+    TSCC,     ///< timestamp counter configuration
+    TSCV,     ///< timestamp counter value
+    TOCC,     ///< timeout counter configuration
+    TOCV,     ///< timeout counter value
+    RSVD1,    ///< reserved
+    RSVD2,    ///< reserved
+    RSVD3,    ///< reserved
+    RSVD4,    ///< reserved
+    ECR,      ///< error count
+    PSR,      ///< protocol status
+    TDCR,     ///< transmitter delay compensation
+    RSVD5,    ///< reserved
+    IR,       ///< interrupt status
+    IE,       ///< interrupt enable
+    ILS,      ///< interrupt line select
+    ILE,      ///< interrupt line enable
+    RSVD6,    ///< reserved
+    RSVD7,    ///< reserved
+    RSVD8,    ///< reserved
+    RSVD9,    ///< reserved
+    RSVD10,   ///< reserved
+    RSVD11,   ///< reserved
+    RSVD12,   ///< reserved
+    RSVD13,   ///< reserved
+              //   From here on the register offsets differ between
+              //   implementations:
+              //   TCAN STM32 < register offset
+    GFC,      ///< 0x80 0x80 global filter configuration
+    XIDAM,    ///< 0x90 0x84 extended ID and mask
+    HPMS,     ///< 0x94 0x88 high prioirty message status
+    RSVDx2,   ///< 0xA0 ---- RX FIFO 0 configuration
+    RXF0S,    ///< 0xA4 0x90 RX FIFO 0 status
+    RXF0A,    ///< 0xA8 0x94 RX FIFO 0 Acknowledge
+    RXF1S,    ///< 0xB4 0x98 RX FIFO 1 status
+    RXF1A,    ///< 0xB8 0x9C RX FIFO 1 acknowledge
+    RSVDx3,
+    RSVDx4,
+    RSVDx5,
+    RSVDx6,
+    RSVDx7,
+    RSVDx8,
+    RSVDx9,
+    RSVDx10,
+    TXBC,   ///< 0xC0 0xC0 TX buffer configuration
+    TXFQS,  ///< 0xC4 0xC4 TX FIFO/queue status
+    TXBRP,  ///< 0xCC 0xC8 TX buffer request pending
+    TXBAR,  ///< 0xD0 0xCC TX buffer add request
+    TXBCR,  ///< 0xD4 0xD0 TX buffer cancellation request
+    TXBTO,  ///< 0xD8 0xD4 TX buffer transmission occurred
+    TXBCF,  ///< 0xDC 0xD8 TX buffer cancellation finished
+    TXBTIE, ///< 0xE0 0xDC TX buffer transmission interrupt enable
+    TXBCIE, ///< 0xE4 0xE0 TX buffer cancellation finished interrupt enable
+    TXEFS,  ///< 0xF4 0xE4 TX event FIFO status
+    TXEFA,  ///< 0xF8 0xE8 TX event FIFO acknowledge
+};
+
+class Stm32MCan : public MCANCan<>
+{
+public:
+    /// Constructor.
+    ///
+    /// @param name device name, e.g. "/dev/can0"
+    /// @param inst instance pointer for memory mapped registers, FDCAN1 or
+    /// FDCAN2
+    /// @param interrupt interrupt number for the module.
+    Stm32MCan(const char *name, FDCAN_GlobalTypeDef *inst, IRQn_Type interrupt)
+        : MCANCan(name)
+    { }
+
+    void interrupt_handler()
+    {
+        MCANCan::interrupt_handler();
+    }
+
+private:
+    void interrupt_disable()
+    { }
+};
+
+#endif // _FREERTOS_DRIVERS_ST_STM32MCAN_HXX_

--- a/targets/freertos.armv6m/freertos_drivers/stm32cubeg0b1xe/sources
+++ b/targets/freertos.armv6m/freertos_drivers/stm32cubeg0b1xe/sources
@@ -82,11 +82,8 @@ CXXSRCS += Stm32Uart.cxx \
            Stm32SPI.cxx \
            Stm32I2C.cxx \
            Stm32EEPROMEmulation.cxx \
-           Stm32RailcomSender.cxx
-
-# Note: Stm32Can.cxx was removed because the G0 has an MCAN peripheral, which
-# is not compatible with the CAN peripheral that Stm32Can was written for.
-
+           Stm32RailcomSender.cxx \
+           Stm32MCan.cxx
 
 # for some reason, -0s changes the behavior of HAL_FLASHEx_Erase() and
 # doesn't perform the erase.


### PR DESCRIPTION
Abstracts the TCAN4550 driver into a generic Bosch MCAN driver and a specialization for the TCAN4550.
Adds new specialization for the STM32 FDCAN controller.
