### PR TITLE
Add Automatic Build and Deployment of Doxygen Documentation to GitHub Pages

### DIFF
--- a/.github/workflows/DoxygenBuild.yml
+++ b/.github/workflows/DoxygenBuild.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3
       with:
-        path: html/
+        path: doc/html/
     - name: Deploy
       id: deployment
       uses: actions/deploy-pages@v4

--- a/.github/workflows/DoxygenBuild.yml
+++ b/.github/workflows/DoxygenBuild.yml
@@ -1,0 +1,33 @@
+name: Deploy Doxygen Documentation to Pages
+
+on:
+  push:
+    branches: [master] # branch to trigger deployment
+
+jobs:
+  pages:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+      with:
+        submodules: "true"
+    - name: Install Dependencies
+      run: sudo apt-get update && sudo apt-get install -y doxygen make graphviz
+      shell: bash
+    - name: Build Documentation
+      id: build
+      run: cd doc && make html && touch html/.nojekyll
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: html/
+    - name: Deploy
+      id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
An example of a functional deployment is available at: [https://www.uncommonmodels.com/openmrn/](https://www.uncommonmodels.com/openmrn/) 

Please note that the Pages deployment source must be set to "GitHub Actions" in the repository settings.