### PR TITLE
Fixes GpioInitializer to be always_inline and use tail recursion.

### DIFF
--- a/src/utils/GpioInitializer.hxx
+++ b/src/utils/GpioInitializer.hxx
@@ -35,6 +35,8 @@
 #ifndef _UTILS_GPIOINITIALIZER_HXX_
 #define _UTILS_GPIOINITIALIZER_HXX_
 
+#include <tuple>
+
 /// Forward declaration to make the template matcher happy.
 template <class T> struct GpioInitHelper;
 


### PR DESCRIPTION
Currently hw_init gets split into a bunch of functions that each add unnecessary some stack space.