### PR TITLE
Adds a way to define hardware pins for STM32 in the gpio helpers

### DIFF
--- a/src/freertos_drivers/st/Stm32Gpio.hxx
+++ b/src/freertos_drivers/st/Stm32Gpio.hxx
@@ -36,14 +36,14 @@
 #ifndef _FREERTOS_DRIVERS_ST_STM32GPIO_HXX_
 #define _FREERTOS_DRIVERS_ST_STM32GPIO_HXX_
 
-#include "os/Gpio.hxx"
 #include "GpioWrapper.hxx"
+#include "os/Gpio.hxx"
 
 #include "stm32f_hal_conf.hxx"
 
 /// Static GPIO implementation for the STM32 microcontrollers. Do not use
 /// directly: use @ref GPIO_PIN macro.
-/// @param PORT is the port base address pointer (e.g. GPIOC) 
+/// @param PORT is the port base address pointer (e.g. GPIOC)
 /// @param PIN is the GPIO_PIN_# value for the pin number.
 /// @param PIN_NUM is the number of the pin in the port. Zero-based.
 template <uint32_t GPIOx, uint16_t PIN, uint8_t PIN_NUM> struct Stm32GpioDefs
@@ -93,7 +93,7 @@ template <uint32_t GPIOx, uint16_t PIN, uint8_t PIN_NUM> struct Stm32GpioDefs
     {
         set(!get());
     }
-    
+
     /// @return a os-indepentent Gpio abstraction instance for use in
     /// libraries.
     static constexpr const Gpio *instance()
@@ -104,18 +104,20 @@ template <uint32_t GPIOx, uint16_t PIN, uint8_t PIN_NUM> struct Stm32GpioDefs
     /// @return whether this pin is configured as an output.
     static bool is_output()
     {
-        uint8_t* mode = (uint8_t*)port();
+        uint8_t *mode = (uint8_t *)port();
         uint8_t m = mode[PIN_NUM >> 1];
-        if (PIN_NUM & 1) { m >>= 4; }
+        if (PIN_NUM & 1)
+        {
+            m >>= 4;
+        }
         return (m & 3) != 0;
     }
-
 };
 
 template <class Defs, bool SAFE_VALUE> struct GpioOutputPin : public Defs
 {
-    using Defs::port;
     using Defs::pin;
+    using Defs::port;
     using Defs::set;
     /// Initializes the hardware pin.
     static void hw_init()
@@ -141,29 +143,26 @@ template <class Defs, bool SAFE_VALUE> struct GpioOutputPin : public Defs
 /// Do not use this class directly. Use @ref GPIO_PIN instead.
 template <class Defs>
 struct GpioOutputSafeLow : public GpioOutputPin<Defs, false>
-{
-};
+{ };
 
 /// Defines a GPIO output pin, initialized to be an output pin with high level.
 ///
 /// Do not use this class directly. Use @ref GPIO_PIN instead.
 template <class Defs>
 struct GpioOutputSafeHigh : public GpioOutputPin<Defs, true>
-{
-};
+{ };
 
 /// Defines a GPIO output pin for driving an LED. The MCU must be in spec for
 /// the necessary output current.
 ///
 /// Do not use this class directly. Use @ref GPIO_PIN instead.
 template <class Defs> struct LedPin : public GpioOutputPin<Defs, false>
-{
-};
+{ };
 
 template <class Defs, uint32_t PULL_MODE> struct GpioInputPin : public Defs
 {
-    using Defs::port;
     using Defs::pin;
+    using Defs::port;
     using Defs::set;
     /// Initializes the hardware pin.
     static void hw_init()
@@ -181,7 +180,7 @@ template <class Defs, uint32_t PULL_MODE> struct GpioInputPin : public Defs
         hw_init();
     }
     /// @return true if the pin is set to drive an output.
-    static bool is_output()
+    static constexpr bool is_output()
     {
         return false;
     }
@@ -192,23 +191,111 @@ template <class Defs, uint32_t PULL_MODE> struct GpioInputPin : public Defs
 /// Do not use this class directly. Use @ref GPIO_PIN instead.
 template <class Defs>
 struct GpioInputPU : public GpioInputPin<Defs, GPIO_PULLUP>
-{
-};
+{ };
 
 /// GPIO Input pin with weak pull down.
 ///
 /// Do not use this class directly. Use @ref GPIO_PIN instead.
 template <class Defs>
 struct GpioInputPD : public GpioInputPin<Defs, GPIO_PULLDOWN>
-{
-};
+{ };
 
 /// GPIO Input pin in standard configuration (no pull).
 ///
 /// Do not use this class directly. Use @ref GPIO_PIN instead.
 template <class Defs>
 struct GpioInputNP : public GpioInputPin<Defs, GPIO_NOPULL>
+{ };
+
+#include "utils/OptionalArgs.hxx"
+
+/// Configuration options for an STM32 GPIO pin.
+struct Stm32GpioOptionDefs
 {
+    /// Mode: GPIO_MODE_xx value, including GPIO_MODE_INPUT,
+    /// GPIO_MODE_OUTPUT_PP, GPIO_MODE_OUTPUT_OD, GPIO_MODE_AF_PP,
+    /// GPIO_MODE_AF_OD.
+    DECLARE_OPTIONALARG(GpioMode, gpio_mode, uint32_t, 0, GPIO_MODE_INPUT);
+    /// Open Drain. false is push-pull, true is open-drain. Only used for AF
+    /// and Output modes. When true, switches a PP mode to OD mode.
+    DECLARE_OPTIONALARG(OD, gpio_od, bool, 1, false);
+    /// Pullup/Pulldown configuration. One of GPIO_NOPULL, GPIO_PULLUP,
+    /// GPIO_PULLDOWN.
+    DECLARE_OPTIONALARG(Pull, pull, uint32_t, 2, GPIO_NOPULL);
+    /// Speed configuration. One of GPIO_SPEED_FREQ_LOW,
+    /// GPIO_SPEED_FREQ_MEDIUM, GPIO_SPEED_FREQ_HIGH, GPIO_SPEED_FREQ_VERYHIGH.
+    DECLARE_OPTIONALARG(Speed, speed, uint32_t, 3, GPIO_SPEED_FREQ_LOW);
+    /// Used for selecting alternate function. Many values are possible, for
+    /// example GPIO_AF0_UART3 or GPIO_AF3_FDCAN1. Typically AF0 to AF7, or on
+    /// some chips until AF15, and the peripheral name can be a large
+    /// variety. Take the values from the datasheet or the specific chip's
+    /// header file.
+    DECLARE_OPTIONALARG(AfMode, afmode, uint32_t, 4, 0xffffffff);
+
+    /// Sets the GPIO port base, like GPIOA_BASE, GPIOB_BASE, etc. Required.
+    DECLARE_OPTIONALARG(PeriphBase, periph_base, uint32_t, 10, 0xffffffff);
+    /// Sets the GPIO pin number, like GPIO_PIN_0, GPIO_PIN_1, etc. Required.
+    DECLARE_OPTIONALARG(Pin, pin, uint16_t, 11, 0xffff);
+    /// Sets the GPIO pin number, 0..15. Required.
+    DECLARE_OPTIONALARG(PinNum, pin_num, uint8_t, 11, 0xff);
+
+    using Base = OptionalArg<Stm32GpioOptionDefs, GpioMode, OD, Pull, Speed,
+        AfMode, PeriphBase, Pin, PinNum>;
+};
+
+class Stm32GpioOptions : public Stm32GpioOptionDefs::Base
+{
+public:
+    INHERIT_CONSTEXPR_CONSTRUCTOR(Stm32GpioOptions, Stm32GpioOptionDefs::Base);
+
+    DEFINE_OPTIONALARG(GpioMode, gpio_mode, uint32_t);
+    DEFINE_OPTIONALARG(OD, gpio_od, bool);
+    DEFINE_OPTIONALARG(Pull, pull, uint32_t);
+    DEFINE_OPTIONALARG(Speed, speed, uint32_t);
+    DEFINE_OPTIONALARG(AfMode, afmode, uint32_t);
+
+    DEFINE_OPTIONALARG(PeriphBase, periph_base, uint32_t);
+    DEFINE_OPTIONALARG(Pin, pin, uint16_t);
+    DEFINE_OPTIONALARG(PinNum, pin_num, uint8_t);
+
+    constexpr bool is_af() const
+    {
+        return (gpio_mode() == GPIO_MODE_AF_PP) ||
+            (gpio_mode() == GPIO_MODE_AF_OD);
+    }
+
+    constexpr bool is_od() const
+    {
+        return (gpio_mode() == GPIO_MODE_AF_OD) ||
+            (gpio_mode() == GPIO_MODE_OUTPUT_OD);
+    }
+
+    template <typename... Args>
+    static constexpr void __attribute__((always_inline))
+    fill_options(GPIO_InitTypeDef *gpio_init, Args... args)
+    {
+#if 0
+        constexpr Stm32GpioOptions ao(args...);
+        static_assert(IS_GPIO_MODE(Stm32GpioOptions(args...).gpio_mode()), "Incorrect gpio mode");
+        static_assert(IS_GPIO_SPEED(ao.speed()), "Incorrect gpio speed");
+        static_assert(IS_GPIO_PULL(ao.pull()), "Incorrect gpio pull");
+        static_assert((ao.is_af() && ao.has_afmode()) ||
+                (!ao.is_af() && !ao.has_afmode()),
+            "Must specify AfMode for any AF modes.");
+#endif        
+        gpio_init->Mode = Stm32GpioOptions(args...).gpio_mode();
+        gpio_init->Pull = Stm32GpioOptions(args...).pull();
+        gpio_init->Speed = Stm32GpioOptions(args...).speed();
+        gpio_init->Alternate = Stm32GpioOptions(args...).has_afmode()
+            ? Stm32GpioOptions(args...).afmode()
+            : 0;
+    }
+
+    /// @return the GPIO structure of the given gpio port.
+    constexpr GPIO_TypeDef *port() const
+    {
+        return (GPIO_TypeDef *)periph_base();
+    }
 };
 
 /// Helper macro for defining GPIO pins.
@@ -229,7 +316,243 @@ struct GpioInputNP : public GpioInputPin<Defs, GPIO_NOPULL>
 ///  GPIO_PIN(FOO, LedPin, 0, 3);
 ///  ...
 ///  FOO_Pin::set(true);
+#define GPIO_XPIN(NAME, BaseClass, PORTNAME, NUM, ARGS...)                     \
+    struct NAME##_PinDefs                                                      \
+    {                                                                          \
+        using PeriphBase = Stm32GpioOptions::PeriphBase;                       \
+        using Pin = Stm32GpioOptions::Pin;                                     \
+        using PinNum = Stm32GpioOptions::PinNum;                               \
+        using GpioMode = Stm32GpioOptions::GpioMode;                           \
+        using Pull = Stm32GpioOptions::Pull;                                   \
+        using Speed = Stm32GpioOptions::Speed;                                 \
+        using AfMode = Stm32GpioOptions::AfMode;                               \
+        static constexpr Pull PullUp()                                         \
+        {                                                                      \
+            return Pull(GPIO_PULLUP);                                          \
+        }                                                                      \
+        static constexpr Pull PullDown()                                       \
+        {                                                                      \
+            return Pull(GPIO_PULLDOWN);                                        \
+        }                                                                      \
+        static constexpr Pull NoPull()                                         \
+        {                                                                      \
+            return Pull(GPIO_NOPULL);                                          \
+        }                                                                      \
+        static constexpr GpioMode Output()                                     \
+        {                                                                      \
+            return GpioMode(GPIO_MODE_OUTPUT_PP);                              \
+        }                                                                      \
+        static constexpr GpioMode OutputOd()                                   \
+        {                                                                      \
+            return GpioMode(GPIO_MODE_OUTPUT_OD);                              \
+        }                                                                      \
+        static constexpr GpioMode Af()                                         \
+        {                                                                      \
+            return GpioMode(GPIO_MODE_AF_PP);                                  \
+        }                                                                      \
+        static constexpr GpioMode AfOd()                                       \
+        {                                                                      \
+            return GpioMode(GPIO_MODE_AF_OD);                                  \
+        }                                                                      \
+        static constexpr Stm32GpioOptions opts()                               \
+        {                                                                      \
+            return Stm32GpioOptions(PeriphBase(GPIO##PORTNAME##_BASE),         \
+                Pin(GPIO_PIN_##NUM), PinNum(NUM), ##ARGS);                     \
+        }                                                                      \
+    };                                                                         \
+    typedef BaseClass<NAME##_PinDefs> NAME##_Pin
+
+template <class Defs>
+struct GpioHwPin : public Stm32GpioDefs<Defs::opts().periph_base(),
+                       Defs::opts().pin(), Defs::opts().pin_num()>
+{
+    /// Implements hw_init functionality for this pin only.
+    static void hw_init()
+    {
+        GPIO_InitTypeDef gpio_init = {0};
+        Stm32GpioOptions::fill_options(&gpio_init, Defs::opts());
+        HAL_GPIO_Init(Defs::opts().port(), &gpio_init);
+    }
+
+    /// Implements hw_set_to_safe functionality for this pin only.
+    static void hw_set_to_safe()
+    {
+        hw_init();
+    }
+
+    /// Switches the GPIO pin to the hardware peripheral. */
+    static void set_hw()
+    {
+        hw_init();
+    }
+
+    static constexpr Stm32GpioOptions output_opts()
+    {
+        return Stm32GpioOptions(Stm32GpioOptions::GpioMode(Defs::opts().is_od()
+                                        ? GPIO_MODE_OUTPUT_OD
+                                        : GPIO_MODE_OUTPUT_PP),
+            Defs::opts());
+    }
+
+    static constexpr Stm32GpioOptions input_opts()
+    {
+        return Stm32GpioOptions(
+            Stm32GpioOptions::GpioMode(GPIO_MODE_INPUT), Defs::opts());
+    }
+
+    /// Switches the GPIO pin to an output pin. Maintains the OD status from
+    /// the original options.
+    static void set_output()
+    {
+        GPIO_InitTypeDef gpio_init = {0};
+        output_opts().fill_options(&gpio_init);
+        HAL_GPIO_Init(Defs::opts().port(), &gpio_init);
+    }
+
+    /// Switches the GPIO pin to an input pin. Maintains the pull from the
+    /// original options.
+    static void set_input()
+    {
+        GPIO_InitTypeDef gpio_init = {0};
+        input_opts().fill_options(&gpio_init);
+        HAL_GPIO_Init(Defs::opts().port(), &gpio_init);
+    }
+}; // class GpioHwPin
+
+#if 0
+
+template <uint32_t afnum, uint32_t afmode = GPIO_AF_PP,
+    uint32_t pull = GPIO_NOPULL, uint32_t speed = GPIO_SPEED_FREQ_LOW>
+struct GpioHwParams
+{
+    /// Used for setting pullup pulldown, example value GPIO_NOPULL,
+    /// GPIO_PULLUP, GPIO_PULLDOWN.
+    static constexpr uint32_t PULL_MODE = pull;
+    /// Used for setting slew rate, example value GPIO_SPEED_FREQ_LOW,
+    /// GPIO_SPEED_FREQ_HIGH.
+    static constexpr uint32_t SPEED_FREQ = speed;
+    /// Used for setting alternate function mode, example GPIO_AF_PP,
+    /// GPIO_AF_OD.
+    static constexpr uint32_t AF_MODE = afmode;
+    
+    static constexpr uint32_t AF_NUM = afnum;
+    
+    using Input = GpioInputPin;
+};
+
+template<class Defs>
+struct GpioHwPin : public Defs
+{
+    using Defs::PULL_MODE;
+    using Defs::SPEED_FREQ;
+    using Defs::AF_MODE;    
+
+    /// Implements hw_init functionality for this pin only.
+    static void hw_init()
+    {
+        GPIO_InitTypeDef gpio_init = {0};
+        gpio_init.Pin = pin();
+        gpio_init.Mode = AF_MODE;
+        gpio_init.Pull = PULL_MODE;
+        gpio_init.Speed = SPEED_FREQ;
+        gpio_init.Alternate = GPIO_AF3_FDCAN1;
+        HAL_GPIO_Init(port(), &gpio_init);
+
+
+        gpio_init.Mode = GPIO_MODE_AF_PP;
+        gpio_init.Pull = GPIO_NOPULL;
+        gpio_init.Speed = GPIO_SPEED_FREQ_LOW;
+        gpio_init.Alternate = GPIO_AF3_FDCAN1;
+        gpio_init.Pin = GPIO_PIN_8;
+        HAL_GPIO_Init(GPIOB, &gpio_init);
+        gpio_init.Pin = GPIO_PIN_9;
+        HAL_GPIO_Init(GPIOB, &gpio_init);
+    }
+
+    /// Implements hw_set_to_safe functionality for this pin only.
+    static void hw_set_to_safe()
+    {
+        Defs::Safe::hw_init();
+    }
+
+    /// Switches the GPIO pin to the hardware peripheral. */
+    static void set_hw()
+    {
+        hw_init();
+    }
+
+    /// Switches the GPIO pin to an output pin. Note that this will set the pin
+    /// to the SAFE value. Use the set() command afterwards to define the
+    /// desired value.
+    static void set_output()
+    {
+        Defs::Output::hw_init();
+        static_assert(
+            Defs::Output::is_output() == true, "Output pin is not correct");
+    }
+
+    /** Switches the GPIO pin to an input pin. Use the get() command to
+     * retrieve the value.
+     *
+     * @param drive_type specifies whether there should be a weak pullup
+     * (GPIO_PIN_TYPE_STD_WPU), pull-down (GPIO_PIN_TYPE_STD_WPD) or standard
+     * pin (default, GPIO_PIN_TYPE_STD)*/
+    static void set_input()
+    {
+        Defs::Input::hw_init();
+        static_assert(Defs::Output::is_output() == true);
+    }
+
+/// Helper macro for defining GPIO pins with a specific hardware config on the
+/// Tiva microcontrollers.
+///
+/// @param NAME is the basename of the declaration. For NAME==FOO the macro
+/// declared FOO_Pin as a structure on which the read-write functions will be
+/// available.
+///
+/// @param BaseClass is the initialization structure, such as @ref LedPin, or
+/// @ref GpioOutputSafeHigh or @ref GpioOutputSafeLow.
+///
+/// @param PORTNAME is the letter (e.g. D)
+///
+/// @param NUM is the pin number, such as 3
+///
+/// @param CONFIG is the suffix of the symbol that defines the pinmux for the
+/// hardware, e.g. U7TX.
+///
+/// @param TYPE is a suffix for a TivaWare GPIOPinType function such as UART
+/// for GPIOPinTypeUART() to set the pin to the hardware configuration.
+#define GPIO_HWPIN(NAME, SafeType, PORTNAME, NUM, AFTYPE, AFNUM, Args...)      \
+    struct NAME##Defs                                                          \
+    {                                                                          \
+        DECL_HWPIN(GPIO, PORT, NUM, CONFIG, TYPE);                             \
+        using Params = HwPinParams<Args...>;                                   \
+    };                                                                         \
+    typedef GpioHwPin<NAME##Defs> NAME##_Pin
+
+#endif // if 0, for HWPIN draft.
+
+/// Helper macro for defining GPIO pins.
+///
+/// @param NAME is the basename of the declaration. For NAME==FOO the macro
+/// declares FOO_Pin as a structure on which the read-write functions will be
+/// available.
+///
+/// @param BaseClass is the initialization structure, such as @ref LedPin, or
+/// @ref GpioOutputSafeHigh or @ref GpioOutputSafeLow.
+///
+/// @param PORTNAME is a letter defining which port this is (like A, B,
+/// C). E.g. for PC8 this is C.
+///
+/// @param NUM is the pin number, such as 8 for PC8.
+///
+/// Example:
+///  GPIO_PIN(FOO, LedPin, 0, 3);
+///  ...
+///  FOO_Pin::set(true);
 #define GPIO_PIN(NAME, BaseClass, PORTNAME, NUM)                               \
-    typedef BaseClass<Stm32GpioDefs<(uint32_t)(GPIO ## PORTNAME ## _BASE), GPIO_PIN_ ## NUM, NUM>> NAME##_Pin
+    typedef BaseClass<                                                         \
+        Stm32GpioDefs<(uint32_t)(GPIO##PORTNAME##_BASE), GPIO_PIN_##NUM, NUM>> \
+        NAME##_Pin
 
 #endif // _FREERTOS_DRIVERS_ST_STM32GPIO_HXX_

--- a/src/freertos_drivers/st/Stm32Gpio.hxx
+++ b/src/freertos_drivers/st/Stm32Gpio.hxx
@@ -284,6 +284,7 @@ public:
             "Must specify AfMode for any AF modes.");
 #endif        
         gpio_init->Mode = Stm32GpioOptions(args...).gpio_mode();
+        gpio_init->Pin = Stm32GpioOptions(args...).pin();
         gpio_init->Pull = Stm32GpioOptions(args...).pull();
         gpio_init->Speed = Stm32GpioOptions(args...).speed();
         gpio_init->Alternate = Stm32GpioOptions(args...).has_afmode()
@@ -386,6 +387,10 @@ struct GpioHwPin : public Stm32GpioDefs<Defs::opts().periph_base(),
         hw_init();
     }
 
+    static constexpr Stm32GpioOptions opts() {
+        return Defs::opts();
+    }
+    
     static constexpr Stm32GpioOptions output_opts()
     {
         return Stm32GpioOptions(Stm32GpioOptions::GpioMode(Defs::opts().is_od()

--- a/src/freertos_drivers/st/Stm32Gpio.hxx
+++ b/src/freertos_drivers/st/Stm32Gpio.hxx
@@ -357,6 +357,10 @@ public:
         {                                                                      \
             return GpioMode(GPIO_MODE_AF_PP);                                  \
         }                                                                      \
+        static constexpr GpioMode Analog()                                     \
+        {                                                                      \
+            return GpioMode(GPIO_MODE_ANALOG);                                 \
+        }                                                                      \
         static constexpr GpioMode AfOd()                                       \
         {                                                                      \
             return GpioMode(GPIO_MODE_AF_OD);                                  \

--- a/src/utils/Stm32GpioTest.cxxtest
+++ b/src/utils/Stm32GpioTest.cxxtest
@@ -23,9 +23,12 @@ void HAL_GPIO_Init(GPIO_TypeDef* port, GPIO_InitTypeDef* cfg) {
 GPIO_XPIN(TEST, GpioHwPin, B, 5);
 GPIO_XPIN(TEST2, GpioHwPin, B, 5, PullDown());
 
+GPIO_XPIN(TEST_AF, GpioHwPin, B, 5, PullDown(), Af(), AfMode(GPIO_AF3_FDCAN1));
+
+GPIO_XPIN(TEST_AFOD, GpioHwPin, B, 5, PullDown(), AfOd(), AfMode(GPIO_AF3_FDCAN1));
+
 class GpioTest : public ::testing::Test {
 protected:
-    
     ::testing::StrictMock<InitMock> mock_;
 };
 
@@ -33,14 +36,27 @@ protected:
 TEST_F(GpioTest, base_settings) {
     EXPECT_EQ(GPIOB, TEST_Pin::port());
     EXPECT_EQ(GPIO_PIN_5, TEST_Pin::pin());
+
+    EXPECT_EQ(GPIO_NOPULL, TEST_Pin::opts().pull());
+    EXPECT_EQ(GPIO_PULLDOWN, TEST2_Pin::opts().pull());
 }
 
 TEST_F(GpioTest, input_settings) {
     EXPECT_EQ(GPIOB, TEST_Pin::input_opts().port());
     EXPECT_EQ(GPIO_PIN_5, TEST_Pin::input_opts().pin());
     EXPECT_EQ(GPIO_MODE_INPUT, TEST_Pin::input_opts().gpio_mode());
+    EXPECT_EQ(GPIO_NOPULL, TEST_Pin::input_opts().pull());
     EXPECT_FALSE(TEST_Pin::input_opts().has_afmode());
     EXPECT_EQ(0xffffffff, TEST_Pin::input_opts().afmode());
+}
+
+TEST_F(GpioTest, output_settings) {
+    EXPECT_EQ(GPIOB, TEST_Pin::output_opts().port());
+    EXPECT_EQ(GPIO_PIN_5, TEST_Pin::output_opts().pin());
+    EXPECT_EQ(GPIO_MODE_OUTPUT_PP, TEST_Pin::output_opts().gpio_mode());
+    EXPECT_EQ(GPIO_NOPULL, TEST_Pin::output_opts().pull());
+    EXPECT_FALSE(TEST_Pin::output_opts().has_afmode());
+    EXPECT_EQ(0xffffffff, TEST_Pin::output_opts().afmode());
 }
 
 TEST_F(GpioTest, copy_constructor) {
@@ -52,6 +68,14 @@ TEST_F(GpioTest, fill_options) {
     GPIO_InitTypeDef gpio_init = {0};
     Stm32GpioOptions::fill_options(&gpio_init, TEST_Pin::opts());
     EXPECT_EQ(GPIO_PIN_5, gpio_init.Pin);
+    EXPECT_EQ(GPIO_NOPULL, gpio_init.Pull);
+}
+
+TEST_F(GpioTest, fill_options2) {
+    GPIO_InitTypeDef gpio_init = {0};
+    Stm32GpioOptions::fill_options(&gpio_init, TEST2_Pin::opts());
+    EXPECT_EQ(GPIO_PIN_5, gpio_init.Pin);
+    EXPECT_EQ(GPIO_PULLDOWN, gpio_init.Pull);
 }
 
 TEST_F(GpioTest, test_hw_init)
@@ -62,12 +86,66 @@ TEST_F(GpioTest, test_hw_init)
     TEST_Pin::hw_init();
 }
 
-TEST_F(GpioTest, test_in_out)
+TEST_F(GpioTest, test2_hw_init)
 {
     EXPECT_CALL(mock_,
         gpio_init(GPIOB_BASE, GPIO_PIN_5, GPIO_MODE_INPUT, GPIO_PULLDOWN,
             GPIO_SPEED_FREQ_LOW, 0));
-    TEST_Pin::hw_init();
+    TEST2_Pin::hw_init();
+}
+
+TEST_F(GpioTest, test2_output)
+{
+    EXPECT_CALL(mock_,
+        gpio_init(GPIOB_BASE, GPIO_PIN_5, GPIO_MODE_OUTPUT_PP, GPIO_PULLDOWN,
+            GPIO_SPEED_FREQ_LOW, 0));
+    TEST2_Pin::set_output();
+}
+
+TEST_F(GpioTest, set_i_o_hw)
+{
+    EXPECT_CALL(mock_,
+        gpio_init(GPIOB_BASE, GPIO_PIN_5, GPIO_MODE_AF_PP, GPIO_PULLDOWN,
+            GPIO_SPEED_FREQ_LOW, GPIO_AF3_FDCAN1));
+    TEST_AF_Pin::hw_init();
+
+    EXPECT_CALL(mock_,
+        gpio_init(GPIOB_BASE, GPIO_PIN_5, GPIO_MODE_INPUT, GPIO_PULLDOWN,
+            GPIO_SPEED_FREQ_LOW, GPIO_AF3_FDCAN1));
+    TEST_AF_Pin::set_input();
+
+    EXPECT_CALL(mock_,
+        gpio_init(GPIOB_BASE, GPIO_PIN_5, GPIO_MODE_OUTPUT_PP, GPIO_PULLDOWN,
+            GPIO_SPEED_FREQ_LOW, GPIO_AF3_FDCAN1));
+    TEST_AF_Pin::set_output();
+
+    EXPECT_CALL(mock_,
+        gpio_init(GPIOB_BASE, GPIO_PIN_5, GPIO_MODE_AF_PP, GPIO_PULLDOWN,
+            GPIO_SPEED_FREQ_LOW, GPIO_AF3_FDCAN1));
+    TEST_AF_Pin::set_hw();
+}
+
+TEST_F(GpioTest, set_i_o_hw_od)
+{
+    EXPECT_CALL(mock_,
+        gpio_init(GPIOB_BASE, GPIO_PIN_5, GPIO_MODE_AF_OD, GPIO_PULLDOWN,
+            GPIO_SPEED_FREQ_LOW, GPIO_AF3_FDCAN1));
+    TEST_AFOD_Pin::hw_init();
+
+    EXPECT_CALL(mock_,
+        gpio_init(GPIOB_BASE, GPIO_PIN_5, GPIO_MODE_INPUT, GPIO_PULLDOWN,
+            GPIO_SPEED_FREQ_LOW, GPIO_AF3_FDCAN1));
+    TEST_AFOD_Pin::set_input();
+
+    EXPECT_CALL(mock_,
+        gpio_init(GPIOB_BASE, GPIO_PIN_5, GPIO_MODE_OUTPUT_OD, GPIO_PULLDOWN,
+            GPIO_SPEED_FREQ_LOW, GPIO_AF3_FDCAN1));
+    TEST_AFOD_Pin::set_output();
+
+    EXPECT_CALL(mock_,
+        gpio_init(GPIOB_BASE, GPIO_PIN_5, GPIO_MODE_AF_OD, GPIO_PULLDOWN,
+            GPIO_SPEED_FREQ_LOW, GPIO_AF3_FDCAN1));
+    TEST_AFOD_Pin::set_hw();
 }
 
 #else

--- a/src/utils/Stm32GpioTest.cxxtest
+++ b/src/utils/Stm32GpioTest.cxxtest
@@ -1,10 +1,40 @@
+#include "utils/test_main.hxx"
+#include "utils/Singleton.hxx"
+
+
+struct InitMock : public Singleton<InitMock>
+{
+    MOCK_METHOD6(gpio_init,
+        void(uint32_t base, uint32_t pin, uint32_t mode, uint32_t pull,
+            uint32_t speed, uint32_t alternate));
+}; //InitMock
+
+
 #ifdef STM32G0B1xx
 
 #include "freertos_drivers/st/Stm32Gpio.hxx"
 
+extern "C" {
+void HAL_GPIO_Init(GPIO_TypeDef* port, GPIO_InitTypeDef* cfg) {
+    InitMock::instance()->gpio_init((uint32_t)port, cfg->Pin, cfg->Mode, cfg->Pull, cfg->Speed, cfg->Alternate);
+}
+} // extern "C"
+
+GPIO_XPIN(TEST, GpioHwPin, B, 5);
+
+class GpioTest : public ::testing::Test {
+protected:
+    
+    ::testing::StrictMock<InitMock> mock_;
+};
+
+
+TEST_F(GpioTest, bar) {
+    TEST_Pin::hw_init();
+}
+
+#else
+#info Not compiling Stm32Gpio test because G0B1 Cube is not available.
 #endif
 
-#include "utils/test_main.hxx"
 
-
-TEST(foo, bar) {}

--- a/src/utils/Stm32GpioTest.cxxtest
+++ b/src/utils/Stm32GpioTest.cxxtest
@@ -1,0 +1,10 @@
+#ifdef STM32G0B1xx
+
+#include "freertos_drivers/st/Stm32Gpio.hxx"
+
+#endif
+
+#include "utils/test_main.hxx"
+
+
+TEST(foo, bar) {}

--- a/src/utils/Stm32GpioTest.cxxtest
+++ b/src/utils/Stm32GpioTest.cxxtest
@@ -21,6 +21,7 @@ void HAL_GPIO_Init(GPIO_TypeDef* port, GPIO_InitTypeDef* cfg) {
 } // extern "C"
 
 GPIO_XPIN(TEST, GpioHwPin, B, 5);
+GPIO_XPIN(TEST2, GpioHwPin, B, 5, PullDown());
 
 class GpioTest : public ::testing::Test {
 protected:
@@ -29,12 +30,50 @@ protected:
 };
 
 
-TEST_F(GpioTest, bar) {
+TEST_F(GpioTest, base_settings) {
+    EXPECT_EQ(GPIOB, TEST_Pin::port());
+    EXPECT_EQ(GPIO_PIN_5, TEST_Pin::pin());
+}
+
+TEST_F(GpioTest, input_settings) {
+    EXPECT_EQ(GPIOB, TEST_Pin::input_opts().port());
+    EXPECT_EQ(GPIO_PIN_5, TEST_Pin::input_opts().pin());
+    EXPECT_EQ(GPIO_MODE_INPUT, TEST_Pin::input_opts().gpio_mode());
+    EXPECT_FALSE(TEST_Pin::input_opts().has_afmode());
+    EXPECT_EQ(0xffffffff, TEST_Pin::input_opts().afmode());
+}
+
+TEST_F(GpioTest, copy_constructor) {
+    EXPECT_EQ(GPIO_PIN_5, TEST_Pin::opts().pin());
+    EXPECT_EQ(GPIO_PIN_5, Stm32GpioOptions(TEST_Pin::opts()).pin());
+}
+
+TEST_F(GpioTest, fill_options) {
+    GPIO_InitTypeDef gpio_init = {0};
+    Stm32GpioOptions::fill_options(&gpio_init, TEST_Pin::opts());
+    EXPECT_EQ(GPIO_PIN_5, gpio_init.Pin);
+}
+
+TEST_F(GpioTest, test_hw_init)
+{
+    EXPECT_CALL(mock_,
+        gpio_init(GPIOB_BASE, GPIO_PIN_5, GPIO_MODE_INPUT, GPIO_NOPULL,
+            GPIO_SPEED_FREQ_LOW, 0));
+    TEST_Pin::hw_init();
+}
+
+TEST_F(GpioTest, test_in_out)
+{
+    EXPECT_CALL(mock_,
+        gpio_init(GPIOB_BASE, GPIO_PIN_5, GPIO_MODE_INPUT, GPIO_PULLDOWN,
+            GPIO_SPEED_FREQ_LOW, 0));
     TEST_Pin::hw_init();
 }
 
 #else
-#info Not compiling Stm32Gpio test because G0B1 Cube is not available.
+
+// Not compiling Stm32Gpio test because G0B1 Cube is not available.
+
 #endif
 
 


### PR DESCRIPTION
- Adds a constexpr class hierarchy for options related to Stm32 pins. (This comes from the library we use for the CDI definitions.) Represents not just the common options (input, output, pullup) but also hardware pins including Af numbers and open drain.
- Adds a new Gpio Pin class that can switch between input, output and hardware option.
- Adds a test, which is not currently running (a different PR is needed for it).