### PR TITLE
Fixes for upgrading googletest to v1.16.0.

### DIFF
--- a/etc/path.mk
+++ b/etc/path.mk
@@ -433,9 +433,37 @@ endif
 endif #CMSIS_LPC11_PATH
 
 
+############### GTEST ###################
+ifndef GTESTPATH
+SEARCHPATH := \
+  /opt/gtest/default \
+  /opt/gtest/default/googletest \
+  /opt/gtest/gtest \
+  /opt/gtest/googletest \
+
+
+TRYPATH:=$(call findfirst,include/gtest/gtest.h,$(SEARCHPATH))
+ifneq ($(TRYPATH),)
+GTESTPATH:=$(TRYPATH)
+endif
+endif #GTESTPATH
+
+ifndef GTESTSRCPATH
+SEARCHPATH := \
+  $(GTESTPATH) \
+
+TRYPATH:=$(call findfirst,src/gtest-all.cc,$(SEARCHPATH))
+ifneq ($(TRYPATH),)
+GTESTSRCPATH:=$(TRYPATH)
+endif
+endif #GTESTSRCPATH
+
 ############### GMOCK ###################
 ifndef GMOCKPATH
 SEARCHPATH := \
+  $(GTESTPATH)/googlemock \
+  $(GTESTPATH)/../googlemock \
+  /opt/gtest/default/googlemock \
   /opt/gmock/default \
   /usr \
 
@@ -456,35 +484,6 @@ ifneq ($(TRYPATH),)
 GMOCKSRCPATH:=$(TRYPATH)
 endif
 endif #GMOCKSRCPATH
-
-
-############### GTEST ###################
-ifndef GTESTPATH
-SEARCHPATH := \
-  $(GMOCKPATH)/gtest \
-  /opt/gmock/default/gtest \
-  /opt/gtest/gtest \
-  /opt/gtest/default \
-  /usr \
-
-TRYPATH:=$(call findfirst,include/gtest/gtest.h,$(SEARCHPATH))
-ifneq ($(TRYPATH),)
-GTESTPATH:=$(TRYPATH)
-endif
-endif #GTESTPATH
-
-ifndef GTESTSRCPATH
-SEARCHPATH := \
-  $(GTESTPATH) \
-  /opt/gmock/default/gtest \
-  /usr/src/gtest \
-  /opt/gtest/default \
-
-TRYPATH:=$(call findfirst,src/gtest-all.cc,$(SEARCHPATH))
-ifneq ($(TRYPATH),)
-GTESTSRCPATH:=$(TRYPATH)
-endif
-endif #GTESTSRCPATH
 
 ################### MIPS-ELF-GCC #####################
 ifndef MIPSGCCPATH

--- a/src/dcc/Packet.cxxtest
+++ b/src/dcc/Packet.cxxtest
@@ -710,7 +710,7 @@ TEST_F(Train28Test, MinSpeed)
 
 TEST_F(Train28Test, ZeroSpeed)
 {
-    EXPECT_CALL(loop_, send_update(&train_, _)).Times(2).WillRepeatedly(
+    EXPECT_CALL(loop_, send_update(&train_, _)).WillOnce(
         SaveArg<1>(&code_));
     SpeedType s;
     // Even the smallest nonzero velocity should set the train in motion.
@@ -719,6 +719,8 @@ TEST_F(Train28Test, ZeroSpeed)
     do_callback();
     EXPECT_THAT(get_packet(), ElementsAre(55, 0b01100010, _));
 
+    EXPECT_CALL(loop_, send_update(&train_, _)).WillOnce(
+        SaveArg<1>(&code_));
     s.set_mph(0);
     train_.set_speed(s);
     do_callback();
@@ -732,7 +734,7 @@ TEST_F(Train28Test, EstopSaved)
     s.set_mph(128);
     code_ = 0;
     EXPECT_CALL(loop_, send_update(&train_, _))
-        .WillRepeatedly(SaveArg<1>(&code_));
+        .WillOnce(SaveArg<1>(&code_));
 
     // First make the train move.
     train_.set_speed(s);
@@ -741,6 +743,9 @@ TEST_F(Train28Test, EstopSaved)
     EXPECT_THAT(get_packet(), ElementsAre(55, 0b01111111, _));
     EXPECT_FALSE(train_.get_emergencystop());
     EXPECT_NEAR(128, train_.get_speed().mph(), 0.1);
+
+    EXPECT_CALL(loop_, send_update(&train_, _))
+        .WillOnce(SaveArg<1>(&code_));
 
     // Then estop the train.
     EXPECT_FALSE(train_.get_emergencystop());
@@ -754,6 +759,9 @@ TEST_F(Train28Test, EstopSaved)
     EXPECT_TRUE(train_.get_emergencystop());
     EXPECT_NEAR(0, train_.get_speed().mph(), 0.1);
 
+    EXPECT_CALL(loop_, send_update(&train_, _))
+        .WillOnce(SaveArg<1>(&code_));
+    
     // Move the train again.
     s = 37.5;
     train_.set_speed(s);

--- a/src/utils/SimpleQueue.cxxtest
+++ b/src/utils/SimpleQueue.cxxtest
@@ -122,7 +122,7 @@ protected:
     QTHelper<QT> helper_;
 };
 
-TYPED_TEST_CASE_P(SimpleQueueTest);
+TYPED_TEST_SUITE_P(SimpleQueueTest);
 
 TYPED_TEST_P(SimpleQueueTest, empty) {
     EXPECT_THAT(this->list_queue(&this->q_), ElementsAre());
@@ -202,8 +202,8 @@ TYPED_TEST_P(SimpleQueueTest, reuse) {
     EXPECT_THAT(this->list_queue(&this->q_), ElementsAre(24, 23, 25));
 }
 
-REGISTER_TYPED_TEST_CASE_P(SimpleQueueTest, empty, push_front, pop_front, insert, erase, reuse);
+REGISTER_TYPED_TEST_SUITE_P(SimpleQueueTest, empty, push_front, pop_front, insert, erase, reuse);
 
-INSTANTIATE_TYPED_TEST_CASE_P(Simple, SimpleQueueTest, SimpleQueue);
+INSTANTIATE_TYPED_TEST_SUITE_P(Simple, SimpleQueueTest, SimpleQueue);
 
-INSTANTIATE_TYPED_TEST_CASE_P(Typed, SimpleQueueTest, TypedQueue<ValueQMember>);
+INSTANTIATE_TYPED_TEST_SUITE_P(Typed, SimpleQueueTest, TypedQueue<ValueQMember>);

--- a/src/utils/StoredBitSet.cxxtest
+++ b/src/utils/StoredBitSet.cxxtest
@@ -277,7 +277,7 @@ TEST_P(BitSetMultiTest, set_multi_small)
     expect_all_one();
 }
 
-INSTANTIATE_TEST_CASE_P(AllTests, BitSetMultiTest,
+INSTANTIATE_TEST_SUITE_P(AllTests, BitSetMultiTest,
     Combine(Values(7, 31, 32, 33, 67, 131, 254), Range(1, 33)));
 
 using BitSetMultiLargeTest = BitSetMultiTest;
@@ -300,5 +300,5 @@ TEST_P(BitSetMultiLargeTest, multi_dirty)
     EXPECT_EQ(dlist, actual);
 }
 
-INSTANTIATE_TEST_CASE_P(AllTests, BitSetMultiLargeTest,
+INSTANTIATE_TEST_SUITE_P(AllTests, BitSetMultiLargeTest,
     Combine(Values(67, 131, 254), Range(1, 33)));

--- a/src/utils/async_if_test_helper.hxx
+++ b/src/utils/async_if_test_helper.hxx
@@ -22,6 +22,7 @@ using ::testing::AtMost;
 using ::testing::Eq;
 using ::testing::Field;
 using ::testing::Invoke;
+using ::testing::DoAll;
 using ::testing::IsNull;
 using ::testing::Mock;
 using ::testing::NiceMock;


### PR DESCRIPTION
GoogleMock is now part of googletest. Previously this was reversed, googletest was part of googlemock. Adjusts the path.mk accordingly.

Fixes errors that were triggered:
- WillRepeatedly does not survive the VerifyAndClear operation. The expectation needs to be repeatedly issued if we use VerifyAndClear.
- Typed tests use slightly different macros now.
- Adds missing using declaration for DoAll.