### PR TITLE
Add GitHub actions tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+          path: openmrn
 
       - name: Checkout googletest
         uses: actions/checkout@v4
@@ -24,4 +25,6 @@ jobs:
           path: googletest
 
       - name: Run tests
-        run: make -j5 tests
+        run: |
+          cd openmrn
+          make -j5 tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout googletest
+        uses: actions/checkout@v4
+        with:
+          repository: google/googletest
+          ref: v1.16.0
+          path: googletest
+
+      - name: Run tests
+        run: make -j5 tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run tests
         run: |
           cd openmrn
-          make -j5 tests TESTBLACKLIST=utils/SocketClient.cxxtest
+          make -j1 tests TESTBLACKLIST=utils/SocketClient.cxxtest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run tests
         run: |
           cd openmrn
-          make -j5 tests
+          make -j5 tests TESTBLACKLIST=utils/SocketClient.cxxtest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,4 +34,4 @@ jobs:
       - name: Run tests
         run: |
           cd openmrn
-          make -j5 tests-single TESTBLACKLIST=utils/SocketClient.cxxtest
+          make -j5 tests-single TESTBLACKLIST="utils/SocketClient.cxxtest openlcb/IfTcp.cxxtest"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
           path: openmrn
 
       - name: Checkout googletest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,9 @@ jobs:
           ref: v1.16.0
           path: googletest
 
+      - name: Install dependent packages
+        run: sudo apt install -y libavahi-client-dev libssl-dev
+    
       - name: Run tests
         run: |
           cd openmrn

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run tests
         run: |
           cd openmrn
-          make -j1 tests TESTBLACKLIST=utils/SocketClient.cxxtest
+          make -j5 tests-single TESTBLACKLIST=utils/SocketClient.cxxtest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,10 @@ jobs:
 
       - name: Install dependent packages
         run: sudo apt install -y libavahi-client-dev libssl-dev
-    
+
+      - name: Look at proc
+        run: cat /proc/cpuinfo
+        
       - name: Run tests
         run: |
           cd openmrn

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ cov:
 tests:
 	$(MAKE) -C targets/test tests
 
+tests-single:
+	$(MAKE) -C targets/test tests-single
+
 llvm-tests:
 	$(MAKE) -C targets/linux.llvm run-tests
 

--- a/etc/core_test.mk
+++ b/etc/core_test.mk
@@ -106,7 +106,7 @@ run-tests-single:
 
 tests: run-tests
 
-tests-single: run-tests
+tests-single: run-tests-single
 
 clean-gtest:
 	rm -f {gtest-all,gmock-all}.{d,o,gcno}

--- a/etc/core_test.mk
+++ b/etc/core_test.mk
@@ -100,7 +100,13 @@ endif
 
 run-tests: $(TESTOUTPUTS) $(TESTMD5)
 
+run-tests-single:
+	$(MAKE) $(TESTMD5)
+	$(MAKE) -j1 $(TESTOUTPUTS)
+
 tests: run-tests
+
+tests-single: run-tests
 
 clean-gtest:
 	rm -f {gtest-all,gmock-all}.{d,o,gcno}

--- a/etc/path.mk
+++ b/etc/path.mk
@@ -440,6 +440,7 @@ SEARCHPATH := \
   /opt/gtest/default/googletest \
   /opt/gtest/gtest \
   /opt/gtest/googletest \
+  $(abspath $(OPENMRNPATH)/../googletest/googletest) \
 
 
 TRYPATH:=$(call findfirst,include/gtest/gtest.h,$(SEARCHPATH))


### PR DESCRIPTION
Adds an actions workflow to run the tests.

Special conditions:
- adds a new method to run tests by building the test binariesi n parallel, but executing the actual tests in sequence. Invoke this with make tests-single at toplevel.
- Checks out the googletest git repository to fulfill test dependencies. 
- Installs some deb packages to make our linux code and tests compile

Two tests are blacklisted:
- SocketClient test, because MDNS class can not be instantiated on a linux host when avahi daemon is not running.
- IfTcp test because the remote connect test fails (something related to sockets in the github runner I think).