### PR TITLE
Traction Modem Outputs

### DIFF
--- a/cmake/test_setup_epilogue.cmake
+++ b/cmake/test_setup_epilogue.cmake
@@ -12,7 +12,12 @@ endif()
 
 # Build an executable for each test file.
 foreach(testsourcefile ${TESTS})
+    # Manipulate path to result in unique test names.
     get_filename_component(testname ${testsourcefile} NAME_WE)
+    get_filename_component(testdir ${testsourcefile} DIRECTORY)
+    get_filename_component(testdir ${testdir} NAME)
+    set(testname "${testdir}_${testname}")
+
     add_executable(${testname} ${testsourcefile})
     target_include_directories(${testname}
         PUBLIC

--- a/cmake/test_setup_epilogue.cmake
+++ b/cmake/test_setup_epilogue.cmake
@@ -27,6 +27,7 @@ foreach(testsourcefile ${TESTS})
 
         -fPIC
         -lgcov
+        -lcrypto
         -Wl,--start-group
         openmrn
         ${LINK_LIBS}

--- a/etc/esp-idf/CMakeLists.txt
+++ b/etc/esp-idf/CMakeLists.txt
@@ -79,7 +79,6 @@ set(SRCS
     ${OPENMRNPATH}/src/openlcb/TractionTrain.cxx
     ${OPENMRNPATH}/src/openlcb/Velocity.cxx
     ${OPENMRNPATH}/src/openlcb/WriteHelper.cxx
-
     
     ${OPENMRNPATH}/src/os/FakeClock.cxx
     ${OPENMRNPATH}/src/os/logging_malloc.cxx
@@ -90,6 +89,8 @@ set(SRCS
     ${OPENMRNPATH}/src/os/stack_malloc.c
     ${OPENMRNPATH}/src/os/TempFile.cxx
     ${OPENMRNPATH}/src/os/watchdog.c
+
+    ${OPENMRNPATH}/src/traction_modem/Output.cxx
 
     ${OPENMRNPATH}/src/utils/Base64.cxx
     ${OPENMRNPATH}/src/utils/Blinker.cxx

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -261,6 +261,12 @@ set(TESTS ${TESTS}
     ${OPENMRNPATH}/src/os/FakeClock.cxxtest
     ${OPENMRNPATH}/src/os/OS.cxxtest
 
+    ${OPENMRNPATH}/src/traction_modem/Defs.cxxtest
+    ${OPENMRNPATH}/src/traction_modem/MemorySpace.cxxtest
+    ${OPENMRNPATH}/src/traction_modem/ModemTrain.cxxtest
+    ${OPENMRNPATH}/src/traction_modem/Output.cxxtest
+    ${OPENMRNPATH}/src/traction_modem/RxTxFlow.cxxtest
+
     ${OPENMRNPATH}/src/utils/async_if_test_helper.cxxtest
     ${OPENMRNPATH}/src/utils/BandwidthMerger.cxxtest
     ${OPENMRNPATH}/src/utils/Base64.cxxtest

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,6 +101,8 @@ set(SOURCES
     ${OPENMRNPATH}/src/os/TempFile.cxx
     ${OPENMRNPATH}/src/os/watchdog.c
 
+    ${OPENMRNPATH}/src/traction_modem/Output.cxx
+
     ${OPENMRNPATH}/src/utils/Base64.cxx
     ${OPENMRNPATH}/src/utils/Blinker.cxx
     ${OPENMRNPATH}/src/utils/Buffer.cxx

--- a/src/traction_modem/Defs.cxxtest
+++ b/src/traction_modem/Defs.cxxtest
@@ -88,17 +88,17 @@ TEST(DefsTest, GetWirelessPresentPayload)
 //
 // GetOutputStatePayload
 //
-TEST(DefsTest, GetOutputStatePayload)
+TEST(DefsTest, GetOutputStateQueryPayload)
 {
     Defs::Payload result;
     Defs::Payload expected;
 
-    result = Defs::get_output_state_payload(1);
+    result = Defs::get_output_state_query_payload(1);
     expected = "\x41\xd2\xc3\x7a"s "\x03\x01"s "\x00\x02"s "\x00\x01"s;
     append_expected_crc(&expected);
     EXPECT_EQ(expected, result);
 
-    result = Defs::get_output_state_payload(256);
+    result = Defs::get_output_state_query_payload(256);
     expected = "\x41\xd2\xc3\x7a"s "\x03\x01"s "\x00\x02"s "\x01\x00"s;
     append_expected_crc(&expected);
     EXPECT_EQ(expected, result);

--- a/src/traction_modem/Defs.cxxtest
+++ b/src/traction_modem/Defs.cxxtest
@@ -86,6 +86,25 @@ TEST(DefsTest, GetWirelessPresentPayload)
 }
 
 //
+// GetOutputStatePayload
+//
+TEST(DefsTest, GetOutputStatePayload)
+{
+    Defs::Payload result;
+    Defs::Payload expected;
+
+    result = Defs::get_output_state_payload(1);
+    expected = "\x41\xd2\xc3\x7a"s "\x03\x01"s "\x00\x02"s "\x00\x01"s;
+    append_expected_crc(&expected);
+    EXPECT_EQ(expected, result);
+
+    result = Defs::get_output_state_payload(256);
+    expected = "\x41\xd2\xc3\x7a"s "\x03\x01"s "\x00\x02"s "\x01\x00"s;
+    append_expected_crc(&expected);
+    EXPECT_EQ(expected, result);
+}
+
+//
 // GetFnSetPayload
 //
 TEST(DefsTest, GetFnSetPayload)

--- a/src/traction_modem/Defs.hxx
+++ b/src/traction_modem/Defs.hxx
@@ -59,20 +59,23 @@ struct Defs
     /// Command values.
     enum Command : uint16_t
     {
-        CMD_PING              = 0x0000, ///< ping
-        CMD_NOP               = 0x0001, ///< no-operation (do nothing)
-        CMD_REBOOT            = 0x0002, ///< reboot request
-        CMD_BAUD_RATE_QUERY   = 0x0003, ///< query the supported baud rates
-        CMD_BAUD_RATE_REQUEST = 0x0004, ///< request a specific baud rate
-        CMD_SPEED_SET         = 0x0100, ///< set velocity
-        CMD_FN_SET            = 0x0101, ///< set function
-        CMD_ESTOP_SET         = 0x0102, ///< emergency stop request
-        CMD_SPEED_QUERY       = 0x0110, ///< query current speed
-        CMD_FN_QUERY          = 0x0111, ///< query function status
-        CMD_DC_DCC_PRESENT    = 0x0200, ///< DC/DCC present
-        CMD_WIRELESS_PRESENT  = 0x0201, ///< wireless present
-        CMD_MEM_R             = 0x1000, ///< memory read
-        CMD_MEM_W             = 0x1001, ///< memory write
+        CMD_PING               = 0x0000, ///< ping
+        CMD_NOP                = 0x0001, ///< no-operation (do nothing)
+        CMD_REBOOT             = 0x0002, ///< reboot request
+        CMD_BAUD_RATE_QUERY    = 0x0003, ///< query the supported baud rates
+        CMD_BAUD_RATE_REQUEST  = 0x0004, ///< request a specific baud rate
+        CMD_SPEED_SET          = 0x0100, ///< set velocity
+        CMD_FN_SET             = 0x0101, ///< set function
+        CMD_ESTOP_SET          = 0x0102, ///< emergency stop request
+        CMD_SPEED_QUERY        = 0x0110, ///< query current speed
+        CMD_FN_QUERY           = 0x0111, ///< query function status
+        CMD_DC_DCC_PRESENT     = 0x0200, ///< DC/DCC present
+        CMD_WIRELESS_PRESENT   = 0x0201, ///< wireless present
+        CMD_OUTPUT_STATE       = 0x0300, ///< command the output state
+        CMD_OUTPUT_STATE_QUERY = 0x0301, ///< query the output state
+        CMD_OUTPUT_RESTART     = 0x0302, ///< synchronize/restart the output
+        CMD_MEM_R              = 0x1000, ///< memory read
+        CMD_MEM_W              = 0x1001, ///< memory write
 
         //
         // response commands
@@ -95,6 +98,8 @@ struct Defs
         RESP_DC_DCC_PRESENT   = RESPONSE | CMD_DC_DCC_PRESENT,
         /// wireless present response
         RESP_WIRELESS_PRESENT = RESPONSE | CMD_WIRELESS_PRESENT,
+        /// Output state query response
+        RESP_OUTPUT_STATE_QUERY = RESPONSE | CMD_OUTPUT_STATE_QUERY,
         /// memory read response
         RESP_MEM_R            = RESPONSE | CMD_MEM_R,
         /// memory write response
@@ -188,6 +193,14 @@ struct Defs
         {
             return !(all_ == c.all_ && even_ == c.even_ && odd_ == c.odd_);
         }
+    };
+
+    /// Structure of an output state command
+    struct OutputState
+    {
+        Header header_; ///< packet header
+        uint16_t output_; ///< output number
+        uint16_t effect_; ///< 0 = off, 0xFFFF = on, else effect
     };
 
     /// Structure of a read reply packet

--- a/src/traction_modem/Defs.hxx
+++ b/src/traction_modem/Defs.hxx
@@ -130,6 +130,8 @@ struct Defs
     static constexpr unsigned LEN_ESTOP_SET = 0;
     /// Length of the data payload of a wireless present packet.
     static constexpr unsigned LEN_WIRELESS_PRESENT = 1;
+    /// Length of the data payload of an output state queue packet.
+    static constexpr unsigned LEN_OUTPUT_STATE_QUERY = 2;
     /// Length of the data payload of a set estop packet.
     static constexpr unsigned LEN_MEM_R = 6;
     /// Base length of the data, add the number of payload bytes.
@@ -203,6 +205,22 @@ struct Defs
         uint16_t effect_; ///< 0 = off, 0xFFFF = on, else effect
     };
 
+    /// Structure of an output state query response
+    struct OutputStateQueryResponse
+    {
+        Header header_; ///< packet header
+        uint16_t error_; ///< error code
+        uint16_t output_; ///< output number
+        uint16_t effect_; ///< 0 = off, 0xFFFF = on, else effect
+    };
+
+    /// Structure of an output restart command (synchronize lighting effect)
+    struct OutputRestart
+    {
+        Header header_; ///< packet header
+        uint16_t output_; ///< output number
+    };
+
     /// Structure of a read reply packet
     struct ReadResponse
     {
@@ -240,6 +258,19 @@ struct Defs
         Payload p;
         prepare(&p, CMD_WIRELESS_PRESENT, LEN_WIRELESS_PRESENT);
         append_uint8(&p, is_present ? 1 : 0);
+
+        append_crc(&p);
+        return p;
+    }
+
+    /// Computes the payload to query for the current output state
+    /// @param output output number
+    /// @return wire formatted payload
+    static Payload get_output_state_payload(uint16_t output)
+    {
+        Payload p;
+        prepare(&p, CMD_OUTPUT_STATE_QUERY, LEN_OUTPUT_STATE_QUERY);
+        append_uint16(&p, output);
 
         append_crc(&p);
         return p;

--- a/src/traction_modem/MemorySpace.cxxtest
+++ b/src/traction_modem/MemorySpace.cxxtest
@@ -1,51 +1,13 @@
 #include "utils/test_main.hxx"
 
+#include "traction_modem/modem_test_helper.hxx"
+
 #include "traction_modem/MemorySpace.hxx"
 
 #include "os/FakeClock.hxx"
 
 namespace traction_modem
 {
-
-//
-// Mock objects.
-//
-class MockRxFlow : public RxInterface
-{
-public:
-    MOCK_METHOD1(start, void(int));
-    MOCK_METHOD3(register_handler,
-        void(PacketFlowInterface*, Message::id_type, Message::id_type));
-    MOCK_METHOD3(unregister_handler,
-        void(PacketFlowInterface*, Message::id_type, Message::id_type));
-    MOCK_METHOD1(unregister_handler_all, void(PacketFlowInterface*));
-};
-
-class MyMockRxFlow : public MockRxFlow
-{
-public:
-    void register_handler(PacketFlowInterface *interface, Message::id_type id,
-        Message::id_type mask = Message::EXACT_MASK) override
-    {
-        dispatcher_.register_handler(interface, id, mask);
-        MockRxFlow::register_handler(interface, id, mask);
-    }
- 
-    void unregister_handler_all(PacketFlowInterface *interface) override
-    {
-        dispatcher_.unregister_handler_all(interface);
-        MockRxFlow::unregister_handler_all(interface);
-    }
-
-    DispatchFlow<Buffer<Message>, 2> dispatcher_{&g_service};
-};
-
-class MockTxFlow : public TxInterface
-{
-public:
-    MOCK_METHOD1(start, void(int));
-    MOCK_METHOD1(send_packet, void(Defs::Payload));
-};
 
 /// Test object for memory spaces.
 class MemorySpaceTest : public ::testing::Test

--- a/src/traction_modem/ModemTrain.cxxtest
+++ b/src/traction_modem/ModemTrain.cxxtest
@@ -1,31 +1,11 @@
 #include "utils/test_main.hxx"
 
+#include "traction_modem/modem_test_helper.hxx"
+
 #include "traction_modem/ModemTrain.hxx"
-#include "traction_modem/ModemTrainHwInterface.hxx"
 
 namespace traction_modem
 {
-
-//
-// Mock objects.
-//
-class MockRxFlow : public RxInterface
-{
-public:
-    MOCK_METHOD1(start, void(int));
-    MOCK_METHOD3(register_handler,
-        void(PacketFlowInterface*, Message::id_type, Message::id_type));
-    MOCK_METHOD3(unregister_handler,
-        void(PacketFlowInterface*, Message::id_type, Message::id_type));
-    MOCK_METHOD1(unregister_handler_all, void(PacketFlowInterface*));
-};
-
-class MockTxFlow : public TxInterface
-{
-public:
-    MOCK_METHOD1(start, void(int));
-    MOCK_METHOD1(send_packet, void(Defs::Payload));
-};
 
 /// Test object for the ModemTrain.
 class ModemTrainTest : public ::testing::Test
@@ -41,7 +21,7 @@ protected:
             .Times(1);
         EXPECT_CALL(mRxFlow_,
             register_handler(_, Defs::RESP_OUTPUT_STATE_QUERY, _)).Times(1);
-        train_ = new ModemTrain(&g_service, &mTxFlow_, &mRxFlow_, &hwIf_);
+        train_ = new ModemTrain(&g_service, &mTxFlow_, &mRxFlow_, &mHwIf_);
         testing::Mock::VerifyAndClearExpectations(&mRxFlow_);
     }
 
@@ -56,7 +36,7 @@ protected:
 
     ::testing::StrictMock<MockRxFlow> mRxFlow_;
     ::testing::StrictMock<MockTxFlow> mTxFlow_;
-    ModemTrainHwInterface hwIf_;
+    ::testing::StrictMock<ModemTrainHwInterface> mHwIf_;
     ModemTrain *train_; ///< modem train instance
 };
 

--- a/src/traction_modem/ModemTrain.cxxtest
+++ b/src/traction_modem/ModemTrain.cxxtest
@@ -1,6 +1,7 @@
 #include "utils/test_main.hxx"
 
 #include "traction_modem/ModemTrain.hxx"
+#include "traction_modem/ModemTrainHwInterface.hxx"
 
 namespace traction_modem
 {
@@ -40,7 +41,7 @@ protected:
             .Times(1);
         EXPECT_CALL(mRxFlow_,
             register_handler(_, Defs::RESP_OUTPUT_STATE_QUERY, _)).Times(1);
-        train_ = new ModemTrain(&g_service, &mTxFlow_, &mRxFlow_);
+        train_ = new ModemTrain(&g_service, &mTxFlow_, &mRxFlow_, &hwIf_);
         testing::Mock::VerifyAndClearExpectations(&mRxFlow_);
     }
 
@@ -55,6 +56,7 @@ protected:
 
     ::testing::StrictMock<MockRxFlow> mRxFlow_;
     ::testing::StrictMock<MockTxFlow> mTxFlow_;
+    ModemTrainHwInterface hwIf_;
     ModemTrain *train_; ///< modem train instance
 };
 

--- a/src/traction_modem/ModemTrain.cxxtest
+++ b/src/traction_modem/ModemTrain.cxxtest
@@ -32,18 +32,26 @@ class ModemTrainTest : public ::testing::Test
 protected:
     /// Constructor.
     ModemTrainTest()
-        : train_(&g_service, &mTxFlow_, &mRxFlow_)
     {
+        using ::testing::_;
+        EXPECT_CALL(
+            mRxFlow_, register_handler(_, Defs::CMD_OUTPUT_STATE, _)).Times(1);
+        train_ = new ModemTrain(&g_service, &mTxFlow_, &mRxFlow_);
+        testing::Mock::VerifyAndClearExpectations(&mRxFlow_);
     }
 
     /// Destructor.
     ~ModemTrainTest()
     {
+        testing::Mock::VerifyAndClearExpectations(&mRxFlow_);
+        using ::testing::_;
+        EXPECT_CALL(mRxFlow_, unregister_handler_all(_)).Times(1);
+        delete train_;
     }
 
     ::testing::StrictMock<MockRxFlow> mRxFlow_;
     ::testing::StrictMock<MockTxFlow> mTxFlow_;
-    ModemTrain train_; ///< modem train instance
+    ModemTrain *train_; ///< modem train instance
 };
 
 TEST_F(ModemTrainTest, Create)
@@ -54,13 +62,13 @@ TEST_F(ModemTrainTest, Start)
 {
     EXPECT_CALL(mRxFlow_, start(9)).Times(1);
     EXPECT_CALL(mTxFlow_, start(9)).Times(1);
-    train_.start(9);
+    train_->start(9);
 }
 
 TEST_F(ModemTrainTest, GetFlow)
 {
-    EXPECT_EQ(&mTxFlow_, train_.get_tx_flow());
-    EXPECT_EQ(&mRxFlow_, train_.get_rx_flow());
+    EXPECT_EQ(&mTxFlow_, train_->get_tx_flow());
+    EXPECT_EQ(&mRxFlow_, train_->get_rx_flow());
 }
 
 TEST_F(ModemTrainTest, Set_Is_Active)
@@ -70,12 +78,12 @@ TEST_F(ModemTrainTest, Set_Is_Active)
 
     EXPECT_CALL(mTxFlow_, send_packet(StartsWith(
         "\x41\xD2\xC3\x7A\x02\x01\x00\x01\x01"s))).Times(1);
-    train_.set_is_active(true);
+    train_->set_is_active(true);
     testing::Mock::VerifyAndClearExpectations(&mTxFlow_);
 
     EXPECT_CALL(mTxFlow_, send_packet(StartsWith(
         "\x41\xD2\xC3\x7A\x02\x01\x00\x01\x00"s))).Times(1);
-    train_.set_is_active(false);
+    train_->set_is_active(false);
 }
 
 TEST_F(ModemTrainTest, Speed)
@@ -96,10 +104,10 @@ TEST_F(ModemTrainTest, Speed)
         "\x41\xD2\xC3\x7A\x01\x00\x00\x01\xB9"s))).Times(1);
     v.set_mph(56);
     v.set_direction(openlcb::Velocity::FORWARD);
-    train_.set_speed(v);
-    estop = train_.get_emergencystop();
+    train_->set_speed(v);
+    estop = train_->get_emergencystop();
     EXPECT_FALSE(estop);
-    lastspeed = train_.get_speed();
+    lastspeed = train_->get_speed();
     EXPECT_EQ(v,lastspeed);
     testing::Mock::VerifyAndClearExpectations(&mTxFlow_);
     }
@@ -109,20 +117,20 @@ TEST_F(ModemTrainTest, Speed)
         "\x41\xD2\xC3\x7A\x01\x00\x00\x01\x0B"s))).Times(1);
     v.set_mph(10);
     v.set_direction(openlcb::Velocity::REVERSE);
-    train_.set_speed(v);
-    estop = train_.get_emergencystop();
+    train_->set_speed(v);
+    estop = train_->get_emergencystop();
     EXPECT_FALSE(estop);
-    lastspeed = train_.get_speed();
+    lastspeed = train_->get_speed();
     EXPECT_EQ(v,lastspeed);
     testing::Mock::VerifyAndClearExpectations(&mTxFlow_);
 
     // Set emergency stop.
     EXPECT_CALL(mTxFlow_, send_packet(StartsWith(
         "\x41\xD2\xC3\x7A\x01\x02\x00\x00"s))).Times(1);
-    train_.set_emergencystop();
-    estop = train_.get_emergencystop();
+    train_->set_emergencystop();
+    estop = train_->get_emergencystop();
     EXPECT_TRUE(estop);
-    lastspeed = train_.get_speed();
+    lastspeed = train_->get_speed();
     v.set_mph(0); // keeps direction
     EXPECT_EQ(v,lastspeed);
     testing::Mock::VerifyAndClearExpectations(&mTxFlow_);
@@ -131,10 +139,10 @@ TEST_F(ModemTrainTest, Speed)
     EXPECT_CALL(mTxFlow_, send_packet(StartsWith(
         "\x41\xD2\xC3\x7A\x01\x00\x00\x01\x80"s))).Times(1);
     v.set_direction(openlcb::Velocity::FORWARD);
-    train_.set_speed(v);
-    estop = train_.get_emergencystop();
+    train_->set_speed(v);
+    estop = train_->get_emergencystop();
     EXPECT_FALSE(estop);
-    lastspeed = train_.get_speed();
+    lastspeed = train_->get_speed();
     EXPECT_EQ(v,lastspeed);
 }
 
@@ -153,12 +161,12 @@ TEST_F(ModemTrainTest, Function)
         "\x41\xD2\xC3\x7A\x02\x01\x00\x01\x01"s))).Times(1);
     EXPECT_CALL(mTxFlow_, send_packet(StartsWith(
         "\x41\xD2\xC3\x7A\x01\x01\x00\x06\x00\x00\x00\x00\x00\x01"s))).Times(1);
-    train_.set_fn(address,value);
+    train_->set_fn(address,value);
     testing::Mock::VerifyAndClearExpectations(&mTxFlow_);
     }
 
     // Get function.
-    value = train_.get_fn(address);
+    value = train_->get_fn(address);
     EXPECT_EQ(0 ,value);
 }
 
@@ -168,11 +176,11 @@ TEST_F(ModemTrainTest, Legacy_Address)
     dcc::TrainAddressType type;
 
     // Get address value.
-    address = train_.legacy_address();
+    address = train_->legacy_address();
     EXPECT_EQ(883U ,address);
 
     // Get address type.
-    type = train_.legacy_address_type();
+    type = train_->legacy_address_type();
     EXPECT_EQ(dcc::TrainAddressType::DCC_LONG_ADDRESS,type);
 }
 

--- a/src/traction_modem/ModemTrain.cxxtest
+++ b/src/traction_modem/ModemTrain.cxxtest
@@ -34,8 +34,12 @@ protected:
     ModemTrainTest()
     {
         using ::testing::_;
-        EXPECT_CALL(
-            mRxFlow_, register_handler(_, Defs::CMD_OUTPUT_STATE, _)).Times(1);
+        EXPECT_CALL(mRxFlow_, register_handler(_, Defs::CMD_OUTPUT_STATE, _))
+            .Times(1);
+        EXPECT_CALL(mRxFlow_, register_handler(_, Defs::CMD_OUTPUT_RESTART, _))
+            .Times(1);
+        EXPECT_CALL(mRxFlow_,
+            register_handler(_, Defs::RESP_OUTPUT_STATE_QUERY, _)).Times(1);
         train_ = new ModemTrain(&g_service, &mTxFlow_, &mRxFlow_);
         testing::Mock::VerifyAndClearExpectations(&mRxFlow_);
     }

--- a/src/traction_modem/ModemTrain.hxx
+++ b/src/traction_modem/ModemTrain.hxx
@@ -47,7 +47,25 @@
 namespace traction_modem
 {
 
-class ModemTrain : public openlcb::TrainImpl
+/// Virtual interface for a ModemTrain.
+class ModemTrainInterface
+{
+public:
+    /// Set an output state.
+    /// @param output output number
+    /// @param effect 0 = off, 0xFFFF = on, else effect
+    virtual void output_state(uint16_t output, uint16_t effect)
+    {
+    }
+
+    /// Restart an output (synchronize lighting effect).
+    /// @param output output number
+    virtual void output_restart(uint16_t output)
+    {
+    }
+};
+
+class ModemTrain : public ModemTrainInterface, public openlcb::TrainImpl
 {
 public:
     /// Constructor.
@@ -60,9 +78,7 @@ public:
         , rxFlow_(rx_flow)
         , cvSpace_(service, tx_flow, rx_flow)
         , fuSpace_(service, tx_flow, rx_flow)
-        , output_(tx_flow, rx_flow, std::bind(
-            &ModemTrain::set_output, this, std::placeholders::_1,
-            std::placeholders::_2))
+        , output_(tx_flow, rx_flow, this)
         , isActive_(false)
     {
     }
@@ -151,13 +167,6 @@ public:
     bool get_emergencystop() override
     {
         return inEStop_;
-    }
-
-    /// Set an output state.
-    /// @param output output number
-    /// @param effect 0 = off, 0xFFFF = on, else effect
-    virtual void set_output(uint16_t output, uint16_t effect)
-    {
     }
 
     /// Sets the value of a function.

--- a/src/traction_modem/ModemTrain.hxx
+++ b/src/traction_modem/ModemTrain.hxx
@@ -24,7 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @file Train.hxx
+ * @file ModemTrain.hxx
  *
  * Implements a Traction Modem Train.
  *
@@ -34,8 +34,6 @@
 
 #ifndef _TRACTION_MODEM_TRAIN_HXX_
 #define _TRACTION_MODEM_TRAIN_HXX_
-
-#include <functional>
 
 #include "openlcb/TrainInterface.hxx"
 #include "traction_modem/Defs.hxx"
@@ -47,38 +45,25 @@
 namespace traction_modem
 {
 
-/// Virtual interface for a ModemTrain.
-class ModemTrainInterface
-{
-public:
-    /// Set an output state.
-    /// @param output output number
-    /// @param effect 0 = off, 0xFFFF = on, else effect
-    virtual void output_state(uint16_t output, uint16_t effect)
-    {
-    }
+// Forward declaration
+class ModemTrainHwInterface;
 
-    /// Restart an output (synchronize lighting effect).
-    /// @param output output number
-    virtual void output_restart(uint16_t output)
-    {
-    }
-};
-
-class ModemTrain : public ModemTrainInterface, public openlcb::TrainImpl
+/// ModemTrain definition.
+class ModemTrain : public openlcb::TrainImpl
 {
 public:
     /// Constructor.
     /// @param service Service instance to bind this flow to.
     /// @param tx_flow reference to the transmit flow
     /// @param rx_flow reference to the receive flow
-    ModemTrain(
-        Service *service, TxInterface *tx_flow, RxInterface *rx_flow)
+    /// @param hw_interface hardware specific interface to the modem train.
+    ModemTrain(Service *service, TxInterface *tx_flow, RxInterface *rx_flow,
+        ModemTrainHwInterface *hw_interface)
         : txFlow_(tx_flow)
         , rxFlow_(rx_flow)
         , cvSpace_(service, tx_flow, rx_flow)
         , fuSpace_(service, tx_flow, rx_flow)
-        , output_(tx_flow, rx_flow, this)
+        , output_(tx_flow, rx_flow, hw_interface)
         , isActive_(false)
     {
     }

--- a/src/traction_modem/ModemTrainHwInterface.hxx
+++ b/src/traction_modem/ModemTrainHwInterface.hxx
@@ -1,6 +1,6 @@
 /** @copyright
  * Copyright (c) 2025, Stuart Baker
- * All rights reserved.
+ * All rights reserved
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are  permitted provided that the following conditions are met:
@@ -24,51 +24,38 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @file Output.hxx
+ * @file ModemTrainHwInterface.hxx
  *
- * Logic for interacting with outputs.
+ * Provides an abstract modem train interface for hardware specific logic
  *
  * @author Stuart Baker
- * @date 17 May 2025
+ * @date 22 May 2025
  */
 
-#ifndef _TRACTION_MODEM_OUTPUT_HXX_
-#define _TRACTION_MODEM_OUTPUT_HXX_
-
-#include "traction_modem/Message.hxx"
+#ifndef _TRACTION_MODEMTRAINHWINTERFACE_HXX_
+#define _TRACTION_MODEMTRAINHWINTERFACE_HXX_
 
 namespace traction_modem
 {
 
-// Forward declarations.
-class ModemTrainHwInterface;
-class TxInterface;
-class RxInterface;
-
-/// Object for handling output messages.
-class Output : public PacketFlowInterface
+    // Virtual interface for a ModemTrain.
+class ModemTrainHwInterface
 {
 public:
-    /// Constructor.
-    /// @param tx_flow reference to the transmit flow
-    /// @param rx_flow reference to the receive flow
-    /// @param hw_interface hardware specific interface to the modem train.
-    Output(TxInterface *tx_flow, RxInterface *rx_flow,
-        ModemTrainHwInterface *hw_interface);
+    /// Set an output state.
+    /// @param output output number
+    /// @param effect 0 = off, 0xFFFF = on, else effect
+    virtual void output_state(uint16_t output, uint16_t effect)
+    {
+    }
 
-    /// Destructor.
-    ~Output();
-
-private:
-    /// Receive for output commands.
-    /// @buf incoming message
-    /// @prio message priority
-    void send(Buffer<Message> *buf, unsigned prio) override;
-
-    RxInterface *rxFlow_; ///< reference to the receive flow
-    ModemTrainHwInterface *hwIf_; ///< hardware specific interface
+    /// Restart an output (synchronize lighting effect).
+    /// @param output output number
+    virtual void output_restart(uint16_t output)
+    {
+    }
 };
 
 } // namespace traction_modem
 
-#endif // _TRACTION_MODEM_OUTPUT_HXX_
+#endif // _TRACTION_MODEMTRAINHWINTERFACE_HXX_

--- a/src/traction_modem/ModemTrainHwInterface.hxx
+++ b/src/traction_modem/ModemTrainHwInterface.hxx
@@ -38,7 +38,7 @@
 namespace traction_modem
 {
 
-    // Virtual interface for a ModemTrain.
+/// Virtual interface for hardware access needed for a ModemTrain.
 class ModemTrainHwInterface
 {
 public:

--- a/src/traction_modem/Output.cxx
+++ b/src/traction_modem/Output.cxx
@@ -66,10 +66,12 @@ void Output::send(Buffer<Message> *buf, unsigned prio)
             break;
         }
         case Defs::CMD_OUTPUT_RESTART:
+        {
             Defs::OutputRestart *o_restart =
                 (Defs::OutputRestart*)b->data()->payload.data();
             train_->output_restart(be16toh(o_restart->output_));
             break;
+        }
     }
 }
 

--- a/src/traction_modem/Output.cxx
+++ b/src/traction_modem/Output.cxx
@@ -32,9 +32,10 @@
  * @date 17 May 2025
  */
 
- #include "traction_modem/Output.hxx"
+#include "traction_modem/Output.hxx"
 
- #include "traction_modem/ModemTrain.hxx"
+#include "traction_modem/ModemTrain.hxx"
+
 namespace traction_modem
 {
 

--- a/src/traction_modem/Output.cxxtest
+++ b/src/traction_modem/Output.cxxtest
@@ -1,6 +1,7 @@
 #include "utils/test_main.hxx"
 
 #include "traction_modem/Output.hxx"
+#include "traction_modem/ModemTrain.hxx"
 
 namespace traction_modem
 {
@@ -45,10 +46,11 @@ public:
     MOCK_METHOD1(send_packet, void(Defs::Payload));
 };
 
-class MockOutputCallback
+class MockTrain : public ModemTrainInterface
 {
 public:
-    MOCK_METHOD2(set_output, void(uint16_t, uint16_t));
+    MOCK_METHOD2(output_state, void(uint16_t, uint16_t));
+    MOCK_METHOD1(output_restart, void(uint16_t));
 };
 
 /// Test object for memory spaces.
@@ -59,11 +61,13 @@ protected:
     OutputTest()
     {
         using ::testing::_;
-        EXPECT_CALL(
-            mRxFlow_, register_handler(_, Defs::CMD_OUTPUT_STATE, _)).Times(1);
-        output_ = new Output(&mTxFlow_, &mRxFlow_, std::bind(
-            &MockOutputCallback::set_output, &mOutCback_,
-            std::placeholders::_1, std::placeholders::_2));
+        EXPECT_CALL(mRxFlow_, register_handler(_, Defs::CMD_OUTPUT_STATE, _))
+            .Times(1);
+        EXPECT_CALL(mRxFlow_, register_handler(_, Defs::CMD_OUTPUT_RESTART, _))
+            .Times(1);
+        EXPECT_CALL(mRxFlow_,
+            register_handler(_, Defs::RESP_OUTPUT_STATE_QUERY, _)).Times(1);
+        output_ = new Output(&mTxFlow_, &mRxFlow_, &mTrain_);
         testing::Mock::VerifyAndClearExpectations(&mRxFlow_);
     }
 
@@ -79,7 +83,7 @@ protected:
 
     ::testing::StrictMock<MyMockRxFlow> mRxFlow_; ///< mock receive flow
     ::testing::StrictMock<MockTxFlow> mTxFlow_; ///< mock transmit flow
-    ::testing::StrictMock<MockOutputCallback> mOutCback_; ///< mock callback
+    ::testing::StrictMock<MockTrain> mTrain_; ///< mock train
     Output *output_; ///< output instance
 };
 
@@ -90,7 +94,7 @@ TEST_F(OutputTest, Create)
 TEST_F(OutputTest, OutputState)
 {
     // Output 0, value 0
-    EXPECT_CALL(mOutCback_, set_output(0, 0)).Times(1);
+    EXPECT_CALL(mTrain_, output_state(0, 0)).Times(1);
     {
         auto *b = mRxFlow_.dispatcher_.alloc();
         Defs::prepare(&b->data()->payload, Defs::CMD_OUTPUT_STATE, 4);
@@ -100,10 +104,10 @@ TEST_F(OutputTest, OutputState)
         mRxFlow_.dispatcher_.send(b);
         wait_for_main_executor();
     }
-    testing::Mock::VerifyAndClearExpectations(&mOutCback_);
+    testing::Mock::VerifyAndClearExpectations(&mTrain_);
 
     // Output 25, value 55
-    EXPECT_CALL(mOutCback_, set_output(25, 55)).Times(1);
+    EXPECT_CALL(mTrain_, output_state(25, 55)).Times(1);
     {
         auto *b = mRxFlow_.dispatcher_.alloc();
         Defs::prepare(&b->data()->payload, Defs::CMD_OUTPUT_STATE, 4);
@@ -113,7 +117,81 @@ TEST_F(OutputTest, OutputState)
         mRxFlow_.dispatcher_.send(b);
         wait_for_main_executor();
     }
-    testing::Mock::VerifyAndClearExpectations(&mOutCback_);
+    testing::Mock::VerifyAndClearExpectations(&mTrain_);
+}
+
+TEST_F(OutputTest, OutputStateQueryResponse)
+{
+    using ::testing::_;
+
+    // No error, Output 0, value 0
+    EXPECT_CALL(mTrain_, output_state(0, 0)).Times(1);
+    {
+        auto *b = mRxFlow_.dispatcher_.alloc();
+        Defs::prepare(&b->data()->payload, Defs::RESP_OUTPUT_STATE_QUERY, 6);
+        Defs::append_uint16(&b->data()->payload, 0);
+        Defs::append_uint16(&b->data()->payload, 0);
+        Defs::append_uint16(&b->data()->payload, 0);
+        Defs::append_crc(&b->data()->payload);
+        mRxFlow_.dispatcher_.send(b);
+        wait_for_main_executor();
+    }
+    testing::Mock::VerifyAndClearExpectations(&mTrain_);
+
+    // No error, Output 25, value 55
+    EXPECT_CALL(mTrain_, output_state(25, 55)).Times(1);
+    {
+        auto *b = mRxFlow_.dispatcher_.alloc();
+        Defs::prepare(&b->data()->payload, Defs::RESP_OUTPUT_STATE_QUERY, 6);
+        Defs::append_uint16(&b->data()->payload, 0);
+        Defs::append_uint16(&b->data()->payload, 25);
+        Defs::append_uint16(&b->data()->payload, 55);
+        Defs::append_crc(&b->data()->payload);
+        mRxFlow_.dispatcher_.send(b);
+        wait_for_main_executor();
+    }
+    testing::Mock::VerifyAndClearExpectations(&mTrain_);
+
+    // Unsupported, Output 25, value 55
+    EXPECT_CALL(mTrain_, output_state(_, _)).Times(0);
+    {
+        auto *b = mRxFlow_.dispatcher_.alloc();
+        Defs::prepare(&b->data()->payload, Defs::RESP_OUTPUT_STATE_QUERY, 6);
+        Defs::append_uint16(&b->data()->payload, 0x1001);
+        Defs::append_uint16(&b->data()->payload, 25);
+        Defs::append_uint16(&b->data()->payload, 55);
+        Defs::append_crc(&b->data()->payload);
+        mRxFlow_.dispatcher_.send(b);
+        wait_for_main_executor();
+    }
+    testing::Mock::VerifyAndClearExpectations(&mTrain_);
+}
+
+TEST_F(OutputTest, OutputRestart)
+{
+    // Output 0, value 0
+    EXPECT_CALL(mTrain_, output_restart(0)).Times(1);
+    {
+        auto *b = mRxFlow_.dispatcher_.alloc();
+        Defs::prepare(&b->data()->payload, Defs::CMD_OUTPUT_RESTART, 4);
+        Defs::append_uint16(&b->data()->payload, 0);
+        Defs::append_crc(&b->data()->payload);
+        mRxFlow_.dispatcher_.send(b);
+        wait_for_main_executor();
+    }
+    testing::Mock::VerifyAndClearExpectations(&mTrain_);
+
+    // Output 25, value 55
+    EXPECT_CALL(mTrain_, output_restart(25)).Times(1);
+    {
+        auto *b = mRxFlow_.dispatcher_.alloc();
+        Defs::prepare(&b->data()->payload, Defs::CMD_OUTPUT_RESTART, 4);
+        Defs::append_uint16(&b->data()->payload, 25);
+        Defs::append_crc(&b->data()->payload);
+        mRxFlow_.dispatcher_.send(b);
+        wait_for_main_executor();
+    }
+    testing::Mock::VerifyAndClearExpectations(&mTrain_);
 }
 
 } // namespace traction_modem

--- a/src/traction_modem/Output.cxxtest
+++ b/src/traction_modem/Output.cxxtest
@@ -1,61 +1,13 @@
 #include "utils/test_main.hxx"
 
+#include "traction_modem/modem_test_helper.hxx"
+
 #include "traction_modem/Output.hxx"
-#include "traction_modem/ModemTrainHwInterface.hxx"
-#include "traction_modem/RxFlow.hxx"
-#include "traction_modem/TxFlow.hxx"
 
 namespace traction_modem
 {
 
-//
-// Mock objects.
-//
-class MockRxFlow : public RxInterface
-{
-public:
-    MOCK_METHOD1(start, void(int));
-    MOCK_METHOD3(register_handler,
-        void(PacketFlowInterface*, Message::id_type, Message::id_type));
-    MOCK_METHOD3(unregister_handler,
-        void(PacketFlowInterface*, Message::id_type, Message::id_type));
-    MOCK_METHOD1(unregister_handler_all, void(PacketFlowInterface*));
-};
-
-class MyMockRxFlow : public MockRxFlow
-{
-public:
-    void register_handler(PacketFlowInterface *interface, Message::id_type id,
-        Message::id_type mask = Message::EXACT_MASK) override
-    {
-        dispatcher_.register_handler(interface, id, mask);
-        MockRxFlow::register_handler(interface, id, mask);
-    }
- 
-    void unregister_handler_all(PacketFlowInterface *interface) override
-    {
-        dispatcher_.unregister_handler_all(interface);
-        MockRxFlow::unregister_handler_all(interface);
-    }
-
-    DispatchFlow<Buffer<Message>, 2> dispatcher_{&g_service};
-};
-
-class MockTxFlow : public TxInterface
-{
-public:
-    MOCK_METHOD1(start, void(int));
-    MOCK_METHOD1(send_packet, void(Defs::Payload));
-};
-
-class MockTrainHwInterface : public ModemTrainHwInterface
-{
-public:
-    MOCK_METHOD2(output_state, void(uint16_t, uint16_t));
-    MOCK_METHOD1(output_restart, void(uint16_t));
-};
-
-/// Test object for memory spaces.
+/// Test object for outputs.
 class OutputTest : public ::testing::Test
 {
 protected:

--- a/src/traction_modem/Output.cxxtest
+++ b/src/traction_modem/Output.cxxtest
@@ -1,7 +1,9 @@
 #include "utils/test_main.hxx"
 
 #include "traction_modem/Output.hxx"
-#include "traction_modem/ModemTrain.hxx"
+#include "traction_modem/ModemTrainHwInterface.hxx"
+#include "traction_modem/RxFlow.hxx"
+#include "traction_modem/TxFlow.hxx"
 
 namespace traction_modem
 {
@@ -46,7 +48,7 @@ public:
     MOCK_METHOD1(send_packet, void(Defs::Payload));
 };
 
-class MockTrain : public ModemTrainInterface
+class MockTrainHwInterface : public ModemTrainHwInterface
 {
 public:
     MOCK_METHOD2(output_state, void(uint16_t, uint16_t));
@@ -67,7 +69,7 @@ protected:
             .Times(1);
         EXPECT_CALL(mRxFlow_,
             register_handler(_, Defs::RESP_OUTPUT_STATE_QUERY, _)).Times(1);
-        output_ = new Output(&mTxFlow_, &mRxFlow_, &mTrain_);
+        output_ = new Output(&mTxFlow_, &mRxFlow_, &mHwIf_);
         testing::Mock::VerifyAndClearExpectations(&mRxFlow_);
     }
 
@@ -83,7 +85,7 @@ protected:
 
     ::testing::StrictMock<MyMockRxFlow> mRxFlow_; ///< mock receive flow
     ::testing::StrictMock<MockTxFlow> mTxFlow_; ///< mock transmit flow
-    ::testing::StrictMock<MockTrain> mTrain_; ///< mock train
+    ::testing::StrictMock<MockTrainHwInterface> mHwIf_; ///< mock train hardware
     Output *output_; ///< output instance
 };
 
@@ -94,7 +96,7 @@ TEST_F(OutputTest, Create)
 TEST_F(OutputTest, OutputState)
 {
     // Output 0, value 0
-    EXPECT_CALL(mTrain_, output_state(0, 0)).Times(1);
+    EXPECT_CALL(mHwIf_, output_state(0, 0)).Times(1);
     {
         auto *b = mRxFlow_.dispatcher_.alloc();
         Defs::prepare(&b->data()->payload, Defs::CMD_OUTPUT_STATE, 4);
@@ -104,10 +106,10 @@ TEST_F(OutputTest, OutputState)
         mRxFlow_.dispatcher_.send(b);
         wait_for_main_executor();
     }
-    testing::Mock::VerifyAndClearExpectations(&mTrain_);
+    testing::Mock::VerifyAndClearExpectations(&mHwIf_);
 
     // Output 25, value 55
-    EXPECT_CALL(mTrain_, output_state(25, 55)).Times(1);
+    EXPECT_CALL(mHwIf_, output_state(25, 55)).Times(1);
     {
         auto *b = mRxFlow_.dispatcher_.alloc();
         Defs::prepare(&b->data()->payload, Defs::CMD_OUTPUT_STATE, 4);
@@ -117,7 +119,7 @@ TEST_F(OutputTest, OutputState)
         mRxFlow_.dispatcher_.send(b);
         wait_for_main_executor();
     }
-    testing::Mock::VerifyAndClearExpectations(&mTrain_);
+    testing::Mock::VerifyAndClearExpectations(&mHwIf_);
 }
 
 TEST_F(OutputTest, OutputStateQueryResponse)
@@ -125,7 +127,7 @@ TEST_F(OutputTest, OutputStateQueryResponse)
     using ::testing::_;
 
     // No error, Output 0, value 0
-    EXPECT_CALL(mTrain_, output_state(0, 0)).Times(1);
+    EXPECT_CALL(mHwIf_, output_state(0, 0)).Times(1);
     {
         auto *b = mRxFlow_.dispatcher_.alloc();
         Defs::prepare(&b->data()->payload, Defs::RESP_OUTPUT_STATE_QUERY, 6);
@@ -136,10 +138,10 @@ TEST_F(OutputTest, OutputStateQueryResponse)
         mRxFlow_.dispatcher_.send(b);
         wait_for_main_executor();
     }
-    testing::Mock::VerifyAndClearExpectations(&mTrain_);
+    testing::Mock::VerifyAndClearExpectations(&mHwIf_);
 
     // No error, Output 25, value 55
-    EXPECT_CALL(mTrain_, output_state(25, 55)).Times(1);
+    EXPECT_CALL(mHwIf_, output_state(25, 55)).Times(1);
     {
         auto *b = mRxFlow_.dispatcher_.alloc();
         Defs::prepare(&b->data()->payload, Defs::RESP_OUTPUT_STATE_QUERY, 6);
@@ -150,10 +152,10 @@ TEST_F(OutputTest, OutputStateQueryResponse)
         mRxFlow_.dispatcher_.send(b);
         wait_for_main_executor();
     }
-    testing::Mock::VerifyAndClearExpectations(&mTrain_);
+    testing::Mock::VerifyAndClearExpectations(&mHwIf_);
 
     // Unsupported, Output 25, value 55
-    EXPECT_CALL(mTrain_, output_state(_, _)).Times(0);
+    EXPECT_CALL(mHwIf_, output_state(_, _)).Times(0);
     {
         auto *b = mRxFlow_.dispatcher_.alloc();
         Defs::prepare(&b->data()->payload, Defs::RESP_OUTPUT_STATE_QUERY, 6);
@@ -164,13 +166,13 @@ TEST_F(OutputTest, OutputStateQueryResponse)
         mRxFlow_.dispatcher_.send(b);
         wait_for_main_executor();
     }
-    testing::Mock::VerifyAndClearExpectations(&mTrain_);
+    testing::Mock::VerifyAndClearExpectations(&mHwIf_);
 }
 
 TEST_F(OutputTest, OutputRestart)
 {
     // Output 0, value 0
-    EXPECT_CALL(mTrain_, output_restart(0)).Times(1);
+    EXPECT_CALL(mHwIf_, output_restart(0)).Times(1);
     {
         auto *b = mRxFlow_.dispatcher_.alloc();
         Defs::prepare(&b->data()->payload, Defs::CMD_OUTPUT_RESTART, 4);
@@ -179,10 +181,10 @@ TEST_F(OutputTest, OutputRestart)
         mRxFlow_.dispatcher_.send(b);
         wait_for_main_executor();
     }
-    testing::Mock::VerifyAndClearExpectations(&mTrain_);
+    testing::Mock::VerifyAndClearExpectations(&mHwIf_);
 
     // Output 25, value 55
-    EXPECT_CALL(mTrain_, output_restart(25)).Times(1);
+    EXPECT_CALL(mHwIf_, output_restart(25)).Times(1);
     {
         auto *b = mRxFlow_.dispatcher_.alloc();
         Defs::prepare(&b->data()->payload, Defs::CMD_OUTPUT_RESTART, 4);
@@ -191,7 +193,7 @@ TEST_F(OutputTest, OutputRestart)
         mRxFlow_.dispatcher_.send(b);
         wait_for_main_executor();
     }
-    testing::Mock::VerifyAndClearExpectations(&mTrain_);
+    testing::Mock::VerifyAndClearExpectations(&mHwIf_);
 }
 
 } // namespace traction_modem

--- a/src/traction_modem/Output.cxxtest
+++ b/src/traction_modem/Output.cxxtest
@@ -1,0 +1,119 @@
+#include "utils/test_main.hxx"
+
+#include "traction_modem/Output.hxx"
+
+namespace traction_modem
+{
+
+//
+// Mock objects.
+//
+class MockRxFlow : public RxInterface
+{
+public:
+    MOCK_METHOD1(start, void(int));
+    MOCK_METHOD3(register_handler,
+        void(PacketFlowInterface*, Message::id_type, Message::id_type));
+    MOCK_METHOD3(unregister_handler,
+        void(PacketFlowInterface*, Message::id_type, Message::id_type));
+    MOCK_METHOD1(unregister_handler_all, void(PacketFlowInterface*));
+};
+
+class MyMockRxFlow : public MockRxFlow
+{
+public:
+    void register_handler(PacketFlowInterface *interface, Message::id_type id,
+        Message::id_type mask = Message::EXACT_MASK) override
+    {
+        dispatcher_.register_handler(interface, id, mask);
+        MockRxFlow::register_handler(interface, id, mask);
+    }
+ 
+    void unregister_handler_all(PacketFlowInterface *interface) override
+    {
+        dispatcher_.unregister_handler_all(interface);
+        MockRxFlow::unregister_handler_all(interface);
+    }
+
+    DispatchFlow<Buffer<Message>, 2> dispatcher_{&g_service};
+};
+
+class MockTxFlow : public TxInterface
+{
+public:
+    MOCK_METHOD1(start, void(int));
+    MOCK_METHOD1(send_packet, void(Defs::Payload));
+};
+
+class MockOutputCallback
+{
+public:
+    MOCK_METHOD2(set_output, void(uint16_t, uint16_t));
+};
+
+/// Test object for memory spaces.
+class OutputTest : public ::testing::Test
+{
+protected:
+    /// Constructor.
+    OutputTest()
+    {
+        using ::testing::_;
+        EXPECT_CALL(
+            mRxFlow_, register_handler(_, Defs::CMD_OUTPUT_STATE, _)).Times(1);
+        output_ = new Output(&mTxFlow_, &mRxFlow_, std::bind(
+            &MockOutputCallback::set_output, &mOutCback_,
+            std::placeholders::_1, std::placeholders::_2));
+        testing::Mock::VerifyAndClearExpectations(&mRxFlow_);
+    }
+
+    /// Destructor.
+    ~OutputTest()
+    {
+        testing::Mock::VerifyAndClearExpectations(&mRxFlow_);
+        using ::testing::_;
+        EXPECT_CALL(mRxFlow_, unregister_handler_all(_)).Times(1);
+        delete output_;
+    }
+
+
+    ::testing::StrictMock<MyMockRxFlow> mRxFlow_; ///< mock receive flow
+    ::testing::StrictMock<MockTxFlow> mTxFlow_; ///< mock transmit flow
+    ::testing::StrictMock<MockOutputCallback> mOutCback_; ///< mock callback
+    Output *output_; ///< output instance
+};
+
+TEST_F(OutputTest, Create)
+{
+}
+
+TEST_F(OutputTest, OutputState)
+{
+    // Output 0, value 0
+    EXPECT_CALL(mOutCback_, set_output(0, 0)).Times(1);
+    {
+        auto *b = mRxFlow_.dispatcher_.alloc();
+        Defs::prepare(&b->data()->payload, Defs::CMD_OUTPUT_STATE, 4);
+        Defs::append_uint16(&b->data()->payload, 0);
+        Defs::append_uint16(&b->data()->payload, 0);
+        Defs::append_crc(&b->data()->payload);
+        mRxFlow_.dispatcher_.send(b);
+        wait_for_main_executor();
+    }
+    testing::Mock::VerifyAndClearExpectations(&mOutCback_);
+
+    // Output 25, value 55
+    EXPECT_CALL(mOutCback_, set_output(25, 55)).Times(1);
+    {
+        auto *b = mRxFlow_.dispatcher_.alloc();
+        Defs::prepare(&b->data()->payload, Defs::CMD_OUTPUT_STATE, 4);
+        Defs::append_uint16(&b->data()->payload, 25);
+        Defs::append_uint16(&b->data()->payload, 55);
+        Defs::append_crc(&b->data()->payload);
+        mRxFlow_.dispatcher_.send(b);
+        wait_for_main_executor();
+    }
+    testing::Mock::VerifyAndClearExpectations(&mOutCback_);
+}
+
+} // namespace traction_modem

--- a/src/traction_modem/Output.hxx
+++ b/src/traction_modem/Output.hxx
@@ -56,8 +56,7 @@ public:
     /// @param train reference to a train object
     Output(TxInterface *tx_flow, RxInterface *rx_flow,
         ModemTrainInterface *train)
-        : txFlow_(tx_flow)
-        , rxFlow_(rx_flow)
+        : rxFlow_(rx_flow)
         , train_(train)
     {
         rxFlow_->register_handler(this, Defs::CMD_OUTPUT_STATE);
@@ -77,7 +76,6 @@ private:
     /// @prio message priority
     void send(Buffer<Message> *buf, unsigned prio) override;
 
-    TxInterface *txFlow_; ///< reference to the transmit flow
     RxInterface *rxFlow_; ///< reference to the receive flow
     ModemTrainInterface *train_;
 };

--- a/src/traction_modem/modem_test_helper.hxx
+++ b/src/traction_modem/modem_test_helper.hxx
@@ -1,0 +1,55 @@
+#include "traction_modem/ModemTrainHwInterface.hxx"
+#include "traction_modem/RxFlow.hxx"
+#include "traction_modem/TxFlow.hxx"
+
+namespace traction_modem
+{
+
+//
+// Mock objects.
+//
+class MockRxFlow : public RxInterface
+{
+public:
+    MOCK_METHOD1(start, void(int));
+    MOCK_METHOD3(register_handler,
+        void(PacketFlowInterface*, Message::id_type, Message::id_type));
+    MOCK_METHOD3(unregister_handler,
+        void(PacketFlowInterface*, Message::id_type, Message::id_type));
+    MOCK_METHOD1(unregister_handler_all, void(PacketFlowInterface*));
+};
+
+class MyMockRxFlow : public MockRxFlow
+{
+public:
+    void register_handler(PacketFlowInterface *interface, Message::id_type id,
+        Message::id_type mask = Message::EXACT_MASK) override
+    {
+        dispatcher_.register_handler(interface, id, mask);
+        MockRxFlow::register_handler(interface, id, mask);
+    }
+ 
+    void unregister_handler_all(PacketFlowInterface *interface) override
+    {
+        dispatcher_.unregister_handler_all(interface);
+        MockRxFlow::unregister_handler_all(interface);
+    }
+
+    DispatchFlow<Buffer<Message>, 2> dispatcher_{&g_service};
+};
+
+class MockTxFlow : public TxInterface
+{
+public:
+    MOCK_METHOD1(start, void(int));
+    MOCK_METHOD1(send_packet, void(Defs::Payload));
+};
+
+class MockTrainHwInterface : public ModemTrainHwInterface
+{
+public:
+    MOCK_METHOD2(output_state, void(uint16_t, uint16_t));
+    MOCK_METHOD1(output_restart, void(uint16_t));
+};
+
+} // namespace traction_modem


### PR DESCRIPTION
- Provides an abstract interface for a custom application to stub in output state callbacks
- Provides a handler for received output messages.
- Removes temporary hardware specific handling of output messages.