### PR TITLE
Fix Railcom detection on HW Channel 0 by removing call to notify_empty() in RailcomBroadcastDecoder

### DIFF
--- a/src/dcc/RailcomBroadcastDecoder.cxx
+++ b/src/dcc/RailcomBroadcastDecoder.cxx
@@ -54,7 +54,6 @@ bool RailcomBroadcastDecoder::process_packet(const dcc::Feedback &packet)
     else
     {
         // No channel1 data.
-        notify_empty();
         if (!packet.ch2Size)
         {
             return true; // empty packet.


### PR DESCRIPTION
tldr;

In process_data(), we call notify_empty() which resets countL_ and countH_ as well as currentAddress_ to 0. This affects operation of the Railcom hardware channel 0 when DCC timer tick is tied to the same hardware channel, causing the failure to process Railcom data.

The long

On LCC nodes that detect Railcom data, physical ports enumerate from 0. The DCC timer tick also happens to be tied to hardware channel 0 at least in one implementation (Tiva Railcom/openmrn_cue) where empty Railcom ch1 and ch2 packets are constantly being sent, and eventually reaching RailcomBroadcastDecoder.cxx

These packets marked as coming from hardware channel 0 end up resetting the countL_/countH_/currentAddress_ because they pass through process_data() method and being empty (packet.ch1Size is false) hit notify_empty().

The flood of these empty packets is what causes the reset (the DCC timer tick happens more frequently) while the actual Railcom data from hardware channel 0 never gets to be processed - we require countL_ and countH_ both to be >= MIN_REPEAT_COUNT * 2, but notify_empty() gets called on every DCC timer tick never allowing the counters to increase.

This is only the case with hardware channel 0. All other hardware channels are not impacted, neither by the DCC timer tick (when bound to hardware channel 0) nor by removal of notify_empty() from the process_data() method.