### PR TITLE
[WIP] New WiFi manager for ESP-IDF

### DIFF
--- a/etc/esp-idf/CMakeLists.txt
+++ b/etc/esp-idf/CMakeLists.txt
@@ -28,7 +28,7 @@ set(SRCS
     ${OPENMRNPATH}/src/freertos_drivers/esp32/Esp32HardwareTwai.cxx
     ${OPENMRNPATH}/src/freertos_drivers/esp32/Esp32Ledc.cxx
     ${OPENMRNPATH}/src/freertos_drivers/esp32/Esp32SocInfo.cxx
-    ${OPENMRNPATH}/src/freertos_drivers/esp32/Esp32WiFiManager.cxx
+    ${OPENMRNPATH}/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
 
     ${OPENMRNPATH}/src/openlcb/AliasAllocator.cxx
     ${OPENMRNPATH}/src/openlcb/AliasCache.cxx
@@ -147,6 +147,7 @@ set(IDF_DEPS
     hal
     heap
     mdns
+    nvs_flash
     pthread
     vfs)
 

--- a/src/freertos_drivers/common/WiFiInterface.hxx
+++ b/src/freertos_drivers/common/WiFiInterface.hxx
@@ -46,25 +46,6 @@
 class WiFiInterface : public WiFiDefs, public Singleton<WiFiInterface>
 {
 public:
-    /// Network info, typically used in an access point scan.
-    struct NetworkEntry
-    {
-        /// Constructor.
-        /// @param ssid SSID of the access point
-        /// @param sec_type security type of the access point
-        /// @param rssi receive signal strength of the access point
-        NetworkEntry(const char *ssid, SecurityType sec_type, int rssi)
-            : ssid(ssid)
-            , secType(sec_type)
-            , rssi(rssi)
-        {
-        }
-
-        std::string ssid; ///< SSID of the access point
-        SecurityType secType; ///< security type of the access point
-        int rssi; ///< receive signal strength of the access point
-    };
-
     /// Initialize the WiFi.
     virtual void init()
     {

--- a/src/freertos_drivers/common/WiFiInterface.hxx
+++ b/src/freertos_drivers/common/WiFiInterface.hxx
@@ -1,0 +1,273 @@
+/** @copyright
+ * Copyright (c) 2025 Stuart Baker
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file WiFiInterface.hxx
+ *
+ * Common interface for WiFi operations.
+ *
+ * @author Stuart Baker
+ * @date 23 Jun 2025
+ */
+
+#ifndef _FREERTOS_DRIVERS_COMMON_WIFIINTERFACE_HXX_
+#define _FREERTOS_DRIVERS_COMMON_WIFIINTERFACE_HXX_
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "utils/Singleton.hxx"
+#include "freertos_drivers/common/WifiDefs.hxx"
+
+/// Abstract interface for WiFi operations
+class WiFiInterface : public Singleton<WiFiInterface>
+{
+public:
+    /// Interface index by type.
+    enum Interface : uint8_t
+    {
+        IFACE_STA, ///< STA mode interface
+        IFACE_AP, ///< AP mode interface
+    };
+
+    /// Security types.
+    enum SecurityType : uint8_t
+    {
+        SEC_OPEN = 0, ///< open (no security)
+        SEC_WEP, ///< WEP security mode
+        SEC_WPA2, ///< WPA2 security mode
+    };
+
+    /// Network info, typically used in an access point scan.
+    struct NetworkEntry
+    {
+        /// Constructor.
+        /// @param ssid SSID of the access point
+        /// @param sec_type security type of the access point
+        /// @param rssi receive signal strength of the access point
+        NetworkEntry(const char *ssid, SecurityType sec_type, int rssi)
+            : ssid(ssid)
+            , secType(sec_type)
+            , rssi(rssi)
+        {
+        }
+
+        std::string ssid; ///< SSID of the access point
+        SecurityType secType; ///< security type of the access point
+        int rssi; ///< receive signal strength of the access point
+    };
+
+    /// Initialize the WiFi.
+    virtual void init()
+    {
+    }
+
+    /// Start the WiFi.
+    /// @param role device role
+    virtual void start(WlanRole role = WlanRole::DEFAULT_ROLE) = 0;
+
+    /// Stop the WiFi.
+    virtual void stop() = 0;
+
+    /// Get the started state of the WiFi.
+    /// @return true if started, else false
+    virtual bool is_started()
+    {
+        return started_;
+    }
+
+    /// Connect to access point.
+    /// @param ssid access point SSID
+    /// @param pass access point password
+    /// @param sec_type access point security type
+    /// @return WlanConnectResult::CONNECT_OK upon connect, else error code
+    virtual WlanConnectResult connect(
+        const char *ssid, const char *pass, SecurityType sec_type) = 0;
+
+    /// Disconnect from the current AP.
+    virtual void disconnect() = 0;
+
+    /// Gets the connected state of the STA interface
+    /// @return true if STA connected/associated to an AP, else false
+    virtual bool is_connected()
+    {
+        return connected_;
+    }
+
+    /// Setup access point role credentials. May require reboot to take effect.
+    /// @param ssid access point SSID
+    /// @param pass access point password
+    /// @param sec_type access point security type
+    virtual void setup_ap(
+        const char *ssid, const char *pass, SecurityType sec_type) = 0;
+
+    /// Retrieve current access point config.
+    /// @param ssid access point SSID
+    /// @param sec_type access point security type
+    virtual void get_ap_config(std::string *ssid, SecurityType *sec_type) = 0;
+
+    /// Retrieves the number of clients connected to the WiFi in access point
+    /// mode.
+    /// @return number of connected stations, else -1 if not in AP mode.
+    virtual int get_ap_sta_count() = 0;
+
+    /// Retrieves if ready to start establishing outgoing connections.
+    /// @return true if ready, else false
+    virtual bool ready()
+    {
+        return (ipAcquiredSta_ || ipAcquiredAp_);
+    }
+
+    /// Get the WiFi role.
+    /// @return current WiFi role
+    virtual WlanRole role() = 0;
+
+    /// Change the default role. This will be used in the next start() if the
+    /// DEFAULT_ROLE is specified. The new setting takes effect when the
+    /// device is restarted (either via reboot or stop + start)
+    /// @param new_role new role, must not be UNKOWN or DEFAULT_ROLE
+    virtual void set_role(WlanRole new_role) = 0;
+
+    /// Add a saved WiFi access point profile.
+    /// @param ssid access point SSID
+    /// @param pass access point password
+    /// @param sec_type access point security type
+    /// @param priority priority when more than one profile is saved, 0 =
+    ///        lowest priority, may be unused
+    /// @return resulting index in the list of profiles, else -1 on error
+    virtual int profile_add(const char *ssid, const char *pass,
+        SecurityType sec_type, uint8_t priority) = 0;
+
+    /// Delete a saved WiFi access point profile.
+    /// @param ssid access point SSID
+    /// @return profile index deleted, else -1 if profile not found
+    virtual int profile_del(const char *ssid) = 0;
+
+    /// Delete a saved WiFi access point profile.
+    /// @param index index of profile to delete, 0xFF removes all
+    /// @return 0 if successful, else -1 if profile not found, may be unused
+    virtual int profile_del(uint8_t index) = 0;
+
+    /// Get a saved WiFi access point profile by index.
+    /// @param index index within saved profilelist to get
+    /// @param ssid 33 byte array that will return the SSID of the index
+    /// @param sec_type will return the security type of the index
+    /// @param priority will return the priority of the index
+    /// @return 0 upon success, -1 on error (index does not exist)
+    virtual int profile_get(
+        int index, char ssid[], SecurityType *sec_type, uint8_t *priority) = 0;
+
+    /// Get a list of available networks. This is based on a prior scan. Use
+    /// rescan() and wait for the scan to complete to refresh the list.
+    /// @param entries returns a list of available network entries
+    /// @param count max size of the entry list to return.
+    /// @return number of valid network entries in the list, same as
+    ///         entries->size()
+    virtual int network_list_get(
+        std::vector<NetworkEntry> *entries, size_t count) = 0;
+
+    /// Get the indexed network entry from the last of scan results. Use
+    /// rescan() and wait for the scan to complete to refresh the results.
+    /// @param entry location to fill in the network entry
+    /// @param index index in the network entry list to get
+    /// @return 0 on success, else -1 if index is beyond the list of entries.
+    virtual int network_get(NetworkEntry *entry, unsigned index) = 0;
+
+    /// Initiate scanning of available networks.
+    virtual void scan() = 0;
+
+    /// Get the RSSI of the AP in STA mode.
+    /// @return signal strength, 0 when not connected to an access point
+    virtual int rssi() = 0;
+
+    /// Get the network hostname for the device.
+    /// @return hostname
+    virtual std::string get_hostname() = 0;
+
+    /// Set the callback for when an IP address is acquired.
+    virtual void set_ip_acquired_callback(
+        std::function<void(Interface, bool)> callback)
+    {
+        ipAcquiredCallback_ = callback;
+    }
+
+    /// Set the callback for when a scan is finished.
+    virtual void set_scan_finished_callback(std::function<void()> callback)
+    {
+        scanFinishedCallback_ = callback;
+    }
+
+protected:
+    /// Constructor.
+    WiFiInterface()
+        : started_(false)
+        , connected_(false)
+        , ipAcquiredSta_(false)
+        , ipAcquiredAp_(false)
+        , ipLeased_(false)
+        , securityFailure_(false)
+    {
+    }
+
+    /// Deliver IP acquired callback, if registered.
+    /// @param iface interface index
+    /// @param acquired true if acquired, false if lost
+    void ip_acquired(Interface iface, bool acquired)
+    {
+        if (ipAcquiredCallback_)
+        {
+            ipAcquiredCallback_(iface, acquired);
+        }
+    }
+
+    /// Deliver scan finished callback, if registered.
+    void scan_finished()
+    {
+        if (scanFinishedCallback_)
+        {
+            scanFinishedCallback_();
+        }
+    }
+
+    /// Callback for when IP is acquired.
+    /// @param iface interface index
+    /// @param acquired true if acquired, false if lost
+    std::function<void(Interface iface, bool acquired)> ipAcquiredCallback_;
+
+    /// Callback for when a scan is finished.
+    std::function<void()> scanFinishedCallback_;
+
+    // Note: Because these are bitmasks, care must be taken in the derived
+    //       class that there are no mutual exclusion issues on write.
+    bool started_          : 1; ///< WiFi started
+    bool connected_        : 1; ///< STA mode connection to AP connected state
+    bool ipAcquiredSta_    : 1; ///< IP address acquired STA mode
+    bool ipAcquiredAp_     : 1; ///< IP address acquired AP mode
+    bool ipLeased_         : 1; ///< IP address leased to a client (AP mode)
+    bool securityFailure_  : 1; ///< Disconnected due to wrong password
+};
+
+#endif // _FREERTOS_DRIVERS_COMMON_WIFIINTERFACE_HXX_

--- a/src/freertos_drivers/common/WiFiInterface.hxx
+++ b/src/freertos_drivers/common/WiFiInterface.hxx
@@ -221,11 +221,7 @@ public:
     /// Get a list of available networks. This is based on a prior scan. Use
     /// scan() and wait for the scan to complete to refresh the list.
     /// @param entries returns a list of available network entries
-    /// @param count max size of the entry list to return.
-    /// @return number of valid network entries in the list, same as
-    ///         entries->size()
-    virtual int network_list_get(
-        std::vector<NetworkEntry> *entries, size_t count) = 0;
+    virtual void network_list_get(std::vector<NetworkEntry> *entries) = 0;
 
     /// Get the indexed network entry from the last of scan results. Use
     /// scan() and wait for the scan to complete to refresh the results.

--- a/src/freertos_drivers/common/WiFiInterface.hxx
+++ b/src/freertos_drivers/common/WiFiInterface.hxx
@@ -108,6 +108,31 @@ public:
         return started_;
     }
 
+    /// Get the default AP password.
+    /// @return default AP password
+    virtual const char *default_ap_password() = 0;
+
+    /// Get the default STA password.
+    /// @return default STA password
+    virtual const char *default_sta_password() = 0;
+
+    /// Get the default AP SSID.
+    /// @return default AP SSID
+    virtual const char *default_ap_ssid() = 0;
+
+    /// Get the default STA SSID.
+    /// @return default STA SSID
+    virtual const char *default_sta_ssid() = 0;
+
+    /// Get the maximum number of STA client connections in AP mode. Be careful,
+    // the max supported by hardware is device dependent.
+    /// @return maximum number of STA client connections in AP mode
+    virtual uint8_t max_ap_client_connections() = 0;
+
+    /// Get the maximum number of stored STA profiles.
+    /// @return maximum number of stored STA profiles
+    virtual uint8_t max_sta_profiles() = 0;
+
     /// Connect to access point. This is a non-blocking call. The results will
     /// be delivered by callback registered with set_wlan_connect_callback().
     /// @param ssid access point SSID

--- a/src/freertos_drivers/common/WiFiInterface.hxx
+++ b/src/freertos_drivers/common/WiFiInterface.hxx
@@ -43,33 +43,9 @@
 #include "freertos_drivers/common/WifiDefs.hxx"
 
 /// Abstract interface for WiFi operations
-class WiFiInterface : public Singleton<WiFiInterface>
+class WiFiInterface : public WiFiDefs, public Singleton<WiFiInterface>
 {
 public:
-    /// Interface index by type.
-    enum Interface : uint8_t
-    {
-        IFACE_STA, ///< STA mode interface
-        IFACE_AP, ///< AP mode interface
-    };
-
-    /// Security types.
-    enum SecurityType : uint8_t
-    {
-        SEC_OPEN = 0, ///< open (no security)
-        SEC_WEP, ///< WEP security mode
-        SEC_WPA2, ///< WPA2 security mode
-    };
-
-    /// Result code for connections and disconnections.
-    enum ConnectionResult : uint8_t
-    {
-        CONNECT_OK = 0, ///< connection succeeded
-        AUTHENTICATION_FAILED, ///< authentication failure
-        ASSOCIATION_FAILED, ///< association failure
-        CONNECT_UNKNOWN, ///< unknown result
-    };
-
     /// Network info, typically used in an access point scan.
     struct NetworkEntry
     {

--- a/src/freertos_drivers/common/WifiDefs.hxx
+++ b/src/freertos_drivers/common/WifiDefs.hxx
@@ -81,6 +81,7 @@ struct WiFiDefs
         SEC_OPEN = 0, ///< open (no security)
         SEC_WEP, ///< WEP security mode
         SEC_WPA2, ///< WPA2 security mode
+        SEC_WPA3, ///< WPA3 security mode
     };
 
     /// Result code for connections and disconnections.
@@ -90,6 +91,25 @@ struct WiFiDefs
         AUTHENTICATION_FAILED, ///< authentication failure
         ASSOCIATION_FAILED, ///< association failure
         CONNECT_UNKNOWN, ///< unknown result
+    };
+
+    /// Network info, typically used in an access point scan.
+    struct NetworkEntry
+    {
+        /// Constructor.
+        /// @param ssid SSID of the access point
+        /// @param sec_type security type of the access point
+        /// @param rssi receive signal strength of the access point
+        NetworkEntry(const char *ssid, SecurityType sec_type, int rssi)
+            : ssid(ssid)
+            , secType(sec_type)
+            , rssi(rssi)
+        {
+        }
+
+        std::string ssid; ///< SSID of the access point
+        SecurityType secType; ///< security type of the access point
+        int rssi; ///< receive signal strength of the access point
     };
 };
 

--- a/src/freertos_drivers/common/WifiDefs.hxx
+++ b/src/freertos_drivers/common/WifiDefs.hxx
@@ -64,4 +64,33 @@ extern char WIFI_HUB_HOSTNAME[];
 extern int WIFI_HUB_PORT;
 }
 
+/// Useful WiFi Definitions. Eventually, the enums above should be encorporated
+/// into this structure, but for now they are left separate for legacy code.
+struct WiFiDefs
+{
+    /// Interface index by type.
+    enum Interface : uint8_t
+    {
+        IFACE_STA, ///< STA mode interface
+        IFACE_AP, ///< AP mode interface
+    };
+
+    /// Security types.
+    enum SecurityType : uint8_t
+    {
+        SEC_OPEN = 0, ///< open (no security)
+        SEC_WEP, ///< WEP security mode
+        SEC_WPA2, ///< WPA2 security mode
+    };
+
+    /// Result code for connections and disconnections.
+    enum ConnectionResult : uint8_t
+    {
+        CONNECT_OK = 0, ///< connection succeeded
+        AUTHENTICATION_FAILED, ///< authentication failure
+        ASSOCIATION_FAILED, ///< association failure
+        CONNECT_UNKNOWN, ///< unknown result
+    };
+};
+
 #endif // _FREERTOS_DRIVERS_COMMON_WIFIDEFS_HXX_

--- a/src/freertos_drivers/common/WifiDefs.hxx
+++ b/src/freertos_drivers/common/WifiDefs.hxx
@@ -35,7 +35,8 @@ enum class WlanRole : uint8_t
     UNKNOWN = 0,       /**< Default mode (from stored configuration) */
     DEFAULT_ROLE = UNKNOWN, /**< Default mode (from stored configuration) */
     STA,               /**< Wi-Fi station mode */
-    AP                 /**< Wi-Fi access point mode */
+    AP,                /**< Wi-Fi access point mode */
+    AP_STA,            /**< Wi-Fi access point + station mode */
 };
 
 enum class CountryCode : uint8_t

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
@@ -416,7 +416,6 @@ void EspIdfWiFiBase::mdns_scan(const char *service)
         mdnsClientCache_.emplace_back(std::move(std::string(service)));
     }
     mdns_scanning_start_or_trigger_refresh();
-
 }
 
 //

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
@@ -413,7 +413,7 @@ void EspIdfWiFiBase::mdns_scan(const char *service)
     if (!match)
     {
         // Start looking for a new service.
-        mdnsClientCache_.emplace_back(std::move(std::string(service)));
+        mdnsClientCache_.emplace_back(service);
     }
     mdns_scanning_start_or_trigger_refresh();
 }
@@ -455,6 +455,7 @@ void EspIdfWiFiBase::factory_default()
 
 //
 // EspIdfWiFiBase::MDNSCacheItem::reset()
+//
 void EspIdfWiFiBase::MDNSCacheItem::reset(void *handle)
 {
     if (searchHandle_ && handle != searchHandle_)
@@ -1130,13 +1131,13 @@ void EspIdfWiFiBase::init_wifi(WlanRole role)
             // Fall through.
         case WlanRole::AP_STA:
             ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_APSTA));
-            get_ap_config(&ap_ssid, &ap_pass);
+            get_ap_config_password(&ap_ssid, &ap_pass);
             init_softap(std::move(ap_ssid), std::move(ap_pass));
             init_sta();
             break;
         case WlanRole::AP:
             ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_AP));
-            get_ap_config(&ap_ssid, &ap_pass);
+            get_ap_config_password(&ap_ssid, &ap_pass);
             init_softap(std::move(ap_ssid), std::move(ap_pass));
             break;
         case WlanRole::STA:

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
@@ -1,0 +1,1355 @@
+/** @copyright
+ * Copyright (c) 2024, Balazs Racz, 2025, Stuart Baker
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file EspIdfWiFi.cxx
+ *
+ * Interface for interacting with WiFi services.
+ *
+ * @author Balazs Racz, extended by Stuart Baker
+ * @date 27 Aug 2024, extended starting Jun 17 2025
+ */
+
+#include "freertos_drivers/esp_idf/EspIdfWiFi.hxx"
+
+#include <ifaddrs.h>
+
+#include <esp_event.h>
+#include <esp_wifi.h>
+#include <lwip/inet.h>
+#include <lwip/netdb.h>
+#include <mdns.h>
+
+#include "utils/format_utils.hxx"
+
+/// Scanning parameter configuration.
+static const wifi_scan_config_t SCAN_CONFIG = 
+{
+    .ssid = nullptr,
+    .bssid = nullptr,
+    .channel = 0,
+    .show_hidden = true,
+    .scan_type = WIFI_SCAN_TYPE_ACTIVE,
+    .scan_time = {.active = {.min = 0, .max = 120}, .passive = 360},
+    .home_chan_dwell_time = 30,
+};
+
+//
+// mdns_publish()
+//
+void mdns_publish(const char *name, const char *service, uint16_t port)
+{
+    static_cast<EspIdfWiFi*>(WiFiInterface::instance())
+        ->mdns_service_add(service, port);
+}
+
+//
+// mdns_unpublish()
+//
+void mdns_unpublish(const char *name, const char *service)
+{
+    static_cast<EspIdfWiFi*>(WiFiInterface::instance())
+        ->mdns_service_remove(service);
+}
+
+//
+// mdns_scan()
+//
+void mdns_scan(const char *service)
+{
+    static_cast<EspIdfWiFi*>(WiFiInterface::instance())
+        ->mdns_scan(service);
+}
+
+//
+// mdns_lookup()
+//
+int mdns_lookup(const char *service, struct addrinfo *hints,
+                struct addrinfo **addr)
+{
+    return static_cast<EspIdfWiFi*>(WiFiInterface::instance())
+        ->mdns_lookup(service, hints, addr);
+}
+
+/// Helper method for getifaddrs().
+/// @param iface interface instance pointer
+/// @param name interface name
+static struct ifaddrs *getifaddrs_helper(esp_netif_t *iface, const char *name)
+{
+#if defined(ESP_IDF_WIFI_IPV6)
+#error "Need to add IPV6 support for getifaddrs() implementation."
+#endif
+    if (iface == nullptr)
+    {
+        return nullptr;
+    }
+
+    struct ifaddrs *if_addrs =
+         (struct ifaddrs*)calloc(1, sizeof(struct ifaddrs));
+    esp_netif_ip_info_t ip_info;
+    if (esp_netif_get_ip_info(iface, &ip_info) == ESP_OK)
+    {
+        struct sockaddr_in *addr_in =
+            (struct sockaddr_in*)calloc(2, sizeof(struct sockaddr_in));
+        addr_in[0].sin_family = AF_INET;
+        addr_in[0].sin_addr.s_addr = ip_info.ip.addr;
+        addr_in[1].sin_family = AF_INET;
+        addr_in[1].sin_addr.s_addr = ip_info.netmask.addr;
+
+        LOG(INFO, "wifi: getifaddrs() ip: %s, netmask: %s",
+            ipv4_to_string(addr_in[0].sin_addr.s_addr).c_str(),
+            ipv4_to_string(addr_in[1].sin_addr.s_addr).c_str());
+
+        if_addrs->ifa_addr = (struct sockaddr*)addr_in;
+        if_addrs->ifa_netmask = (struct sockaddr*)(addr_in + 1);
+    }
+    if_addrs->ifa_name = (char*)calloc(1, 4);
+    strncpy(if_addrs->ifa_name, name, 3);
+    if_addrs->ifa_next = nullptr;
+    return if_addrs;
+}
+
+/// Get interface addresses
+/// @param ifap pointer to return the list of interface addresses to
+/// @return 0 upon success, else -1 with errno set to indicate the error
+int getifaddrs(struct ifaddrs **ifap)
+{
+    esp_netif_t *netif_ap = esp_netif_get_handle_from_ifkey("WIFI_AP_DEF");
+    esp_netif_t *netif_sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+    struct ifaddrs *if_addrs_ap = getifaddrs_helper(netif_ap, "ap");
+    struct ifaddrs *if_addrs_sta = getifaddrs_helper(netif_sta, "sta");
+
+    if (netif_ap)
+    {
+        *ifap = if_addrs_ap;
+        if_addrs_ap->ifa_next = if_addrs_sta;
+    }
+    else
+    {
+        *ifap = if_addrs_sta;
+    }
+    if (*ifap == nullptr)
+    {
+        errno = ENODEV;
+        return -1;
+    }
+    return 0;
+}
+
+/// Get the string version of a given error.
+/// @return the string equivalent of the passed error code.
+const char *gai_strerror(int __ecode)
+{
+    switch (__ecode)
+    {
+        default:
+            return "gai_strerror unknown";
+        case EAI_AGAIN:
+            return "temporary failure";
+        case EAI_FAIL:
+            return "non-recoverable failure";
+        case EAI_MEMORY:
+            return "memory allocation failure";
+    }
+}
+
+/// Free interface address list returned by getifaddrs()
+/// @param ifa list of interface addresses to free
+void freeifaddrs(struct ifaddrs *ifa)
+{
+    while (ifa)
+    {
+        struct ifaddrs* current = ifa;
+        ifa = ifa->ifa_next;
+
+        if (current->ifa_addr)
+        {
+            HASSERT(current->ifa_addr->sa_family == AF_INET);
+            free(current->ifa_addr);
+        }
+        free(current->ifa_name);
+        free(current);
+    }
+}
+
+//
+// EspIdfWiFi::stop()
+//
+void EspIdfWiFi::stop()
+{
+    esp_wifi_stop();
+}
+
+//
+// EspIdfWiFi::connect()
+//
+WlanConnectResult EspIdfWiFi::connect(
+    const char *ssid, const char *pass, SecurityType sec_type)
+{
+    securityFailure_ = false;
+    sta_connect(
+        std::string(ssid), std::string(pass), sec_type_translate(sec_type));
+    return WlanConnectResult::CONNECT_OK;
+}
+
+//
+// EspIdfWiFi::disconnect()
+//
+void EspIdfWiFi::disconnect()
+{
+    /// @todo Do we need to manually handle status flags and user callbacks, or
+    ///       will the ESP events be delivered that can do this for us? Need to
+    ///       test.
+    esp_wifi_disconnect();
+}
+
+//
+// EspIdfWiFi::setup_ap()
+//
+void EspIdfWiFi::setup_ap(
+        const char *ssid, const char *pass, SecurityType sec_type)
+{
+    OSMutexLock locker(this);
+    strncpy(userCfg_.ap_.ssid_, ssid, MAX_SSID_LEN);
+    userCfg_.ap_.ssid_[sizeof(userCfg_.ap_.ssid_) - 1] = '\0';
+    strncpy(userCfg_.ap_.pass_, pass, MAX_PASSPHRASE_LEN);
+    userCfg_.ap_.pass_[sizeof(userCfg_.ap_.pass_) - 1] = '\0';
+    userCfg_.ap_.sec_ = sec_type_translate(sec_type);
+    config_sync();
+}
+
+//
+// EspIdfWiFi::set_role()
+//
+void EspIdfWiFi::set_role(WlanRole new_role)
+{
+    // This is a single byte copy, it is already atomic.
+    static_assert(sizeof(userCfg_.mode_)== sizeof(uint8_t));
+    userCfg_.mode_ = new_role;
+    config_sync();
+}
+
+//
+// EspIdfWiFi::profile_add()
+//
+int EspIdfWiFi::profile_add(const char *ssid, const char *pass,
+    SecurityType sec_type, uint8_t priority)
+{
+    // find an "empty" profie
+    OSMutexLock locker(this);
+    int index = find_sta_profile("");
+    if (index >= 0)
+    {
+        strncpy(userCfg_.sta_[index].pass_, pass, MAX_PASS_SIZE);
+        userCfg_.sta_[index].pass_[MAX_PASS_SIZE] = '\0';
+        userCfg_.sta_[index].sec_ = sec_type_encode(sec_type);
+        strncpy(userCfg_.sta_[index].ssid_, ssid, MAX_SSID_SIZE);
+        userCfg_.sta_[index].ssid_[MAX_SSID_SIZE] = '\0';
+        config_sync();
+    }
+    return index;
+}
+
+//
+// EspIdfWiFi::profile_get()
+//
+int EspIdfWiFi::profile_get(
+    int index, char ssid[], SecurityType *sec_type, uint8_t *priority)
+{
+    OSMutexLock locker(this);
+    if (index >= ARRAYSIZE(userCfg_.sta_))
+    {
+        return -1;
+    }
+    strncpy(ssid, userCfg_.sta_[index].ssid_, MAX_SSID_SIZE);
+    ssid[MAX_SSID_SIZE] = '\0';
+    *sec_type = sec_type_encode(userCfg_.sta_[index].sec_);
+    *priority = 0;
+    return 0;
+}
+
+//
+// EspIdfWiFi::scan()
+//
+void EspIdfWiFi::scan()
+{
+    esp_wifi_scan_start(&SCAN_CONFIG, false);
+}
+
+//
+// EspIdfWiFi::rssi()
+//
+int EspIdfWiFi::rssi()
+{
+    if (connected_)
+    {
+        int rssi;
+        esp_wifi_sta_get_rssi(&rssi);
+        return rssi;
+    }
+    return 0;
+}
+
+//
+// EspIdfWiFi::mdns_service_add()
+//
+void EspIdfWiFi::mdns_service_add(const char *service, uint16_t port)
+{
+    std::string name;
+    std::string proto;
+    mdns_split(service, &name, &proto);
+    LOG(INFO, "wifi: MDNS service add, name: %s, proto: %s, port: %u",
+        name.c_str(), proto.c_str(), port);
+    OSMutexLock locker(this);
+    if (!mdnsAdvInhibit_)
+    {
+        ::mdns_service_add(
+            nullptr, name.c_str(), proto.c_str(), port, nullptr, 0);
+    }
+    mdnsServices_.emplace_back(std::move(name), std::move(proto), port);
+}
+
+//
+// EspIdfWiFi::mdns_service_remove()
+//
+void EspIdfWiFi::mdns_service_remove(const char *service)
+{
+    std::string name;
+    std::string proto;
+    mdns_split(service, &name, &proto);
+    LOG(INFO, "wifi: MDNS service remove, service: %s, proto: %s",
+        name.c_str(), proto.c_str());
+    OSMutexLock locker(this);
+    if (!mdnsAdvInhibit_)
+    {
+        ::mdns_service_remove(name.c_str(), proto.c_str());
+    }
+    for (auto it = mdnsServices_.begin(); it != mdnsServices_.end(); ++it)
+    {
+        if ((*it).name_ == name && (*it).proto_ == proto)
+        {
+            mdnsServices_.erase(it);
+            return;
+        }
+    }
+}
+
+//
+// EspIdfWiFi::mdns_lookup()
+//
+int EspIdfWiFi::mdns_lookup(
+    const char *service, struct addrinfo *hints, struct addrinfo **addr)
+{
+    bool looking = false;
+    *addr = nullptr;
+    OSMutexLock locker(this);
+    for (auto it = mdnsClientCache_.begin(); it != mdnsClientCache_.end(); ++it)
+    {
+        if ((*it).service_ != service)
+        {
+            // Not a match.
+            continue;
+        }
+
+        // Found a potential match. Check for an address list
+        looking = true;
+        size_t addr_cnt = (*it).addr_.size();
+        if (addr_cnt == 0)
+        {
+            // No resolved addresses to report.
+            continue;
+        }
+
+        constexpr size_t total_size =
+            sizeof(struct addrinfo) + sizeof(struct sockaddr_storage);
+        static_assert(
+            total_size <= NETDB_ELEM_SIZE, "total_size > NETDB_ELEM_SIZE");
+        struct addrinfo *current = *addr;
+        struct addrinfo *last = nullptr;
+
+        for (auto lit = (*it).addr_.begin(); lit != (*it).addr_.end(); ++lit)
+        {
+// The caller is expected to free the struct addrinfo using the method
+// freeaddrinfo. In the lwIP implementation, they use a special buffer pool
+// to free the struct addrinfo to. Therefore, we must also allocate from the
+// same pool.
+#if !defined(LWIP_HDR_MEMP_H)
+#error "lwIP memory pool implementation required and not found."
+#endif
+            current = (struct addrinfo*)memp_malloc(MEMP_NETDB);
+            if (!current)
+            {
+                // Out of memory in the pool
+                break;
+            }
+            memset(current, 0, total_size);
+            if (last)
+            {
+                // Link the last item to us.
+                last->ai_next = current;
+            }
+            else
+            {
+                // This is the first item.
+                *addr = current;
+            }
+            MDNSCacheAddr *ca = &(*lit);
+#if defined(ESP_IDF_WIFI_IPV6)
+            size_t addr_len = AF_INET == ca->family_ ?
+                sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
+            HASSERT(ca->family_ == AF_INET || ca->family_ == AF_INET6);
+#else
+            size_t addr_len = sizeof(struct sockaddr_in);
+            HASSERT(ca->family_ == AF_INET);
+#endif
+            current->ai_family = ca->family_;
+            current->ai_addrlen = sizeof(struct sockaddr_storage);
+            current->ai_addr = (struct sockaddr*)(current + 1);
+            memcpy(current->ai_addr, &ca->addr_, addr_len);
+            last = current;
+            LOG(INFO, "wifi: mdns_lookup() address: %s, port: %u",
+                ipv4_to_string(ntohl(ca->addrIn_.sin_addr.s_addr)).c_str(),
+                ntohs(ca->addrIn_.sin_port));
+        }
+        if (last)
+        {
+            last->ai_next = nullptr;
+        }
+        return *addr ? 0 : EAI_MEMORY;
+    }
+    if (!looking)
+    {
+        // Not currently looking for the service. Start looking.
+        mdns_scan(service);
+    }
+    return EAI_AGAIN;
+}
+
+//
+// EspIdfWiFi::mdns_scan()
+//
+void EspIdfWiFi::mdns_scan(const char *service)
+{
+    bool match = false;
+    OSMutexLock locker(this);
+    for (auto it = mdnsClientCache_.begin(); it != mdnsClientCache_.end(); ++it)
+    {
+        if ((*it).service_ == service)
+        {
+            match = true;
+        }
+    }
+    if (!match)
+    {
+        // Start looking for a new service.
+        mdnsClientCache_.emplace_back(std::move(std::string(service)));
+    }
+    if (!mdnsClientStarted_)
+    {
+        // Start the client if not already started.
+        mdnsClientStarted_ = true;
+        notify();
+        LOG(INFO, "wifi: mdns_scan() start.");
+    }
+    else if (!mdnsClientTrigRefresh_)
+    {
+        // Trigger the mDNS state machine to execute early. If a query is
+        // already taking place, a new one will start immediately following it.
+        // If a query it not taking place, one will be started immediately.
+        mdnsClientTrigRefresh_ = true;
+        CallbackExecutable *e =
+            new CallbackExecutable([this](){this->timer_.ensure_triggered();});
+        this->service()->executor()->add(e);
+        LOG(INFO, "wifi: mdns_scan() trigger.");
+    }
+}
+
+//
+// EspIdfWiFi::factory_default()
+//
+void EspIdfWiFi::factory_default()
+{
+    LOG(INFO, "wifi: factory_default()");
+    memset(&userCfg_, 0, sizeof(userCfg_));
+    userCfg_.magic_ = WIFI_CONFIG_INIT_MAGIC;
+    userCfg_.mode_ = WlanRole::AP_STA;
+    strncpy(userCfg_.ap_.ssid_, hostname_, MAX_SSID_SIZE);
+    userCfg_.ap_.ssid_[MAX_SSID_SIZE] = '\0';
+    strcpy(userCfg_.ap_.pass_, DEFAULT_PASSWORD);
+    userCfg_.ap_.sec_ = 2;
+    strcpy(userCfg_.sta_[0].ssid_, DEFAULT_STA_SSID);
+    strcpy(userCfg_.sta_[0].pass_, DEFAULT_PASSWORD);
+    userCfg_.sta_[0].sec_ = 2;
+}
+
+//
+// EspIdfWiFi::MDNSCacheItem::reset()
+void EspIdfWiFi::MDNSCacheItem::reset(void *handle)
+{
+    if (searchHandle_ && handle != searchHandle_)
+    {
+        mdns_query_async_delete((mdns_search_once_t*)searchHandle_);
+    }
+    searchHandle_ = handle;
+}
+
+//
+// EspIdfWiFi::mdns_start()
+//
+StateFlowBase::Action EspIdfWiFi::mdns_start()
+{
+    HASSERT(mdnsClientCache_.size() > 0);
+    if (mdnsAdvInhibitSta_)
+    {
+        mdns_adv_inhibit();
+        mdns_restore_sta();
+        mdnsAdvInhibitStaActive_ = true;
+    }
+    return call_immediately(STATE(mdns_query));
+}
+
+//
+// EspIdfWiFi::mdns_query()
+//
+StateFlowBase::Action EspIdfWiFi::mdns_query()
+{
+    OSMutexLock lock(this);
+    mdnsClientTrigRefresh_ = false;
+    for (auto it = mdnsClientCache_.begin(); it != mdnsClientCache_.end(); ++it)
+    {
+        std::string name;
+        std::string proto;
+        mdns_split((*it).service_.c_str(), &name, &proto);
+        (*it).reset((void*)mdns_query_async_new(
+            nullptr, name.c_str(), proto.c_str(), MDNS_TYPE_PTR,
+            MDNS_QUERY_ASYNC_NEW_TIMEOUT_MSEC, 3, nullptr));
+        LOG(VERBOSE, "wifi: mDNS new search query: %s.%s",
+            name.c_str(), proto.c_str());
+    }
+
+    return sleep_and_call(&timer_,
+        MDNS_QUERY_CHECK_TIMEOUT_NSEC, STATE(mdns_check));
+}
+
+//
+// EspIdfWiFi::mdns_check()
+//
+StateFlowBase::Action EspIdfWiFi::mdns_check()
+{
+    bool search_still_active = false;
+    OSMutexLock lock(this);
+    // Loop through all of the service clients.
+    for (auto it = mdnsClientCache_.begin(); it != mdnsClientCache_.end(); ++it)
+    {
+        if ((*it).get() == nullptr)
+        {
+            // No active search for this cache entry.
+            LOG(VERBOSE, "wifi: mDNS no active search for this cache entry.");
+            continue;
+        }
+        mdns_result_t *mdns_result = nullptr;
+        bool result = mdns_query_async_get_results(
+            (mdns_search_once_t*)(*it).get(), 0, &mdns_result, nullptr);
+        if (!result)
+        {
+            // Results not ready yet.
+            LOG(VERBOSE, "wifi: mDNS client results not ready yet.");
+            search_still_active = true;
+            continue;
+        }
+        if (mdns_result == nullptr)
+        {
+            // No results for this service.
+            LOG(VERBOSE, "wifi: No mDNS client results for this service.");
+            (*it).reset();
+            continue;
+        }
+
+        // Loop through all the results.
+        for (mdns_result_t *cur_result = mdns_result;
+            cur_result; cur_result = cur_result->next)
+        {
+            MDNSCacheAddr cache_addr;
+            cache_addr.port_ = htons(cur_result->port);
+
+            for (mdns_ip_addr_t *addr = cur_result->addr; addr;
+                addr = addr->next)
+            {
+                // For some reason, the mdns_result_t::ip_protocol cannot
+                // be trusted. The address results list can contain both
+                // IPv4 and IPv6 addresses.
+                if (addr->addr.type == ESP_IPADDR_TYPE_V4)
+                {
+                    cache_addr.family_ = AF_INET;
+                }
+#if defined(ESP_IDF_WIFI_IPV6)
+                // OpenMRN does not support IPv6 for mdns_lookup() yet.
+                else if (addr->addr.type == ESP_IPADDR_TYPE_V6)
+                {
+                    cache_addr.family_ = AF_INET6;
+                }
+#endif
+                else
+                {
+                    // Unknown protocol.
+                    continue;
+                }
+                bool duplicate = false;
+                for (auto ait = (*it).addr_.begin();
+                    !duplicate && ait != (*it).addr_.end(); ++ait)
+                {
+                    duplicate = (*ait).family_ == cache_addr.family_;
+                    duplicate &= (*ait).port_ == cache_addr.port_;
+                    if (cache_addr.family_ == AF_INET)
+                    {
+                        duplicate &= (*ait).addrIn_.sin_addr.s_addr ==
+                            addr->addr.u_addr.ip4.addr;
+                    }
+#if defined(ESP_IDF_WIFI_IPV6)
+                    else if (cache_addr.family_ == AF_INET6)
+                    {
+                        duplicate &= 
+                            !memcmp((*ait).addrIn6_.sin6_addr.un.u32_addr,
+                                addr->addr.u_addr.ip6.addr, 16);
+                    }
+#endif
+                }
+                if (!duplicate)
+                {
+                    if (cache_addr.family_ == AF_INET)
+                    {
+                        cache_addr.addrIn_.sin_addr.s_addr =
+                            addr->addr.u_addr.ip4.addr;
+                        cache_addr.addrIn_.sin_port = cache_addr.port_;
+                        LOG(INFO, "wifi: mDNS service discovered: %s\n"
+                            "     %s %s:%u", cur_result->hostname,
+                            (*it).service_.c_str(),
+                            ipv4_to_string(ntohl(
+                                cache_addr.addrIn_.sin_addr.s_addr)).c_str(),
+                            ntohs(cache_addr.port_));
+                    }
+#if defined(ESP_IDF_WIFI_IPV6)
+                    else if (cache_addr.family_ == AF_INET6)
+                    {
+                        memcpy(cache_addr.addrIn6_.sin6_addr.un.u32_addr,
+                            addr->addr.u_addr.ip6.addr, 16);
+                        cache_addr.addrIn6_.sin6_port = cache_addr.port_;
+                        LOG(INFO, "wifi: mDNS service discovered: %s\n"
+                            "     %s %s:%u", cur_result->hostname,
+                            (*it).service_.c_str(),
+                            ipv6_to_string(
+                                cache_addr.addrIn6_.sin6_addr.un.u8_addr)
+                                    .c_str(),
+                            ntohs(cache_addr.port_));
+                    }
+#endif
+                    if ((*it).addr_.size() >= MDNS_RESULT_COUNT_MAX)
+                    {
+                        LOG(VERBOSE,
+                            "wifi: mDNS service evict old cache entry");
+                        (*it).addr_.pop_back();
+                    }
+                    (*it).addr_.emplace_front(cache_addr);
+                }
+                else
+                {
+                    LOG(VERBOSE, "wifi: mDNS service discovered duplicate.");
+                }
+            }
+        }
+        mdns_query_results_free(mdns_result);
+        (*it).reset();
+    }
+    if (search_still_active)
+    {
+        // There are still active queries, sleep and check again later.
+        return sleep_and_call(
+            &timer_, MDNS_QUERY_CHECK_TIMEOUT_NSEC, STATE(mdns_check));
+    }
+    else if (mdnsClientTrigRefresh_)
+    {
+        // An mdns_scan() was triggered by the application, start another query
+        // immediately.
+        return call_immediately(STATE(mdns_query));
+    }
+    else
+    {
+        // No more active or pending queries. block mDNS on the STA interface
+        // and resume mDNS advertising.
+        if (mdnsAdvInhibitStaActive_)
+        {
+            mdns_disable_sta();
+            mdns_adv_inhibit_remove();
+            mdnsAdvInhibitStaActive_ = false;
+        }
+        return sleep_and_call(
+            &timer_, MDNS_QUERY_INACTIVE_TIMEOUT_NSEC, STATE(mdns_start));
+    }
+}
+
+//
+// EspIdfWiFi::mdns_adv_inhibit()
+//
+void EspIdfWiFi::mdns_adv_inhibit()
+{
+    OSMutexLock locker(this);
+    if (!mdnsAdvInhibit_)
+    {
+        mdnsAdvInhibit_ = true;
+        for (auto it = mdnsServices_.begin(); it != mdnsServices_.end(); ++it)
+        {
+            LOG(VERBOSE, "wifi: mDNS inhibit, service: %s, proto: %s",
+                (*it).name_.c_str(), (*it).proto_.c_str());
+            ::mdns_service_remove((*it).name_.c_str(), (*it).proto_.c_str());
+        }
+    }
+}
+
+//
+// EspIdfWiFi::mdns_adv_inhibit_remove()
+//
+void EspIdfWiFi::mdns_adv_inhibit_remove()
+{
+   OSMutexLock locker(this);
+    if (mdnsAdvInhibit_)
+    {
+        mdnsAdvInhibit_ = false;
+        for (auto it = mdnsServices_.begin(); it != mdnsServices_.end(); ++it)
+        {
+            LOG(VERBOSE, "wifi: mDNS inhibit removed, service: %s, proto: %s",
+                (*it).name_.c_str(), (*it).proto_.c_str());
+            ::mdns_service_add(nullptr, (*it).name_.c_str(),
+                (*it).proto_.c_str(), (*it).port_, nullptr, 0);
+        }
+    }
+}
+
+//
+// EspIdfWiFi::mdns_disable_sta()
+//
+void EspIdfWiFi::mdns_disable_sta()
+{
+#if !defined(CONFIG_MDNS_PREDEF_NETIF_STA)
+    OSMutexLock locker(this);
+    HASSERT(mdnsStaLockCount_ < 10); // Check for runaway asymmetry.
+    if (mdnsStaLockCount_++ == 0)
+    {
+        ESP_ERROR_CHECK(mdns_unregister_netif(staIface_));
+        LOG(VERBOSE, "wifi: STA unregistered on mDNS.");
+    }
+#endif
+}
+
+//
+// EspIdfWiFi::try_restore_sta()
+//
+void EspIdfWiFi::mdns_restore_sta()
+{
+#if !defined(CONFIG_MDNS_PREDEF_NETIF_STA)
+    OSMutexLock locker(this);
+    HASSERT(mdnsStaLockCount_ != 0);
+    if (--mdnsStaLockCount_ == 0)
+    {
+        if (staIface_)
+        {
+            // If the STA interface is not registered by default, register it.
+            ESP_ERROR_CHECK(mdns_register_netif(staIface_));
+            mdns_event_actions_t action = static_cast<mdns_event_actions_t>(
+                MDNS_EVENT_ENABLE_IP4 | MDNS_EVENT_ENABLE_IP6 |
+                MDNS_EVENT_ANNOUNCE_IP4 | MDNS_EVENT_ANNOUNCE_IP6);
+            ESP_ERROR_CHECK(mdns_netif_action(staIface_, action));
+            LOG(VERBOSE, "wifi: STA registered on mDNS.");
+        }
+    }
+#endif
+}
+
+//
+// EspIdfWiFi::wifi_event_handler()
+//
+void EspIdfWiFi::wifi_event_handler(esp_event_base_t base, int32_t id, void *data)
+{
+    if (base != WIFI_EVENT)
+    {
+        LOG(WARNING, "wifi: wifi_event_handler(), not a WIFI_EVENT.");
+        return;
+    }
+
+    switch (id)
+    {
+        default:
+            LOG(INFO, "wifi: wifi_event_handler() unknown id: %i", (int)id);
+            break;
+        case WIFI_EVENT_WIFI_READY:
+            started_ = true;
+            LOG(INFO, "wifi: WiFi started.");
+            break;
+        case WIFI_EVENT_STA_START:
+        {
+            std::string ssid;
+            std::string pass;
+            uint8_t authmode;
+            uint8_t channel;
+            last_sta_get(&ssid, &pass, &authmode, &channel);
+            if (ssid.empty())
+            {
+                // No valid "fast" connect parameters.
+                esp_wifi_scan_start(&SCAN_CONFIG, false);
+                LOG(INFO, "wifi: STA start, scanning...");
+            }
+            else
+            {
+                // Try the fast connect parameters first.
+                sta_connect(ssid, pass, authmode, channel);
+                LOG(INFO, "wifi: STA start, ssid: %s, pass: %s, connecting...",
+                    ssid.c_str(), pass.c_str());
+            }
+            break;
+        }
+        case WIFI_EVENT_STA_CONNECTED:
+        {
+            HASSERT(!connected_);
+            connected_ = true;
+            securityFailure_ = false;
+            wifi_event_sta_connected_t *sdata =
+                (wifi_event_sta_connected_t*)data;
+            LOG(INFO, "wifi: STA connected, channel: %u, authmode: %u",
+                sdata->channel, (unsigned)sdata->authmode);
+            last_sta_update(std::string((char*)sdata->ssid, sdata->ssid_len),
+                staConnectPass_, sdata->authmode, sdata->channel);
+            break;
+        }
+        case WIFI_EVENT_STA_DISCONNECTED:
+        {
+            HASSERT(connected_);
+            connected_ = false;
+            wifi_event_sta_disconnected_t *evdata =
+                (wifi_event_sta_disconnected_t *)data;
+            LOG(INFO, "wifi: STA disconnected ssid=%s reason %d rssi=%d",
+                evdata->ssid, evdata->reason, evdata->rssi);
+
+            if (evdata->reason == WIFI_REASON_AUTH_FAIL)
+            {
+                securityFailure_ = true;
+            }
+
+            bool try_fast_reconnect = false;
+            {
+                // We have to take a mutex because for some reason the
+                // IP_EVENT_STA_LOST_IP event does not get delivered when there
+                // is an unexpected WiFi disconnect. I guess it is implied?
+                OSMutexLock locker(this);
+                if (ipAcquiredSta_)
+                {
+                    ipAcquiredSta_ = false; // Disconnect implies we lost IP.
+                    try_fast_reconnect = true; // Try a fast reconnect.
+                    mdns_disable_sta();
+                }
+            }
+            if (try_fast_reconnect)
+            {
+                ip_acquired(IFACE_STA, false);
+            }
+            if (try_fast_reconnect || fastConnectOnlySta_)
+            {
+                // First reconnect attempt.
+                esp_wifi_connect();
+                LOG(INFO, "wifi: STA disconnected, fast reconnect attempt...");
+            }
+            else
+            {
+                // Successive reconnect attempts.
+                esp_wifi_scan_start(nullptr, false);
+                LOG(INFO, "wifi: STA disconnected, scanning...");
+            }
+            break;
+        }
+        case WIFI_EVENT_SCAN_DONE:
+        {
+            /// @todo The newer IDF versions have a new api that can read
+            ///       AP records one at a time, which is much more memory
+            ///       friendly. Revisit this when updating the IDF version.
+            int idx = -1;
+            uint16_t number;
+            esp_wifi_scan_get_ap_num(&number);
+            LOG(INFO, "wifi: Scan done, number of records: %u.", number);
+            number = std::min(number, static_cast<uint16_t>(10));
+
+            // This takes a lot of memory. Not the best API design. See note
+            // above.
+            wifi_ap_record_t *ap_records = new wifi_ap_record_t[10];
+            esp_wifi_scan_get_ap_records(&number, ap_records);
+            std::string ssid(MAX_SSID_SIZE + 1, '\0');
+            std::string pass(MAX_PASS_SIZE + 1, '\0');
+            uint8_t sec = WIFI_AUTH_WPA2_PSK;
+            uint8_t conn_channel = 0;
+            {
+                OSMutexLock locker(this);
+                scanResults_.clear();
+                for (unsigned i = 0; i < number; ++i)
+                {
+                    // Cache the scan record for the user to read later.
+                    scanResults_.emplace_back((char*)ap_records[i].ssid,
+                        sec_type_encode(ap_records[i].authmode),
+                        ap_records[i].rssi);
+
+                    if (staIface_ && !connected_ && idx < 0)
+                    {
+                        int index = find_sta_profile(
+                            std::string((char*)ap_records[i].ssid));
+                        if (index >= 0 &&
+                            ap_records[i].authmode >= userCfg_.sta_[index].sec_)
+                        {
+                            // profile SSID and security mode match.
+                            idx = index;
+                            ssid = userCfg_.sta_[index].ssid_;
+                            pass = userCfg_.sta_[index].pass_;
+                            sec = userCfg_.sta_[index].sec_;
+                            conn_channel = ap_records[i].primary;
+                        }
+
+                    }
+                }
+            }
+            delete ap_records;
+            if (staIface_ && !connected_)
+            {
+                // If in STA mode and not connected, always be trying to make
+                // a connection.
+                if (idx < 0)
+                {
+                    // No profile match found, scan again.
+                    esp_wifi_scan_start(nullptr, false);
+                }
+                else
+                {
+                    // Profile match found, connect.
+                    sta_connect(ssid.c_str(), pass.c_str(), sec, conn_channel);
+                }
+            }
+            scan_finished();
+            break;
+        }
+        case WIFI_EVENT_AP_START:
+            ipAcquiredAp_ = true;
+            ip_acquired(IFACE_AP, true);
+            break;
+        case WIFI_EVENT_AP_STOP:
+            ipAcquiredAp_ = false;
+            ip_acquired(IFACE_AP, false);
+            break;
+        case WIFI_EVENT_AP_STACONNECTED:
+        {
+            wifi_event_ap_staconnected_t *event =
+                (wifi_event_ap_staconnected_t *)data;
+            LOG(INFO, "wifi: station " MACSTR " join, AID=%d",
+                MAC2STR(event->mac), event->aid);
+            ++apClientCount_;
+            break;
+        }
+        case WIFI_EVENT_AP_STADISCONNECTED:
+        {
+            wifi_event_ap_stadisconnected_t *event =
+                (wifi_event_ap_stadisconnected_t *)data;
+            LOG(INFO, "wifi: station " MACSTR " leave, AID=%d",
+                MAC2STR(event->mac), event->aid);
+            if (--apClientCount_ == 0)
+            {
+                ipLeased_ = false;
+            }
+            break;
+        }
+    }
+}
+
+//
+// EspIdfWiFi::ip_event_handler()
+//
+void EspIdfWiFi::ip_event_handler(esp_event_base_t base, int32_t id, void *data)
+{
+    if (base != IP_EVENT)
+    {
+        LOG(WARNING, "wifi: ip_event_handler(), not a IP_EVENT.");
+        return;
+    }
+
+    switch (id)
+    {
+        default:
+            LOG(INFO, "wifi: ip_event_handler() unknown id: %i", (int)id);
+            break;
+        case IP_EVENT_STA_GOT_IP:
+        {
+            {
+                // We have to take a mutex because for some reason the
+                // IP_EVENT_STA_LOST_IP event does not get delivered when there
+                // is an unexpected WiFi disconnect. I guess it is implied?
+                OSMutexLock locker(this);
+                HASSERT(ipAcquiredSta_ == false);
+                ipAcquiredSta_ = true;
+                mdns_restore_sta();
+            }
+            ip_event_got_ip_t *d = static_cast<ip_event_got_ip_t *>(data);
+            char ip_addr[16];
+            inet_ntoa_r(d->ip_info.ip.addr, ip_addr, 16);
+            LOG(INFO, "wifi: STA got IP: %s", ip_addr);
+            ip_acquired(IFACE_STA, true);
+            break;
+        }
+        case IP_EVENT_STA_LOST_IP:
+        {
+            {
+                // We have to take a mutex because for some reason the
+                // IP_EVENT_STA_LOST_IP event does not get delivered when there
+                // is an unexpected WiFi disconnect. I guess it is implied?
+                OSMutexLock locker(this);
+                if (ipAcquiredSta_)
+                {
+                    ipAcquiredSta_ = false;
+                    mdns_disable_sta();
+                }
+            }
+            LOG(INFO, "wifi: STA lost IP.");
+            ip_acquired(IFACE_STA, false);
+            break;
+        }
+        case IP_EVENT_AP_STAIPASSIGNED:
+            ipLeased_ = true;
+            break;
+    }
+}
+
+//
+// EspIdfWiFi::init_config()
+//
+void EspIdfWiFi::init_config()
+{
+    esp_err_t result = nvs_open(NVS_NAMESPACE_NAME, NVS_READWRITE, &cfg_);
+    if (result != ESP_OK)
+    {
+        LOG(LEVEL_ERROR, "wifi: Error %s opening NVS handle.",
+            esp_err_to_name(result));
+        return;
+    }
+
+    // User configuration.
+    size_t len = sizeof(userCfg_);
+    result = nvs_get_blob(cfg_, NVS_KEY_USER_NAME, &userCfg_, &len);
+    switch(result)
+    {
+        case ESP_OK:
+            if (userCfg_.magic_ == WIFI_CONFIG_INIT_MAGIC &&
+                len == sizeof(userCfg_))
+            {
+                // Already initialized.
+                break;
+            }
+            // Not initialized yet.
+            // fall through
+        case ESP_ERR_NVS_NOT_FOUND:
+            // fall through
+        case ESP_ERR_NVS_INVALID_LENGTH:
+            // Initialize WiFi user configuration to factory defaults.
+            factory_default();
+            nvs_set_blob(cfg_, NVS_KEY_USER_NAME, &userCfg_, sizeof(userCfg_));
+            nvs_commit(cfg_);
+            break;
+        default:
+            LOG(LEVEL_ERROR, "wifi: Error %s getting userCfg_.",
+                esp_err_to_name(result));
+            break;
+    }
+
+    // Private configuration.
+    len = sizeof(privCfg_);
+    result = nvs_get_blob(cfg_, NVS_KEY_LAST_NAME, &privCfg_, &len);
+    switch (result)
+    {
+        case ESP_OK:
+            if (len == sizeof(privCfg_))
+            {
+                // Already initialized.
+                break;
+            }
+            // Not initialized yet.
+            // fall through
+        case ESP_ERR_NVS_NOT_FOUND:
+            // fall through
+        case ESP_ERR_NVS_INVALID_LENGTH:
+            // Reset to factory defaults.
+            memset(&privCfg_, 0, sizeof(privCfg_));
+            nvs_set_blob(cfg_, NVS_KEY_LAST_NAME, &userCfg_, sizeof(userCfg_));
+            nvs_commit(cfg_);
+            break;
+        default:
+            LOG(LEVEL_ERROR, "wifi: Error %s getting privCfg_.",
+                esp_err_to_name(result));
+            break;
+    }
+}
+
+//
+// EspIdfWiFi::init_wifi()
+//
+void EspIdfWiFi::init_wifi(WlanRole role)
+{
+    if (role == WlanRole::DEFAULT_ROLE)
+    {
+        role = userCfg_.mode_;
+    }
+
+    ESP_ERROR_CHECK(esp_netif_init());
+
+    /// @todo Do we need this?
+    esp_err_t result = esp_event_loop_create_default();
+    if (result != ESP_OK)
+    {
+        LOG(LEVEL_ERROR, "wifi: esp_event_loop_create_default() failed: %s",
+            esp_err_to_name(result));
+    }
+
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(
+        WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler, this, nullptr));
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(
+        IP_EVENT, ESP_EVENT_ANY_ID, &ip_event_handler, this, nullptr));
+
+    // Use this to debug wifi connection problems
+    // esp_log_level_set("wifi", ESP_LOG_VERBOSE);
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
+
+    // Set and initialize the appropriate role(s).
+    switch (role)
+    {
+        default:
+            // Fall through.
+        case WlanRole::UNKNOWN:
+            // Fall through.
+        case WlanRole::AP_STA:
+            ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_APSTA));
+            init_softap(userCfg_.ap_.ssid_, userCfg_.ap_.pass_);
+            init_sta();
+            break;
+        case WlanRole::AP:
+            ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_AP));
+            init_softap(userCfg_.ap_.ssid_, userCfg_.ap_.pass_);
+            break;
+        case WlanRole::STA:
+            ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+            init_sta();
+            break;
+    }
+    // Start the WiFi.
+    ESP_ERROR_CHECK(esp_wifi_start());
+
+    if (apIface_)
+    {
+        esp_netif_ip_info_t ip_info;
+        esp_netif_get_ip_info(
+            esp_netif_get_handle_from_ifkey("WIFI_AP_DEF"), &ip_info);
+
+        char ip_addr[16];
+        inet_ntoa_r(ip_info.ip.addr, ip_addr, 16);
+        LOG(INFO, "wifi: Set up softAP with IP: %s", ip_addr);
+
+        LOG(INFO, "wifi: init_softap() finished. SSID:'%s' password:'%s'",
+            userCfg_.ap_.ssid_, userCfg_.ap_.pass_);
+    }
+
+    // Initialize mDNS.
+    ESP_ERROR_CHECK(mdns_init());
+    mdns_hostname_set(hostname_);
+    mdns_instance_name_set(hostname_);
+}
+
+//
+// EspIdfWiFi::init_softap()
+//
+void EspIdfWiFi::init_softap(std::string ssid, std::string pass)
+{
+    apIface_ = esp_netif_create_default_wifi_ap();
+    esp_netif_set_hostname(apIface_, hostname_);
+
+    wifi_config_t conf;
+    memset(&conf, 0, sizeof(wifi_config_t));
+
+    conf.ap.max_connection = 4;
+    conf.ap.beacon_interval = 100;
+    conf.ap.ssid_len = std::min(ssid.size(), (size_t)MAX_SSID_LEN);
+    memcpy(conf.ap.ssid, ssid.c_str(), conf.ap.ssid_len);
+
+    size_t pass_len = std::min(pass.size(), (size_t)MAX_PASSPHRASE_LEN);
+    if (pass_len == 0)
+    {
+        conf.ap.authmode = WIFI_AUTH_OPEN;
+    }
+    else
+    {
+        memcpy(conf.ap.password, pass.c_str(), pass_len);
+        conf.ap.authmode = WIFI_AUTH_WPA_WPA2_PSK;
+    }
+
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &conf));
+}
+
+//
+// EspIdfWiFi::init_sta()
+//
+void EspIdfWiFi::init_sta()
+{
+    staIface_ = esp_netif_create_default_wifi_sta();
+    esp_netif_set_hostname(staIface_, hostname_);
+    ESP_ERROR_CHECK(esp_netif_dhcpc_start(staIface_));
+}
+
+//
+// EspIdfWiFi::sta_connect()
+//
+void EspIdfWiFi::sta_connect(
+    std::string ssid, std::string pass, uint8_t authmode, uint8_t channel)
+{
+    wifi_config_t conf;
+    memset(&conf, 0, sizeof(wifi_config_t));
+
+    size_t ssid_len = std::min(ssid.size(), (size_t)MAX_SSID_LEN);
+    memcpy(conf.sta.ssid, ssid.c_str(), ssid_len);
+
+    size_t pass_len = std::min(pass.size(), (size_t)MAX_PASSPHRASE_LEN);
+    memcpy(conf.sta.password, pass.c_str(), pass_len);
+    staConnectPass_ = std::move(pass);
+
+    LOG(INFO, "wifi: STA SSID: %s, PASS: %s", conf.sta.ssid, conf.sta.password);
+    if (pass_len)
+    {
+        conf.sta.threshold.authmode = (wifi_auth_mode_t)authmode;
+    }
+    else
+    {
+        conf.sta.threshold.authmode = WIFI_AUTH_OPEN;
+    }
+    conf.sta.pmf_cfg.required = false;
+    conf.sta.scan_method = WIFI_FAST_SCAN;
+    conf.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
+    conf.sta.threshold.rssi = -100;
+    conf.sta.channel = channel;
+
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &conf));
+    esp_wifi_connect();
+}
+
+
+//
+// EspIdfWiFi::last_sta_update()
+//
+void EspIdfWiFi::last_sta_update(
+    std::string ssid, std::string pass, uint8_t authmode, uint8_t channel)
+{
+    if (ssid != privCfg_.last_.ssid_ || pass != privCfg_.last_.pass_ ||
+        authmode != privCfg_.last_.sec_|| channel != privCfg_.channelLast_)
+    {
+        LOG(INFO, "wifi: Update last STA.");
+        strncpy(privCfg_.last_.ssid_, ssid.c_str(), MAX_SSID_SIZE);
+        privCfg_.last_.ssid_[MAX_SSID_SIZE] = '\0';
+        strncpy(privCfg_.last_.pass_, pass.c_str(), MAX_PASS_SIZE);
+        privCfg_.last_.pass_[MAX_PASS_SIZE] = '\0';
+        privCfg_.last_.sec_ = authmode;
+        privCfg_.channelLast_ = channel;
+        nvs_set_blob(cfg_, NVS_KEY_LAST_NAME, &privCfg_, sizeof(privCfg_));
+        nvs_commit(cfg_);
+    }
+}
+
+//
+// EspIdfWiFi::last_sta_set()
+//
+void EspIdfWiFi::last_sta_get(
+    std::string *ssid, std::string *pass, uint8_t *authmode, uint8_t *channel)
+{
+    if (privCfg_.last_.ssid_[0] != '\0' &&
+        find_sta_profile(privCfg_.last_.ssid_) >= 0)
+    {
+        // Last SSID is valid and exists in the profile list.
+        *ssid = privCfg_.last_.ssid_;
+        *pass = privCfg_.last_.pass_;
+        *authmode = privCfg_.last_.sec_;
+        *channel = privCfg_.channelLast_;
+    }
+    else
+    {
+        ssid->clear();
+    }
+}
+
+//
+// EspIdfWiFi::find_sta_profile()
+//
+int EspIdfWiFi::find_sta_profile(std::string ssid)
+{
+    OSMutexLock locker(this);
+    for (unsigned i = 0; i < ARRAYSIZE(userCfg_.sta_); ++i)
+    {
+        if (userCfg_.sta_[i].ssid_ == ssid)
+        {
+            return i;
+        }
+    }
+    return -1;
+}
+
+//
+// EspIdfWiFi::sec_type_translate()
+//
+uint8_t EspIdfWiFi::sec_type_translate(SecurityType sec_type)
+{
+    switch (sec_type)
+    {
+        default:
+        case SEC_OPEN:
+            return WIFI_AUTH_OPEN;
+        case SEC_WEP:
+            return WIFI_AUTH_WEP;
+        case SEC_WPA2:
+            return WIFI_AUTH_WPA2_PSK;
+    }
+}
+
+//
+// EspIdfWiFi::sec_type_translate()
+//
+WiFiInterface::SecurityType EspIdfWiFi::sec_type_encode(uint8_t sec_type)
+{
+    switch (sec_type)
+    {
+        default:
+        case WIFI_AUTH_OPEN:
+            return SEC_OPEN;
+        case WIFI_AUTH_WEP:
+            return SEC_WEP;
+        case WIFI_AUTH_WPA2_PSK:
+            return SEC_WPA2;
+    }
+}

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
@@ -809,7 +809,10 @@ void EspIdfWiFiBase::wifi_event_handler(
         }
         case WIFI_EVENT_STA_DISCONNECTED:
         {
-            HASSERT(connected_);
+            // Note: It is possible to get here when we are already
+            //       "disconnected". Therefore, we should not assert on
+            //       connected_ == true. Every failed connection "attempt"
+            //       lands us here.
             connected_ = false;
             wifi_event_sta_disconnected_t *evdata =
                 (wifi_event_sta_disconnected_t *)data;

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
@@ -475,6 +475,15 @@ private:
     /// Restore mDNS status on the STA interface.
     void mdns_restore_sta();
 
+    /// Will start the mDNS client state machine if not already started. Will
+    /// Trigger the mDNS state machine to execute early if it is already
+    /// started. If a query is already taking place, a new one will start
+    /// immediately following it. If a query it not taking place, one will be
+    /// started immediately.
+    ///
+    /// Note: This API should be called only while holding the lock_ mutex.
+    void mdns_scanning_start_or_trigger_refresh();
+
     /// Static callback for the ESP event handler.
     /// @param arg passed in context (this pointer)
     /// @param base event base

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
@@ -218,7 +218,8 @@ public:
     /// @param service service, e.g. _openlcb-can._tcp
     void mdns_service_remove(const char *service);
 
-    /// Lookup an mDNS name. Non-blocking.
+    /// Lookup an mDNS name. Blocking for up to ~2 seconds, will return early
+    /// if results are available sooner.
     /// @param service servicename to lookup
     /// @param hints hints about limiting the types of services that will
     ///        respond
@@ -368,6 +369,8 @@ private:
     /// Metadata for an subscribed mDNS cashed address.
     struct MDNSCacheAddr
     {
+        uint32_t timestamp_; ///< timestamp in seconds since last discovered
+        uint32_t ttl_; ///< time to live for the entry in seconds
         sa_family_t family_; ///< protocol family
         uint16_t port_; ///< port number, network endianness
         union
@@ -600,7 +603,7 @@ private:
     std::vector<NetworkEntry> scanResults_; ///< AP scan results
     std::string staConnectPass_; ///< last station connect attempt password
     const std::string hostname_; ///< published hostname
-    unsigned mdnsStaLockCount_; ///< counter for recursive mDNS STA lock
+    int mdnsStaLockCount_; ///< counter for recursive mDNS STA lock
     uint8_t apClientCount_; ///< number of connected wifi clients
 
     //

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
@@ -59,13 +59,9 @@
 ///   -# init()
 ///       - performs initialize before starting WiFi
 ///   -# setup_ap()
-///       - option, can be used to override the stored AP profile in bootloader
+///       - optional, can be used to override the stored AP profile
 ///   -# start()
 ///       - starts the WiFi based on config (AP, STA, or AP + STA mode)
-///
-/// By default, all user configuration is volatile, and will be forgotten upon
-/// reboot. This is useful for a bootloader that just needs to connect to the
-/// "last" known STA and broadcast the "default" AP. Bootloader example:
 ///
 /// @code
 /// EspIdfWifi wifi;
@@ -80,12 +76,27 @@
 /// }
 /// @endcode
 ///
-/// In order to support non-volatile configuration, use the specialized version
-/// of this object that includes a DefaultConfigUpdateListener instead.
-/// Whenever there is an update to the WiFi profiles managed by this object,
-/// the virtual method config_sync() is called. config_sync() can be overriden
-/// in a derived version of this object in order to trigger synchronization with
-/// more complex user configuration, such as that of memory spaces and CDI.
+/// This base object contains no user configuration. The only non-volatile
+/// configuration it contains is the credentials for the last STA that a
+/// successful connection was mad to. Its constructor is intentionally protected
+/// such that some derived version is required for further specialization. Two
+/// such specializations are provided.
+///
+///   -# EspIdfWiFi
+///       - This is a templated class that implements user configuration for
+///         AP and STA profiles, factory reset default SSIDs and passwords,
+///         max AP client connections, and max STA profiles.
+///       - DefaultEspIdfWiFiHwDefs is provided as a default configuration. It
+///         can be used directly, or as a reference in creating a customized
+///         variant.
+///   -# EspIdfWiFiConfigDefalt
+///       - Implemented as shorthand for EspIdfWiFi<DefaultEspIdfWiFiHwDefs>
+///   -# EspIdfWiFiNoConfig
+///       - This version provides no user configuration, and assumes that fast
+///         connect will always be used. It allows the user to explicitly
+///         specify the AP credentials at construction. This version can be
+///         useful for bootloaders where fixed credentials and no user
+///         configuration is often desired.
 ///
 /// Note: The protected status variables in the WiFiInterface object are only
 ///       modified from the ESP event handler thread. Therefore, they do not
@@ -1110,7 +1121,7 @@ private:
 
 /// Specialization of the EspIdfWiFiBase with no user configuration. It will
 /// broadcast an AP, if given credentials. In STA mode, it will connect to the
-/// last known AP only.
+/// last known AP only, always using fast connect.
 class EspIdfWiFiNoConfig : public EspIdfWiFiBase
 {
 public:
@@ -1285,7 +1296,7 @@ private:
     SecurityType apSec_; ///< passed in AP security
 };
 
-/// Default configuration type.
+/// Shorthand for default configuration type.
 using EspIdfWiFiConfigDefault = EspIdfWiFi<DefaultEspIdfWiFiHwDefs>;
 
 #endif // _FREERTOS_DRIVERS_ESP_IDF_ESPIDFWIFI_HXX_

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
@@ -1,0 +1,626 @@
+/** @copyright
+ * Copyright (c) 2024, Balazs Racz, 2025, Stuart Baker
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file EspIdfWiFi.hxx
+ *
+ * Interface for interacting with WiFi services.
+ *
+ * @author Balazs Racz, extended by Stuart Baker
+ * @date 27 Aug 2024, extended starting Jun 17 2025
+ */
+
+#ifndef _FREERTOS_DRIVERS_ESP_IDF_ESPIDFWIFI_HXX_
+#define _FREERTOS_DRIVERS_ESP_IDF_ESPIDFWIFI_HXX_
+
+#include <esp_netif.h>
+#include <nvs_flash.h>
+
+#include "executor/Service.hxx"
+#include "executor/StateFlow.hxx"
+#include "freertos_drivers/common/WiFiInterface.hxx"
+
+#include <sys/socket.h>
+
+#include <list>
+
+#if OPENMRN_HAVE_BSD_SOCKETS_IPV6
+#if LWIP_IPV6
+#define ESP_IDF_WIFI_IPV6
+#endif
+#endif
+
+/// Object for managing WiFi and network interfaces. The following sequence
+/// must be called within or after app_main() in the following order:
+///   -# init()
+///       - performs initialize before starting WiFi
+///   -# setup_ap()
+///       - option, can be used to override the stored AP profile in bootloader
+///   -# start()
+///       - starts the WiFi based on config (AP, STA, or AP + STA mode)
+///
+/// By default, all user configuration is volatile, and will be forgotten upon
+/// reboot. This is useful for a bootloader that just needs to connect to the
+/// "last" known STA and broadcast the "default" AP. Bootloader example:
+///
+/// @code
+/// EspIdfWifi wifi;
+///
+/// void app_main(void)
+/// {
+///     ESP_ERROR_CHECK(nvs_flash_init());
+///     wifiMgr.init();
+///     wifiMgr.setup_ap(wifiMgr.get_hostname().c_str(),
+///         wifiMgr.DEFAULT_PASSWORD, wifiMgr.SEC_WPA2);
+///     wifiMgr.start(WlanRole::AP_STA);
+/// }
+/// @endcode
+///
+/// In order to support non-volatile configuration, use the specialized version
+/// of this object EspIdfWiFiWithConfigUpdateListener instead. In this version,
+/// whenever there is an update to the user configuration, an update flow is
+/// triggered which will commit the user config to both NVS and a companion
+/// MemorySpace.
+///
+class EspIdfWiFi : public WiFiInterface, public StateFlowBase, protected OSMutex
+{
+public:
+    /// Default wifi password.
+    static constexpr char DEFAULT_PASSWORD[] = "123456789";
+
+    /// Constructor.
+    /// @param service service to bind this object to.
+    /// @param hostname hostname to publish over the network
+    /// @param can_hub CAN hub to use
+    EspIdfWiFi(Service *service, const char * hostname)
+        : StateFlowBase(service)
+        , OSMutex(true) // Recursive.
+        , initialized_(false)
+        , timer_(this)
+        , apIface_(nullptr)
+        , staIface_(nullptr)
+        , hostname_(hostname)
+        , mdnsStaLockCount_(1) // Start disabled, enable when IP received.
+        , apClientCount_(0)
+        , mdnsClientStarted_(false)
+        , mdnsClientTrigRefresh_(false)
+        , mdnsAdvInhibit_(false)
+        , mdnsAdvInhibitSta_(false)
+        , fastConnectOnlySta_(false)
+    {
+        wait_and_call(STATE(mdns_start));
+    }
+
+    /// Initialize the WiFi.
+    void init() override
+    {
+        init_config();
+    }
+
+    /// Start the WiFi.
+    /// @param role device role
+    void start(WlanRole role = WlanRole::DEFAULT_ROLE) override
+    {
+        init_wifi(role);
+        initialized_ = true;
+    }
+
+    /// Stop the WiFi.
+    void stop() override;
+
+    /// Connect to access point.
+    /// @param ssid access point SSID
+    /// @param pass access point password
+    /// @param sec_type access point security type
+    /// @return WlanConnectResult::CONNECT_OK upon connect, else error code
+    WlanConnectResult connect(
+        const char *ssid, const char *pass, SecurityType sec_type) override;
+
+    /// Disconnect from the current AP.
+    void disconnect() override;
+
+    /// Setup access point role credentials. May require reboot to take effect.
+    /// @param ssid access point SSID
+    /// @param pass access point password
+    /// @param sec_type access point security type
+    void setup_ap(
+        const char *ssid, const char *pass, SecurityType sec_type) override;
+
+    /// Retrieve current access point config.
+    /// @param ssid access point SSID
+    /// @param sec_type access point security type
+    void get_ap_config(std::string *ssid, SecurityType *sec_type) override
+    {
+        OSMutexLock locker(this);
+        *ssid = userCfg_.ap_.ssid_;
+        *sec_type = sec_type_encode(userCfg_.ap_.sec_);
+    }
+
+    /// Retrieves the number of clients connected to the WiFi in access point
+    /// mode.
+    /// @return number of connected stations, else -1 if not in AP mode.
+    int get_ap_sta_count() override
+    {
+        return apIface_ ? apClientCount_ : -1;
+    }
+
+    /// Get the WiFi role.
+    /// @return current WiFi role
+    WlanRole role() override
+    {
+        if (apIface_)
+        {
+            return staIface_ ? WlanRole::AP_STA : WlanRole::AP;
+        }
+        else if (staIface_)
+        {
+            return WlanRole::STA;
+        }
+        return WlanRole::UNKNOWN;
+    }
+
+    /// Change the default role. This will be used in the next start() if the
+    /// DEFAULT_ROLE is specified. The new setting takes effect when the
+    /// device is restarted (either via reboot or stop + start)
+    /// @param new_role new role, must not be UNKOWN or DEFAULT_ROLE
+    void set_role(WlanRole new_role) override;
+
+    /// Add a saved WiFi access point profile.
+    /// @param ssid access point SSID
+    /// @param pass access point password
+    /// @param sec_type access point security type
+    /// @param priority priority when more than one profile is saved, 0 =
+    ///        lowest priority, may be unused
+    /// @return resulting index in the list of profiles, else -1 on error
+    int profile_add(const char *ssid, const char *pass,
+        SecurityType sec_type, uint8_t priority) override;
+
+    /// Delete a saved WiFi access point profile.
+    /// @param ssid access point SSID
+    /// @return profile index deleted, else -1 if profile not found
+    int profile_del(const char *ssid) override
+    {
+        int index = find_sta_profile(std::string(ssid));
+        if (index >= 0)
+        {
+            profile_del(index);
+        }
+        return index;
+    }
+
+    /// Delete a saved WiFi access point profile.
+    /// @param index index of profile to delete, 0xFF removes all
+    /// @return 0 if successful, else -1 if profile not found
+    int profile_del(uint8_t index) override
+    {
+        if (index >= ARRAYSIZE(userCfg_.sta_))
+        {
+            return -1;
+        }
+        {
+            OSMutexLock lock(this);
+            memset(userCfg_.sta_[index].ssid_, 0, MAX_SSID_SIZE);
+            memset(userCfg_.sta_[index].pass_, 0, MAX_SSID_SIZE);
+        }
+        config_sync();
+        return 0;
+    }
+
+    /// Get a saved WiFi access point profile by index.
+    /// @param index index within saved profilelist to get
+    /// @param ssid 33 byte array that will return the SSID of the index
+    /// @param sec_type will return the security type of the index
+    /// @param priority will return the priority of the index, may be unused
+    /// @return 0 upon success, -1 on error (index does not exist)
+    int profile_get(int index, char ssid[], SecurityType *sec_type,
+        uint8_t *priority) override;
+
+    /// Get a list of available networks. This is based on a prior scan. Use
+    /// rescan() and wait for the scan to complete to refresh the list.
+    /// @param entries returns a list of available network entries
+    /// @param count max size of the entry list to return.
+    /// @return number of valid network entries in the list, same as
+    ///         entries->size()
+    int network_list_get(
+        std::vector<NetworkEntry> *entries, size_t count) override
+    {
+        OSMutexLock locker(this);
+        *entries = scanResults_;
+        return entries->size();
+    }
+
+    /// Get the indexed network entry from the last of scan results. Use
+    /// rescan() and wait for the scan to complete to refresh the results.
+    /// @param entry location to fill in the network entry
+    /// @param index index in the network entry list to get
+    /// @return 0 on success, else -1 if index is beyond the list of entries.
+    int network_get(NetworkEntry *entry, unsigned index) override
+    {
+        OSMutexLock locker(this);
+        if (index >= scanResults_.size())
+        {
+            return -1;
+        }
+        *entry = scanResults_[index];
+        return 0;
+    }
+
+    /// Initiate scanning of available networks.
+    void scan() override;
+
+    /// Get the RSSI of the AP in STA mode.
+    /// @return signal strength, 0 when not connected to an access point
+    int rssi() override;
+
+    /// Get the network hostname for the device.
+    /// @return hostname
+    std::string get_hostname() override
+    {
+        // We don't need to get this from the interface because it is cached.
+        return hostname_;
+    }
+
+    /// In some cases, we want to disable mDNS publishing in station mode.
+    void disable_mdns_publish_on_sta()
+    {
+        mdns_disable_sta();
+        mdnsAdvInhibitSta_ = true;
+    }
+
+    /// In some cases, we want to only use the last known connection
+    /// credentials in STA mode.
+    void enable_fast_connect_only_on_sta()
+    {
+        fastConnectOnlySta_ = true;
+    }
+
+    /// Add service to mDNS server.
+    /// @param service service, e.g. _openlcb-can._tcp
+    /// @param port service port
+    void mdns_service_add(const char *service, uint16_t port);
+
+    /// Remove service from mDNS server.
+    /// @param service service, e.g. _openlcb-can._tcp
+    void mdns_service_remove(const char *service);
+
+    /// Lookup an mDNS name.
+    /// @param service servicename to lookup
+    /// @param hints hints about limiting the types of services that will
+    ///        respond
+    /// @param addrinfo structure containing one or more service addressess that
+    ///        match the enquery, else nullptr if no matching service found
+    /// @return 0 upon success, or appropriate EAI_* error on failure, use
+    ///         ::freeaddrinfo() to free up memory allocated to the non nullptr
+    ///         *addr returned
+    int mdns_lookup(
+        const char *service, struct addrinfo *hints, struct addrinfo **addr);
+
+    /// Start continuous scan for mDNS service name.
+    /// @param service servicename to scan
+    void mdns_scan(const char *service);
+
+protected:
+    /// WiFi STA or AP credentials.
+    struct WiFiConfigCredentialsNVS
+    {
+        char ssid_[33]; ///< STA SSID
+        uint8_t sec_; ///< STA security mode
+        char pass_[64]; ///< STA password
+    };
+
+    /// C structure version of the WiFi configuration settings.
+    struct WiFiConfigNVS
+    {
+        uint32_t magic_; ///< magic number to detect initialization
+        WlanRole mode_; ///< role that the device will operate (AP, STA, etc.)
+        WiFiConfigCredentialsNVS ap_; ///< access point configuration
+        WiFiConfigCredentialsNVS sta_[7]; ///< station profiles
+    };
+
+    /// Private configuration metadata.
+    struct ConfigPrivate
+    {
+        WiFiConfigCredentialsNVS last_; ///< last STA successfully connected to
+        uint8_t channelLast_; ///< last channel successfully connected with
+    };
+
+    /// Magic number to detect initialization
+    static constexpr uint32_t WIFI_CONFIG_INIT_MAGIC = 0x6160CBC6;
+
+    /// Default STA SSID.
+    static constexpr char DEFAULT_STA_SSID[] = "LAYOUTWIFI";
+
+    /// NVS key for the WiFi user config.
+    static constexpr char NVS_KEY_USER_NAME[] = "user";
+
+    /// NVS key for the WiFi private config.
+    static constexpr char NVS_KEY_LAST_NAME[] = "last";
+
+    /// Maximum length of a stored SSID not including '/0' termination.
+    static constexpr size_t MAX_SSID_SIZE =
+        sizeof(WiFiConfigCredentialsNVS::ssid_) - 1;
+    static_assert(MAX_SSID_SIZE == 32, "Invalid maximum SSID length.");
+
+    /// Maximum length of a stored password not including '/0' termination.
+    static constexpr size_t MAX_PASS_SIZE =
+        sizeof(WiFiConfigCredentialsNVS::pass_) - 1;
+    static_assert(MAX_PASS_SIZE == 63, "Invalid maximum password length.");
+
+    /// Reset configuration to factory defaults.
+    void factory_default();
+
+    nvs_handle_t cfg_; ///< handle to the nvs config for wifi configuration
+    WiFiConfigNVS userCfg_; ///< cached copy of the wifi user config
+    ConfigPrivate privCfg_; ///< private WiFi configuration
+    bool initialized_; ///< initialization complete
+
+private:
+    /// Metadata for a registered mDNS service.
+    struct MDNSService
+    {
+        /// Add service to mDNS server.
+        /// @param service service name
+        /// @param proto service protocol (_tcp, _udp, ect.)
+        /// @param port service port
+        MDNSService(std::string name, std::string proto, uint16_t port)
+            : name_(name)
+            , proto_(proto)
+            , port_(port)
+        {
+        }
+        std::string name_; ///< service name
+        std::string proto_; ///< service protocol
+        uint16_t port_; ///< service port
+    };
+
+    /// Metadata for an subscribed mDNS cashed address.
+    struct MDNSCacheAddr
+    {
+        sa_family_t family_; ///< protocol family
+        uint16_t port_; ///< port number, network endianness
+        union
+        {
+            struct sockaddr addr_; ///< address
+            struct sockaddr_in addrIn_; ///< IPv4 address
+#if defined(ESP_IDF_WIFI_IPV6)
+            struct sockaddr_in6 addrIn6_; ///< IPv6 address
+#endif
+        };
+    };
+
+    /// Metadata for a subscribed mDNS client.
+    struct MDNSCacheItem
+    {
+        /// Constructor.
+        MDNSCacheItem(std::string service)
+            : service_(service)
+            , searchHandle_(nullptr)
+        {
+        }
+
+        /// Reset the search.
+        /// @param handle the new search handle value, delete previous handle
+        ///        if still valid, should be called with mutex lock
+        void reset(void *handle = nullptr);
+
+        /// Get the current search handle
+        /// @return current search handle
+        void *get()
+        {
+            return searchHandle_;
+        }
+
+        std::string service_; ///< sevice name
+        std::list<MDNSCacheAddr> addr_; ///< list of addresses
+        void *searchHandle_; ///< mDNS search once key
+    };
+
+    /// Cache of all the subscribed mDNS services.
+    std::vector<MDNSCacheItem> mdnsClientCache_;
+
+    /// NVS namespace for the wifi configuration.
+    static constexpr char NVS_NAMESPACE_NAME[] = "wifi_config";
+
+    /// Maximum number of MDNS results we will cache for a given service.
+    static constexpr size_t MDNS_RESULT_COUNT_MAX = 5;
+
+    /// Timeout value passed for an mDNS query in asynchronous mode.
+    static constexpr uint32_t MDNS_QUERY_ASYNC_NEW_TIMEOUT_MSEC = 700;
+
+    /// State flow timeout for checking on mDNS query results.
+    static constexpr long long MDNS_QUERY_CHECK_TIMEOUT_NSEC =
+        MSEC_TO_NSEC(100);
+
+    /// State flow timeout for inactive time between mDNS queries.
+    static constexpr long long MDNS_QUERY_INACTIVE_TIMEOUT_NSEC =
+        SEC_TO_NSEC(10);
+
+    /// Entry point. Wait for mDNS client to be invoked.
+    /// @return next state mdns_start()
+    Action mdns_wait()
+    {
+        return wait_and_call(STATE(mdns_start));
+    }
+
+    /// Start an mDNS query sequence. If mDNS advertising is inhibited in STA
+    /// mode, then inhibit advertisements during the query.
+    /// @return next state mdns_query()
+    Action mdns_start();
+
+    /// Register the mDNS queries with the mDNS client.
+    /// @return next state mdns_check() after timeout
+    Action mdns_query();
+
+    /// Check the results of the mDNS queries.
+    /// @return next state mdns_check() after timeout if there are still active
+    ///         queries, mdns_query() if another mdns_scan() was triggered,
+    ///         else mdns_start() after timeout
+    Action mdns_check();
+
+    /// Split a service into its name and protocol parts
+    /// @param service service, e.g. _openlcb-can._tcp
+    /// @param name name component, e.g. _openlcb-can
+    /// @param proto protocol component, e.g. _tcp
+    void mdns_split(const char *service, std::string *name, std::string *proto)
+    {
+        *name = service;
+        size_t split = name->find('.');
+        if (split != std::string::npos)
+        {
+            proto->assign(name->substr(split + 1));
+            name->resize(split);
+        }
+    }
+
+    /// Put an advertising inhibit in place.
+    void mdns_adv_inhibit();
+
+    /// Remove the advertising inhibit.
+    void mdns_adv_inhibit_remove();
+
+    /// Unconditionally disable mDNS on the station interface.
+    void mdns_disable_sta();
+
+    /// Restore mDNS status on the STA interface.
+    void mdns_restore_sta();
+
+    /// Static callback for the ESP event handler.
+    /// @param arg passed in context (this pointer)
+    /// @param base event base
+    /// @param id event id
+    /// @param data event data
+    static void wifi_event_handler(void *arg, esp_event_base_t base, int32_t id,
+        void *data)
+    {
+        static_cast<EspIdfWiFi*>(arg)->wifi_event_handler(base, id, data);
+    }
+
+        /// Static callback for the ESP event handler.
+    /// @param arg passed in context (this pointer)
+    /// @param base event base
+    /// @param id event id
+    /// @param data event data
+    static void ip_event_handler(void *arg, esp_event_base_t base, int32_t id,
+        void *data)
+    {
+        static_cast<EspIdfWiFi*>(arg)->ip_event_handler(base, id, data);
+    }
+
+    /// In context ESP event handler.
+    /// @param base event base
+    /// @param id event id
+    /// @param data event data
+    void wifi_event_handler(esp_event_base_t base, int32_t id, void *data);
+
+    /// In context ESP event handler.
+    /// @param base event base
+    /// @param id event id
+    /// @param data event data
+    void ip_event_handler(esp_event_base_t base, int32_t id, void *data);
+
+    /// Initialize wifi configuration, including program defaults if necessary.
+    void init_config();
+
+    /// Initialize the WiFi.
+    /// @param role device role
+    void init_wifi(WlanRole role);
+
+    /// Initialize the WiFi soft access point.
+    /// @param ssid SSID
+    /// @param pass password
+    void init_softap(std::string ssid, std::string pass);
+
+    /// Initialize the Wifi station.
+    void init_sta();
+
+    /// Initiate a WiFi station connect.
+    /// @param ssid SSID
+    /// @param pass password
+    /// @param authmode authentication mode, default 1 = WIFI_AUTH_WEP
+    /// @param channel WiFi channel
+    void sta_connect(std::string ssid, std::string pass, uint8_t authmode = 1,
+        uint8_t channel = 0);
+
+    /// Set/Update the last WiFi STA mode connection parameters.
+    /// @param ssid SSID
+    /// @param pass password
+    /// @param authmode authentication mode
+    /// @param channel WiFi channel
+    void last_sta_update(
+        std::string ssid, std::string pass, uint8_t authmode, uint8_t channel);
+
+    /// Get the last WiFi STA mode connection parameters.
+    /// @param ssid SSID, empty string if invalid
+    /// @param pass password
+    /// @param authmode authentication mode
+    /// @param channel WiFi channel
+    void last_sta_get(
+        std::string *ssid, std::string *pass, uint8_t *authmode,
+        uint8_t *channel);
+
+    /// Find a WiFi STA profile that matches the given SSID
+    /// @param ssid SSID to match
+    /// @return index within the wifi profiles config, else -1 if not found
+    int find_sta_profile(std::string ssid);
+
+    /// Translate from generic security type to ESP security type.
+    /// @param sec_type generic security type
+    /// @return ESP security type
+    uint8_t sec_type_translate(SecurityType sec_type);
+
+    /// Translate from ESP security type to generic security type.
+    /// @param sec_type generic security type
+    /// @return ESP security type
+    SecurityType sec_type_encode(uint8_t sec_type);
+
+    /// Trigger synchronize configuration between NVS and MemorySpace.
+    virtual void config_sync()
+    {
+    }
+
+    StateFlowTimer timer_; ///< sleep timer helper object
+    esp_netif_t *apIface_; ///< access point network interface
+    esp_netif_t *staIface_; ///< station network interface
+    std::vector<MDNSService> mdnsServices_; ///< registered mDNS services
+    std::vector<NetworkEntry> scanResults_; ///< AP scan results
+    std::string staConnectPass_; ///< last station connect attempt password
+    const char *hostname_; ///< published hostname
+    unsigned mdnsStaLockCount_; ///< counter for recursive mDNS STA lock
+    uint8_t apClientCount_; ///< number of connected wifi clients
+
+    // Note: The following boolean values are not bitmasks so that mutual
+    //       exclusion is less of a concern. They could be made bitmasks if the
+    //       mutual exclusion contract is reviewed and protections are added
+    //       if needed.
+    bool mdnsClientStarted_; ///< mDNS client state machine started.
+    bool mdnsClientTrigRefresh_; ///< an mDNS client refresh has been triggered
+    bool mdnsAdvInhibit_; ///< true if services are blocked from advertising
+    bool mdnsAdvInhibitSta_; ///< true if mDNS advertising is blocked on STA
+    bool mdnsAdvInhibitStaActive_; ///< true if mdnsAdvInhibitSta_ is active
+    bool mdnsScanActive_; ///< mDNS scanning is active
+    bool fastConnectOnlySta_; ///< true if only to use fast connect credentials
+};
+
+#endif // _FREERTOS_DRIVERS_ESP_IDF_ESPIDFWIFI_HXX_

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
@@ -390,7 +390,16 @@ private:
     struct MDNSCacheItem
     {
         /// Constructor.
+        /// @param service service name to look for, captured by std::move()
         MDNSCacheItem(std::string service)
+            : service_(std::move(service))
+            , searchHandle_(nullptr)
+        {
+        }
+
+        /// Constructor.
+        /// @param service service name to look for, string is copied in
+        MDNSCacheItem(const char *service)
             : service_(service)
             , searchHandle_(nullptr)
         {
@@ -575,7 +584,8 @@ private:
     /// Retrieve current access point config, including password.
     /// @param ssid access point SSID
     /// @param pass access point password
-    virtual void get_ap_config(std::string *ssid, std::string *pass) = 0;
+    virtual void get_ap_config_password(
+        std::string *ssid, std::string *pass) = 0;
 
     /// Find a WiFi STA profile that matches the given SSID
     /// @param ssid SSID to match
@@ -857,7 +867,7 @@ private:
     /// Retrieve current access point config, including password.
     /// @param ssid access point SSID
     /// @param pass access point password
-    void get_ap_config(std::string *ssid, std::string *pass) override
+    void get_ap_config_password(std::string *ssid, std::string *pass) override
     {
         SecurityType sec_type;
         OSMutexLock locker(&lock_);

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
@@ -36,7 +36,6 @@
 #define _FREERTOS_DRIVERS_ESP_IDF_ESPIDFWIFI_HXX_
 
 #include <esp_netif.h>
-#include <nvs_flash.h>
 
 #include "executor/Service.hxx"
 #include "executor/StateFlow.hxx"
@@ -234,10 +233,8 @@ public:
         }
         {
             OSMutexLock locker(&lock_);
-            memset(userCfg_.sta_[index].ssid_, 0,
-                sizeof(userCfg_.sta_[index].ssid_));
-            memset(userCfg_.sta_[index].pass_, 0,
-                sizeof(userCfg_.sta_[index].pass_));
+            memset(userCfg_.sta_[index].ssid_, 0, MAX_SSID_SIZE);
+            memset(userCfg_.sta_[index].pass_, 0, MAX_PASS_SIZE);
         }
         config_sync();
         return 0;
@@ -379,6 +376,9 @@ protected:
     /// Default STA SSID.
     static constexpr char DEFAULT_STA_SSID[] = "LAYOUTWIFI";
 
+    /// NVS namespace for the wifi configuration.
+    static constexpr char NVS_NAMESPACE_NAME[] = "wifi_config";
+
     /// NVS key for the WiFi user config.
     static constexpr char NVS_KEY_USER_NAME[] = "wifi_user.v1";
 
@@ -387,13 +387,13 @@ protected:
 
     /// Maximum length of a stored SSID not including '\0' termination.
     static constexpr size_t MAX_SSID_SIZE =
-        sizeof(WiFiConfigCredentialsNVS::ssid_) - 1;
-    static_assert(MAX_SSID_SIZE == 32, "Invalid maximum SSID length.");
+        sizeof(WiFiConfigCredentialsNVS::ssid_);
+    static_assert(MAX_SSID_SIZE == 33, "Invalid maximum SSID length.");
 
     /// Maximum length of a stored password not including '\0' termination.
     static constexpr size_t MAX_PASS_SIZE =
-        sizeof(WiFiConfigCredentialsNVS::pass_) - 1;
-    static_assert(MAX_PASS_SIZE == 63, "Invalid maximum password length.");
+        sizeof(WiFiConfigCredentialsNVS::pass_);
+    static_assert(MAX_PASS_SIZE == 64, "Invalid maximum password length.");
 
     /// Reset configuration to factory defaults.
     void factory_default();
@@ -426,7 +426,6 @@ protected:
     ///   - mdnsClientCache_ (services being looked for)
     OSMutex lock_;
 
-    nvs_handle_t cfg_; ///< handle to the nvs config for wifi configuration
     WiFiConfigNVS userCfg_; ///< cached copy of the wifi user config
     ConfigPrivate privCfg_; ///< private WiFi configuration
     bool initialized_; ///< initialization complete
@@ -491,9 +490,6 @@ private:
         std::list<MDNSCacheAddr> addr_; ///< list of addresses
         void *searchHandle_; ///< mDNS search once key
     };
-
-    /// NVS namespace for the wifi configuration.
-    static constexpr char NVS_NAMESPACE_NAME[] = "wifi_config";
 
     /// Maximum number of MDNS results we will cache for a given service.
     static constexpr size_t MDNS_RESULT_COUNT_MAX = 5;

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
@@ -496,14 +496,6 @@ private:
         {
         }
 
-        /// Constructor.
-        /// @param service service name to look for, string is copied in
-        MDNSCacheItem(const char *service)
-            : service_(service)
-            , searchHandle_(nullptr)
-        {
-        }
-
         /// Reset the search.
         /// @param handle the new search handle value, delete previous handle
         ///        if still valid, should be called with mutex lock

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
@@ -995,15 +995,15 @@ public:
     ///        it internal mutex.
     /// @param hostname hostname to publish over the network, it is be copied
     ///        over to an std::string
-    /// @param ap_ssid SSID of the AP
-    /// @param ap_pass password of the AP
+    /// @param ap_ssid SSID of the AP, copied into an std::string()
+    /// @param ap_pass password of the AP, copied into an sd::string()
     /// @param ap_sec security mode of the ap
     EspIdfWiFiNoConfig(Service *service, const char *hostname,
-        const char *ap_ssid = nullptr, const char *ap_pass = nullptr,
+        const char *ap_ssid = "", const char *ap_pass = "",
         SecurityType ap_sec = SEC_OPEN)
         : EspIdfWiFiBase(service, hostname)
-        , apSsid_(ap_ssid ? ap_ssid : "")
-        , apPass_(ap_pass ? ap_pass : "")
+        , apSsid_(ap_ssid)
+        , apPass_(ap_pass)
         , apSec_(ap_sec)
     {
         enable_fast_connect_only_on_sta();

--- a/src/utils/format_utils.cxx
+++ b/src/utils/format_utils.cxx
@@ -351,7 +351,7 @@ string ipv6_to_string(uint8_t ip[16])
             }
             ret += tmp;
         }
-        if (i & 0x1 )
+        if (i & 0x1)
         {
             ret.push_back(':');
         }

--- a/src/utils/format_utils.cxx
+++ b/src/utils/format_utils.cxx
@@ -333,3 +333,30 @@ string ipv4_to_string(uint8_t ip[4])
 
     return ret;
 }
+
+string ipv6_to_string(uint8_t ip[16])
+{
+    string ret;
+    ret.reserve(32+8);
+    char tmp[10];
+    for (int i = 0; i < 16; ++i)
+    {
+        uint16_t ip_seg16 = ((uint16_t)ip[i + 1] << 8) + ip[i];
+        if (ip_seg16 != 0)
+        {
+            unsigned_integer_to_buffer_hex(ip[i], tmp);
+            if (ip[i] <= 9)
+            {
+                ret += '0';
+            }
+            ret += tmp;
+        }
+        if (i & 0x1 )
+        {
+            ret.push_back(':');
+        }
+    }
+    ret.pop_back();
+
+    return ret;
+}

--- a/src/utils/format_utils.cxx
+++ b/src/utils/format_utils.cxx
@@ -333,30 +333,3 @@ string ipv4_to_string(uint8_t ip[4])
 
     return ret;
 }
-
-string ipv6_to_string(uint8_t ip[16])
-{
-    string ret;
-    ret.reserve(32+8);
-    char tmp[10];
-    for (int i = 0; i < 16; ++i)
-    {
-        uint16_t ip_seg16 = ((uint16_t)ip[i + 1] << 8) + ip[i];
-        if (ip_seg16 != 0)
-        {
-            unsigned_integer_to_buffer_hex(ip[i], tmp);
-            if (ip[i] <= 9)
-            {
-                ret += '0';
-            }
-            ret += tmp;
-        }
-        if (i & 0x1)
-        {
-            ret.push_back(':');
-        }
-    }
-    ret.pop_back();
-
-    return ret;
-}

--- a/src/utils/format_utils.hxx
+++ b/src/utils/format_utils.hxx
@@ -186,7 +186,7 @@ inline string ipv4_to_string(uint32_t ip)
 /// Formats an IPv6 address to string.
 /// @param ip a 16-byte array storing the IPv6 address, ip[0] will be printed
 ///        at the beginning (network endianness)
-/// @return a string containing a collon-separated printout of the given IPv6
+/// @return a string containing a colon-separated printout of the given IPv6
 ///         address
 string ipv6_to_string(uint8_t ip[16]);
 

--- a/src/utils/format_utils.hxx
+++ b/src/utils/format_utils.hxx
@@ -183,6 +183,14 @@ inline string ipv4_to_string(uint32_t ip)
     return ipv4_to_string((uint8_t*)&ip);
 }
 
+/// Formats an IPv6 address to string.
+/// @param ip a 16-byte array storing the IPv6 address, ip[0] will be printed
+///        at the beginning (network endianness)
+/// @return a string containing a collon-separated printout of the given IPv6
+///         address
+string ipv6_to_string(uint8_t ip[16]);
+
+
 /// Populates a character array with a C string. Copies the C string,
 /// appropriately truncating if it is too long and filling the remaining space
 /// with zeroes. Ensures that at least one null terminator character is

--- a/src/utils/format_utils.hxx
+++ b/src/utils/format_utils.hxx
@@ -183,14 +183,6 @@ inline string ipv4_to_string(uint32_t ip)
     return ipv4_to_string((uint8_t*)&ip);
 }
 
-/// Formats an IPv6 address to string.
-/// @param ip a 16-byte array storing the IPv6 address, ip[0] will be printed
-///        at the beginning (network endianness)
-/// @return a string containing a colon-separated printout of the given IPv6
-///         address
-string ipv6_to_string(uint8_t ip[16]);
-
-
 /// Populates a character array with a C string. Copies the C string,
 /// appropriately truncating if it is too long and filling the remaining space
 /// with zeroes. Ensures that at least one null terminator character is


### PR DESCRIPTION
Done:
- Creates and abstract interface for WiFi management. Eventually this should be harmonized with the CC32xx.
- handles mDNS advertising and queries.
  - includes special handling to allow for masking mDNS advertising on the STA interface during a query.
- Updates WiFi configuration.
- Enforces a consistent (default) hostname between bootloader and application.
- Bootloader always uses well-known AP credentials.
- Bootloader mode "fast" connects only to the last known STA credentials.
- Workaround for "global" mDNS API.

Todo:
- Unit testing.
- Auto scan trigger when STA mode is up and IP assigned.