### PR TITLE
ESP IDF Refactor AP Scan

### DIFF
--- a/src/freertos_drivers/common/WiFiInterface.hxx
+++ b/src/freertos_drivers/common/WiFiInterface.hxx
@@ -91,6 +91,15 @@ public:
     /// @return maximum number of stored STA profiles
     virtual uint8_t max_sta_profiles() = 0;
 
+    /// Get the maximum number of AP scan results collected, per scan.
+    /// @return maximum number of scan results
+    virtual uint8_t max_ap_scan_results() = 0;
+
+    /// Get the configuration for pruning duplicate AP scan results by RSSI.
+    /// @return true to prune out duplicate AP scan results, taking the highest
+    ///         RSSI, else false to keep duplicates
+    virtual bool prune_duplicate_ap_scan_results_by_rssi() = 0;
+
     /// Connect to access point. This is a non-blocking call. The results will
     /// be delivered by callback registered with set_wlan_connect_callback().
     /// The AP credentials are not saved as a connection profile, but they may

--- a/src/freertos_drivers/common/WiFiInterface.hxx
+++ b/src/freertos_drivers/common/WiFiInterface.hxx
@@ -207,9 +207,10 @@ public:
     ///         should be a negative number.
     virtual int rssi() = 0;
 
-    /// Get the network hostname for the device.
+    /// Get the network hostname for the device. This is implemented as a const
+    /// std::string and does not mutate.
     /// @return hostname
-    virtual std::string get_hostname() = 0;
+    virtual const std::string &get_hostname() = 0;
 
     /// Set the callback for when an IP address is acquired.
     /// @param iface interface index

--- a/src/freertos_drivers/common/WifiDefs.hxx
+++ b/src/freertos_drivers/common/WifiDefs.hxx
@@ -100,16 +100,20 @@ struct WiFiDefs
         /// @param ssid SSID of the access point
         /// @param sec_type security type of the access point
         /// @param rssi receive signal strength of the access point
-        NetworkEntry(const char *ssid, SecurityType sec_type, int rssi)
+        /// @param channel channel of the AP, 0 means any/unknown
+        NetworkEntry(const char *ssid, int rssi, SecurityType sec_type,
+            uint8_t channel = 0)
             : ssid(ssid)
-            , secType(sec_type)
             , rssi(rssi)
+            , secType(sec_type)
+            , channel(channel)
         {
         }
 
         std::string ssid; ///< SSID of the access point
+        int16_t rssi; ///< receive signal strength of the access point
         SecurityType secType; ///< security type of the access point
-        int rssi; ///< receive signal strength of the access point
+        uint8_t channel; ///< channel of the AP, 0 means any/unknown
     };
 };
 

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
@@ -773,6 +773,13 @@ struct DefaultEspIdfWiFiHwDefs
 
     /// Maximum number of station profiles we can store.
     static constexpr uint8_t MAX_STA_PROFILES = 7;
+
+    /// Maximum number of AP scan results collected, per scan.
+    static constexpr uint8_t MAX_AP_SCAN_RESULTS = 16;
+
+    /// True to prune out duplicate AP scan results, taking the highest RSSI,
+    /// else false to keep duplicates.
+    static constexpr bool PRUNE_DUPLICATE_AP_SCAN_RESULTS_BY_RSSI = true;
 };
 
 /// Specialization of the EspIdfWiFiBase with allows for user configuration.
@@ -842,6 +849,21 @@ public:
     uint8_t max_sta_profiles() override
     {
         return HWDefs::MAX_STA_PROFILES;
+    }
+
+    /// Get the maximum number of AP scan results collected, per scan.
+    /// @return maximum number of scan results
+    uint8_t max_ap_scan_results() override
+    {
+        return HWDefs::MAX_AP_SCAN_RESULTS;
+    }
+
+    /// Get the configuration for pruning duplicate AP scan results by RSSI.
+    /// @return true to prune out duplicate AP scan results, taking the highest
+    ///         RSSI, else false to keep duplicates
+    bool prune_duplicate_ap_scan_results_by_rssi() override
+    {
+        return HWDefs::PRUNE_DUPLICATE_AP_SCAN_RESULTS_BY_RSSI;
     }
 
     /// Setup access point role credentials. May require reboot to take effect.
@@ -1251,6 +1273,21 @@ public:
     uint8_t max_sta_profiles() override
     {
         return 0;
+    }
+
+    /// Get the maximum number of AP scan results collected, per scan.
+    /// @return maximum number of scan results
+    uint8_t max_ap_scan_results() override
+    {
+        return 16;
+    }
+
+    /// Get the configuration for pruning duplicate AP scan results by RSSI.
+    /// @return true to prune out duplicate AP scan results, taking the highest
+    ///         RSSI, else false to keep duplicates
+    bool prune_duplicate_ap_scan_results_by_rssi() override
+    {
+        return true;
     }
 
     /// Not supported, does nothing.

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
@@ -205,9 +205,10 @@ public:
     ///         should be a negative number.
     int rssi() override;
 
-    /// Get the network hostname for the device.
+    /// Get the network hostname for the device. This is implemented as a const
+    /// std::string and does not mutate.
     /// @return hostname
-    std::string get_hostname() override
+    const std::string &get_hostname() override
     {
         // We don't need to get this from the interface because it is cached.
         return hostname_;

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
@@ -826,7 +826,8 @@ public:
     /// @return default AP SSID, should point to persistent memory
     const char *default_ap_ssid() override
     {
-        return HWDefs::DEFAULT_AP_SSID;
+        return HWDefs::DEFAULT_AP_SSID[0] == '\0' ?
+            get_hostname().c_str() : HWDefs::DEFAULT_AP_SSID;
     }
 
     /// Get the default STA SSID.

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
@@ -647,6 +647,9 @@ private:
     /// @param data event data
     void ip_event_handler(esp_event_base_t base, int32_t id, void *data);
 
+    /// Collect the scan results of a previous scan.
+    void collect_scan_results();
+
     /// Initialize private configuration.
     void init_config_priv();
 
@@ -691,6 +694,10 @@ private:
     /// @param channel WiFi channel
     void last_sta_update(
         std::string ssid, std::string pass, uint8_t authmode, uint8_t channel);
+
+    /// Set/Update the last WiFi STA channel only connection parameter.
+    /// @param channel WiFi channel
+    void last_sta_update_channel(uint8_t channel);
 
     /// Translate from ESP connection reason to generic connection result.
     /// @param reason ESP connection reason

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
@@ -1042,7 +1042,7 @@ private:
         if (index < 0)
         {
             // duplicate slot not found, look for an empty slot.
-            find_sta_profile("");
+            index = find_sta_profile("");
         }
         if (index >= 0)
         {


### PR DESCRIPTION
- Refactor AP scan to use new (improved) ESP IDF API.
- Add configuration for max number of scan results to record for user.
- Add configuration for pruning out duplicate results, keep the highest RSSI.
- Fix bug in profile_add.
- Use hostname as default AP SSID if default AP SSID is empty.