### PR TITLE
WiFi Interface Additions

### DIFF
--- a/src/freertos_drivers/common/WiFiInterface.hxx
+++ b/src/freertos_drivers/common/WiFiInterface.hxx
@@ -143,7 +143,28 @@ public:
     /// @return true if ready, else false
     virtual bool ready()
     {
-        return (ipAcquiredSta_ || ipAcquiredAp_);
+        // It is important to call the API and not access the member variables
+        // directly. This is in case any derived object overrides sta_ready() or
+        // ap_ready() with additional implementation specific logic.
+        return (sta_ready() || ap_ready());
+    }
+
+    /// Get the STA mode ready state.
+    /// @return true if STA is connected to an AP and has an IP address, else
+    ///         false if not connected to an AP or no IP assigned
+    virtual bool sta_ready()
+    {
+        // Typically, an IP cannot be acquired without being connected, so
+        // AND'ing with the connected state flag is simply defensive. An
+        // alternative might be to use an HASSERT(connected_) here instead.
+        return connected_ && ipAcquiredSta_;
+    }
+
+    /// Get the AP mode ready state.
+    /// @return true if AP has an IP address, else false if no IP assigned
+    virtual bool ap_ready()
+    {
+        return ipAcquiredAp_;
     }
 
     /// Get the WiFi role.
@@ -239,6 +260,9 @@ public:
     {
         scanFinishedCallback_ = std::move(callback);
     }
+
+    /// Reset any configuration and/or non-volatile storage to factory defaults.
+    virtual void factory_reset() = 0;
 
 protected:
     /// Constructor.

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
@@ -268,6 +268,29 @@ int EspIdfWiFiBase::rssi()
 }
 
 //
+// EspIdfWiFiBase::factory_reset()
+//
+void EspIdfWiFiBase::factory_reset()
+{
+    nvs_handle_t cfg;
+    esp_err_t result = nvs_open(NVS_NAMESPACE_NAME, NVS_READWRITE, &cfg);
+    if (result != ESP_OK)
+    {
+        LOG_ERROR("wifi: Error %s opening NVS handle.",
+            esp_err_to_name(result));
+        return;
+    }
+
+    // Clear private configuration.
+    memset(&privCfg_, 0, sizeof(privCfg_));
+    nvs_erase_key(cfg, NVS_KEY_LAST_NAME);
+    nvs_commit(cfg);
+    nvs_close(cfg);
+
+    // Default "volatile" values will be put in privCfg_ in init_config_priv().
+}
+
+//
 // EspIdfWiFiBase::mdns_service_add()
 //
 void EspIdfWiFiBase::mdns_service_add(const char *service, uint16_t port)

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
@@ -1263,7 +1263,7 @@ void EspIdfWiFiBase::init_config_priv()
     }
     nvs_close(cfg);
 
-    if (privCfg_.last_.pass_[0] == '\0')
+    if (privCfg_.last_.ssid_[0] == '\0')
     {
         // There are no "last" STA credentials to use for fast connect. Set the
         // default STA as the last connected STA, but do not commit it to
@@ -1272,7 +1272,8 @@ void EspIdfWiFiBase::init_config_priv()
         str_populate<MAX_SSID_SIZE>(privCfg_.last_.ssid_, default_sta_ssid());
         str_populate<MAX_PASS_SIZE>(
             privCfg_.last_.pass_, default_sta_password());
-        privCfg_.last_.sec_ = sec_type_translate(SEC_WPA2);
+        privCfg_.last_.sec_ = privCfg_.last_.pass_[0] == '\0' ?
+            sec_type_translate(SEC_OPEN) : sec_type_translate(SEC_WPA2);
         privCfg_.channelLast_ = 0; // Any channel.
     }
 }

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
@@ -1255,6 +1255,15 @@ void EspIdfWiFiBase::init_config_priv()
             privCfg_.magic_ = PRIV_CONFIG_INIT_MAGIC;
             nvs_set_blob(cfg, NVS_KEY_LAST_NAME, &privCfg_, sizeof(privCfg_));
             nvs_commit(cfg);
+            // Set the default STA as the last connected STA, but do not commit
+            // it to non-volatile storage. It will be commited to non-volatile
+            // storage only once a connection is actually successful.
+            str_populate<MAX_SSID_SIZE>(
+                privCfg_.last_.ssid_, default_sta_ssid());
+            str_populate<MAX_PASS_SIZE>(
+                privCfg_.last_.pass_, default_sta_password());
+            privCfg_.last_.sec_ = sec_type_translate(SEC_WPA2);
+            privCfg_.channelLast_ = 0; // Any channel.
             break;
         default:
             LOG_ERROR("wifi: Error %s getting privCfg_.",

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
@@ -1255,15 +1255,6 @@ void EspIdfWiFiBase::init_config_priv()
             privCfg_.magic_ = PRIV_CONFIG_INIT_MAGIC;
             nvs_set_blob(cfg, NVS_KEY_LAST_NAME, &privCfg_, sizeof(privCfg_));
             nvs_commit(cfg);
-            // Set the default STA as the last connected STA, but do not commit
-            // it to non-volatile storage. It will be commited to non-volatile
-            // storage only once a connection is actually successful.
-            str_populate<MAX_SSID_SIZE>(
-                privCfg_.last_.ssid_, default_sta_ssid());
-            str_populate<MAX_PASS_SIZE>(
-                privCfg_.last_.pass_, default_sta_password());
-            privCfg_.last_.sec_ = sec_type_translate(SEC_WPA2);
-            privCfg_.channelLast_ = 0; // Any channel.
             break;
         default:
             LOG_ERROR("wifi: Error %s getting privCfg_.",
@@ -1271,6 +1262,19 @@ void EspIdfWiFiBase::init_config_priv()
             break;
     }
     nvs_close(cfg);
+
+    if (privCfg_.last_.pass_[0] == '\0')
+    {
+        // There are no "last" STA credentials to use for fast connect. Set the
+        // default STA as the last connected STA, but do not commit it to
+        // non-volatile storage. It will be commited to non-volatile storage
+        // only once a connection is actually successful.
+        str_populate<MAX_SSID_SIZE>(privCfg_.last_.ssid_, default_sta_ssid());
+        str_populate<MAX_PASS_SIZE>(
+            privCfg_.last_.pass_, default_sta_password());
+        privCfg_.last_.sec_ = sec_type_translate(SEC_WPA2);
+        privCfg_.channelLast_ = 0; // Any channel.
+    }
 }
 
 //

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
@@ -1145,7 +1145,7 @@ public:
     void factory_reset() override
     {
         // Reset private configuration.
-        EspIdfWiFiBase::factory_reset();
+        EspIdfWiFi<HWDefs>::factory_reset();
 
         nvs_handle_t cfg;
         esp_err_t result =

--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.hxx
@@ -1255,15 +1255,20 @@ public:
     ///        it internal mutex.
     /// @param hostname hostname to publish over the network, it is be copied
     ///        over to an std::string
-    /// @param ap_ssid SSID of the AP, copied into an std::string()
-    /// @param ap_pass password of the AP, copied into an sd::string()
+    /// @param ap_ssid SSID of the AP, copied into an std::string
+    /// @param ap_pass password of the AP, copied into an sd::string
     /// @param ap_sec security mode of the ap
+    /// @param default_sta_ssid default STA SSID, copied into an std::string
+    /// @param default_sta_pass default STA password, copied into an std::string
     EspIdfWiFiNoConfig(Service *service, const char *hostname,
         const char *ap_ssid = "", const char *ap_pass = "",
-        SecurityType ap_sec = SEC_OPEN)
+        SecurityType ap_sec = SEC_OPEN, const char *default_sta_ssid = "",
+        const char *default_sta_pass = "")
         : EspIdfWiFiBase(service, hostname)
         , apSsid_(ap_ssid)
         , apPass_(ap_pass)
+        , defaultStaSsid_(default_sta_ssid)
+        , defaultStaPass_(default_sta_pass)
         , apSec_(ap_sec)
     {
         enable_fast_connect_only_on_sta();
@@ -1280,7 +1285,7 @@ public:
     /// @return default STA password, should point to persistent memory
     const char *default_sta_password() override
     {
-        return "";
+        return defaultStaPass_.c_str();
     }
 
     /// Get the default AP SSID.
@@ -1294,7 +1299,7 @@ public:
     /// @return default STA SSID, should point to persistent memory
     const char *default_sta_ssid() override
     {
-        return "";
+        return defaultStaSsid_.c_str();
     }
 
     /// Get the maximum number of STA client connections in AP mode. Be careful,
@@ -1426,8 +1431,10 @@ private:
         return -1;
     }
 
-    std::string apSsid_; ///< passed in AP SSID
-    std::string apPass_; ///< passed in AP password
+    const std::string apSsid_; ///< passed in AP SSID
+    const std::string apPass_; ///< passed in AP password
+    const std::string defaultStaSsid_; ///< passed in default STA SSID
+    const std::string defaultStaPass_; ///< passed in default STA password
     SecurityType apSec_; ///< passed in AP security
 };
 


### PR DESCRIPTION
- Add new "ready" API for STA and AP.
- Add factory reset API.
- Port factory reset to ESP IDF.
- Ensure that "default" STA parameters are used in fast connect if non-volatile storage for last STA is empty.