### PR TITLE
Arduino support for Feather M4 CAN 

### DIFF
--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -105,6 +105,14 @@ constexpr UBaseType_t OPENMRN_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO - 1;
 
 #endif
 
+#ifdef ARDUINO_FEATHER_M4_CAN
+
+#include "freertos_drivers/arduino/ArduinoGpio.hxx"
+#include "freertos_drivers/sam/FeatherM4Can.hxx"
+
+#endif
+
+
 namespace openmrn_arduino
 {
 

--- a/arduino/examples/FeatherM4Can/CanSerialNode/CanSerialNode.ino
+++ b/arduino/examples/FeatherM4Can/CanSerialNode/CanSerialNode.ino
@@ -1,0 +1,73 @@
+// OpenMRN demo application for Adafruit SAMD Feather M4 CAN board.
+//
+// This application acts as a USB-CAN interface while also appearing on the
+// OpenLCB bus as a regular node (which does not do anything special really).
+//
+//-----------------------------------------------------------------
+// Board Manager: Adafruit SAMD board
+// Board Manager URL: https://adafruit.github.io/arduino-board-index/package_adafruit_index.json
+
+#ifndef ARDUINO_FEATHER_M4_CAN
+  #error "This sketch should be compiled for Arduino Feather M4 CAN (SAME51)"
+#endif
+
+// These are required to get the right CAN setup working.
+#define CAN0_MESSAGE_RAM_SIZE (0)
+#define CAN1_MESSAGE_RAM_SIZE (1728)
+#include <ACANFD_FeatherM4CAN.h>
+
+//-----------------------------------------------------------------
+
+#include <OpenMRNLite.h>
+
+/// Which serial port to use.
+#define SERIAL_PORT Serial
+
+/// Specify how fast the serial port should be going. In order not to lose
+/// packets on a fully loaded CAN-bus, this has to be at least 460800, but the
+/// default is set to 115200 for better compatibility.
+#define SERIAL_BAUD_RATE 115200
+
+/// This is the OpenLCB Node ID. It must be coming from the Node ID range
+/// assigned to the developer (get a range assigned to you via openlcb.org).
+static constexpr uint64_t NODE_ID = UINT64_C(0x050101011824);
+
+FeatherM4Can CanDriver;
+OpenMRN openmrn(NODE_ID);
+
+OVERRIDE_CONST_TRUE(gc_generate_newlines);
+
+namespace openlcb {
+/// These definitions tell how the Node will appear on the OpenLCB bus for a
+/// network browser.
+extern const SimpleNodeStaticValues SNIP_STATIC_DATA = {
+    4,
+    "OpenMRN",
+    "CAN-Serial-Node Adafruit Feather-M4-CAN",
+    "Feather M4 CAN",
+    "1.00"
+};
+
+extern const char* const SNIP_DYNAMIC_FILENAME = nullptr;
+
+} // namespace openlcb
+
+void setup () {
+  pinMode (LED_BUILTIN, OUTPUT) ;
+  SERIAL_PORT.begin(SERIAL_BAUD_RATE);
+  Serial.println ("OpenMRNLite demo app for Feather M4 CAN") ;
+  openmrn.add_gridconnect_port(&SERIAL_PORT);
+
+  HASSERT(CanDriver.begin());
+  openmrn.add_can_port(&CanDriver);
+  openmrn.begin();
+}
+  
+
+//-----------------------------------------------------------------
+
+void loop () {
+  openmrn.loop();
+}
+
+//-----------------------------------------------------------------

--- a/arduino/examples/FeatherM4Can/ClockConsumer/ClockConsumer.ino
+++ b/arduino/examples/FeatherM4Can/ClockConsumer/ClockConsumer.ino
@@ -1,0 +1,161 @@
+// OpenMRN demo application for Adafruit SAMD Feather M4 CAN board.
+//
+// This application acts as a CAN-only OpenLCB node which consumes the
+// default fast clock, and displays the model time in minutes by printing it
+// to the Arduino monitor port every model minute.
+//
+//-----------------------------------------------------------------
+// Board Manager: Adafruit SAMD board
+// Board Manager URL:
+// https://adafruit.github.io/arduino-board-index/package_adafruit_index.json
+
+#ifndef ARDUINO_FEATHER_M4_CAN
+#error "This sketch should be compiled for Arduino Feather M4 CAN (SAME51)"
+#endif
+
+// These are required to get the right CAN setup working.
+#define CAN0_MESSAGE_RAM_SIZE (0)
+#define CAN1_MESSAGE_RAM_SIZE (1728)
+#include <ACANFD_FeatherM4CAN.h>
+
+//-----------------------------------------------------------------
+
+#include <OpenMRNLite.h>
+
+/// Which serial port to use.
+#define SERIAL_PORT Serial
+
+/// Specify how fast the serial port should be going. In order not to lose
+/// packets on a fully loaded CAN-bus, this has to be at least 460800, but the
+/// default is set to 115200 for better compatibility.
+#define SERIAL_BAUD_RATE 115200
+
+/// This is the OpenLCB Node ID. It must be coming from the Node ID range
+/// assigned to the developer (get a range assigned to you via openlcb.org).
+static constexpr uint64_t NODE_ID = UINT64_C(0x050101011824);
+
+FeatherM4Can CanDriver;
+OpenMRN openmrn(NODE_ID);
+
+OVERRIDE_CONST_TRUE(gc_generate_newlines);
+
+namespace openlcb
+{
+/// These definitions tell how the Node will appear on the OpenLCB bus for a
+/// network browser.
+extern const SimpleNodeStaticValues SNIP_STATIC_DATA = {4, "OpenMRN",
+    "CAN-Serial-Node Adafruit Feather-M4-CAN", "Feather M4 CAN", "1.00"};
+
+extern const char *const SNIP_DYNAMIC_FILENAME = nullptr;
+
+} // namespace openlcb
+
+// This hack is needed because some arduino variants define a macro called
+// "abs" in their toplevel include header.
+#ifdef abs
+#undef abs
+#endif
+
+#include "openlcb/BroadcastTimeAlarm.hxx"
+#include "openlcb/BroadcastTimeClient.hxx"
+
+// Which clock to display.
+static constexpr auto CLOCK_ID =
+    openlcb::BroadcastTimeDefs::DEFAULT_FAST_CLOCK_ID;
+
+// Whether to allow remote control of the fast clock.
+static constexpr auto ALLOW_CONTROL = true;
+
+openlcb::BroadcastTimeClient time_client {
+    openmrn.stack()->node(), CLOCK_ID, ALLOW_CONTROL};
+
+/// Called when the date is changed.
+void update_date(BarrierNotifiable *done)
+{
+    int y = time_client.year();
+    int mon, day;
+    time_client.date(&mon, &day);
+    auto date = openlcb::BroadcastTimeDefs::date_to_string(y, mon, day);
+    SERIAL_PORT.print("Date: ");
+    SERIAL_PORT.println(date.c_str());
+    if (done)
+        done->notify();
+}
+
+/// Called when the minute on the clock is changed.
+void update_minute(BarrierNotifiable *done)
+{
+    struct tm time;
+    time_client.gmtime_r(&time);
+    auto str =
+        openlcb::BroadcastTimeDefs::time_to_string(time.tm_hour, time.tm_min);
+    SERIAL_PORT.println(str.c_str());
+    if (done)
+        done->notify();
+}
+
+/// Called when the current known time makes a jump.
+void time_jump(time_t old, time_t current)
+{
+    if (old != current)
+    {
+        update_date(nullptr);
+        update_minute(nullptr);
+    }
+}
+
+openlcb::BroadcastTimeAlarmMinute alarm_minute {
+    openmrn.stack()->node(), &time_client, &update_minute};
+
+openlcb::BroadcastTimeAlarmDate alarm_date {
+    openmrn.stack()->node(), &time_client, &update_date};
+
+/// Called periodically in the loop. Checks whether we got connected to a
+/// server.
+void check_server()
+{
+    static bool server_shadow = false;
+    bool has_srv = time_client.is_server_detected();
+    if (has_srv != server_shadow)
+    {
+        SERIAL_PORT.println(
+            has_srv ? "Found time source." : "Time source lost.");
+    }
+    server_shadow = has_srv;
+    static bool warning = false;
+    if (!has_srv && !warning && millis() > 5000)
+    {
+        SERIAL_PORT.println("No time source. Make sure that there is a clock "
+                            "generator for the given clock ID.");
+        warning = true;
+    }
+}
+
+void setup()
+{
+    pinMode(LED_BUILTIN, OUTPUT);
+    SERIAL_PORT.begin(SERIAL_BAUD_RATE);
+    // Waits for the host to connect via USB because we are outputting time
+    // information to the host.
+    while (!SERIAL_PORT)
+    {
+        delay(50);
+        digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN));
+    }
+    SERIAL_PORT.println("OpenMRNLite demo app for Feather M4 CAN");
+
+    HASSERT(CanDriver.begin());
+    openmrn.add_can_port(&CanDriver);
+    openmrn.begin();
+    time_client.update_subscribe_add(&time_jump);
+}
+
+//-----------------------------------------------------------------
+
+void loop()
+{
+    openmrn.loop();
+    check_server();
+}
+
+//-----------------------------------------------------------------

--- a/arduino/libify.sh
+++ b/arduino/libify.sh
@@ -205,7 +205,8 @@ copy_file src/openlcb src/openlcb/*.h src/openlcb/*.hxx src/openlcb/*.cxx
 rm -f ${TARGET_LIB_DIR}/src/openlcb/CompileCdiMain.cxx \
     ${TARGET_LIB_DIR}/src/openlcb/EventHandlerMock.hxx \
     ${TARGET_LIB_DIR}/src/openlcb/Stream.cxx \
-    ${TARGET_LIB_DIR}/src/openlcb/Stream.hxx
+    ${TARGET_LIB_DIR}/src/openlcb/Stream.hxx \
+    ${TARGET_LIB_DIR}/src/openlcb/BLE* \
 
 copy_file src/freertos_drivers/arduino \
           src/freertos_drivers/arduino/* \
@@ -225,6 +226,9 @@ copy_file src/freertos_drivers/stm32 \
           src/freertos_drivers/st/Stm32Can.* \
           arduino/stm32f_hal_conf.hxx \
 
+copy_file src/freertos_drivers/sam \
+          src/freertos_drivers/sam/*              
+          
 copy_file src/os src/os/*.h src/os/*.c src/os/*.hxx \
           src/os/{OSImpl,MDNS,OSSelectWakeup}.cxx
 

--- a/src/freertos_drivers/arduino/Can.cxx
+++ b/src/freertos_drivers/arduino/Can.cxx
@@ -36,5 +36,9 @@
 #include "can_frame.h"
 #include <cstdint>
 
+namespace openmrn_arduino {
+
 unsigned Can::numReceivedPackets_{0};
 unsigned Can::numTransmittedPackets_{0};
+
+} // namespace openmrn_arduino

--- a/src/freertos_drivers/arduino/Can.hxx
+++ b/src/freertos_drivers/arduino/Can.hxx
@@ -43,6 +43,8 @@
 #include "os/OS.hxx"
 #include "utils/Atomic.hxx"
 
+namespace openmrn_arduino {
+
 /** Base class for a CAN device for the Arduino environment. */
 class Can : protected Atomic
 {
@@ -51,14 +53,14 @@ public:
     static unsigned numTransmittedPackets_;
 
     /// @return number of CAN frames available for read (input frames).
-    int available()
+    virtual int available()
     {
         return rxBuf->pending();
     }
 
     /// @return number of CAN frames available for write (space in output
     /// buffer).
-    int availableForWrite()
+    virtual int availableForWrite()
     {
         return txBuf->space();
     }
@@ -66,7 +68,7 @@ public:
     /// Read a frame if there is one available.
     /// @param frame will be filled with the input CAN frame.
     /// @return 0 or 1 depending on whether a frame was read or not.
-    int read(struct can_frame *frame)
+    virtual int read(struct can_frame *frame)
     {
         AtomicHolder h(this);
         auto ret = rxBuf->get(frame, 1);
@@ -76,7 +78,7 @@ public:
     /// Send a frame if there is space available.
     /// @param frame the output CAN frame.
     /// @return 0 or 1 depending on whether the write happened or not.
-    int write(const struct can_frame *frame)
+    virtual int write(const struct can_frame *frame)
     {
         AtomicHolder h(this);
         auto ret = txBuf->put(frame, 1);
@@ -124,5 +126,7 @@ protected:
 private:
     DISALLOW_COPY_AND_ASSIGN(Can);
 };
+
+} // namespace openmrn_arduino
 
 #endif /* _FREERTOS_DRIVERS_ARDUINO_CAN_HXX_ */

--- a/src/freertos_drivers/sam/FeatherM4Can.hxx
+++ b/src/freertos_drivers/sam/FeatherM4Can.hxx
@@ -1,0 +1,249 @@
+/** \copyright
+ * Copyright (c) 2025, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file FeatherCan.hxx
+ *
+ * Wrapper for Arduino CAN driver for the Feather M4 CAN board using the
+ * external ACANFD_FeatherM4CAN library.
+ *
+ * @author Balazs Racz
+ * @date 29 July 2025
+ */
+
+#ifndef _ARDUINO_SAM_FEATHERM4CAN_HXX_
+#define _ARDUINO_SAM_FEATHERM4CAN_HXX_
+
+#ifndef ARDUINO_FEATHER_M4_CAN
+#error "This code only works on the Arduino Feather M4 CAN (SAME51)"
+#endif
+
+#include <ACANFD_FeatherM4CAN-from-cpp.h>
+
+#include "freertos_drivers/arduino/Can.hxx"
+
+/// Wrapper for Arduino CAN driver for the Feather M4 CAN board using the
+/// external ACANFD_FeatherM4CAN library.
+/// Usage:
+///
+/// // These are required to get the right CAN setup working.
+/// #define CAN0_MESSAGE_RAM_SIZE (0)
+/// #define CAN1_MESSAGE_RAM_SIZE (1728)
+/// #include <ACANFD_FeatherM4CAN.h>
+///
+/// #include <OpenMRNLite.h>
+/// FeatherM4Can can_driver;
+///
+/// void setup() {
+///   ...
+///   HASSERT(can_driver.begin());
+///   openmrn.add_can_port(&CanDriver);
+///   openmrn.begin();
+///   ...
+/// }
+///
+class FeatherM4Can : public openmrn_arduino::Can
+{
+public:
+    FeatherM4Can(ACANFD_FeatherM4CAN &can = can1)
+        : openmrn_arduino::Can("")
+        , can_(&can)
+    {
+    }
+
+    /// Initializes the CAN-bus driver.
+    /// @return true if successful prints and returns false on error.
+    bool begin()
+    {
+        const uint32_t errorCode = can1.beginFD(get_settings());
+
+        if (0 == errorCode)
+        {
+            return true;
+        }
+        else
+        {
+            Serial.print("Error can configuration: 0x");
+            Serial.println(errorCode, HEX);
+            return false;
+        }
+    }
+
+    ACANFD_FeatherM4CAN_Settings get_settings()
+    {
+        return ACANFD_FeatherM4CAN_Settings(
+            ACANFD_FeatherM4CAN_Settings::CLOCK_48MHz, 125 * 1000,
+            DataBitRateFactor::x1);
+    }
+
+    /// Prints the settings to Serial. Should be called after begin().
+    void print_settings()
+    {
+        auto settings = get_settings();
+
+        Serial.print("Bit Rate prescaler: ");
+        Serial.println(settings.mBitRatePrescaler);
+        Serial.print("Arbitration Phase segment 1: ");
+        Serial.println(settings.mArbitrationPhaseSegment1);
+        Serial.print("Arbitration Phase segment 2: ");
+        Serial.println(settings.mArbitrationPhaseSegment2);
+        Serial.print("Arbitration SJW: ");
+        Serial.println(settings.mArbitrationSJW);
+        Serial.print("Actual Arbitration Bit Rate: ");
+        Serial.print(settings.actualArbitrationBitRate());
+        Serial.println(" bit/s");
+        Serial.print("Arbitration Sample point: ");
+        Serial.print(settings.arbitrationSamplePointFromBitStart());
+        Serial.println("%");
+        Serial.print("Exact Arbitration Bit Rate ? ");
+        Serial.println(settings.exactArbitrationBitRate() ? "yes" : "no");
+        Serial.print("Data Phase segment 1: ");
+        Serial.println(settings.mDataPhaseSegment1);
+        Serial.print("Data Phase segment 2: ");
+        Serial.println(settings.mDataPhaseSegment2);
+        Serial.print("Data SJW: ");
+        Serial.println(settings.mDataSJW);
+        Serial.print("Actual Data Bit Rate: ");
+        Serial.print(settings.actualDataBitRate());
+        Serial.println(" bit/s");
+        Serial.print("Data Sample point: ");
+        Serial.print(settings.dataSamplePointFromBitStart());
+        Serial.println("%");
+        Serial.print("Exact Data Bit Rate ? ");
+        Serial.println(settings.exactDataBitRate() ? "yes" : "no");
+
+        Serial.print("Message RAM required minimum size: ");
+        Serial.print(can().messageRamRequiredMinimumSize());
+        Serial.println(" words");
+    }
+
+    ACANFD_FeatherM4CAN &can()
+    {
+        return *can_;
+    }
+
+    /// @return number of CAN frames available for read (input frames).
+    int available() override
+    {
+        return can().availableFD0() ? 1 : 0;
+    }
+
+    /// @return number of CAN frames available for write (space in output
+    /// buffer).
+    int availableForWrite() override
+    {
+        return can().sendBufferNotFullForIndex(0) ? 1 : 0;
+    }
+
+    /// Reads a frame if there is one available.
+    /// @param frame will be filled with the input CAN frame.
+    /// @return 0 or 1 depending on whether a frame was read or not.
+    int read(struct can_frame *frame) override
+    {
+        CANFDMessage fdframe;
+        if (!can().receiveFD0(fdframe))
+        {
+            return 0;
+        }
+        if (fdframe.type != CANFDMessage::CAN_DATA)
+        {
+            return 0;
+        }
+        CLR_CAN_FRAME_RTR(*frame);
+        CLR_CAN_FRAME_ERR(*frame);
+        if (fdframe.ext)
+        {
+            SET_CAN_FRAME_ID_EFF(*frame, fdframe.id);
+            SET_CAN_FRAME_EFF(*frame);
+        }
+        else
+        {
+            SET_CAN_FRAME_ID(*frame, fdframe.id);
+            CLR_CAN_FRAME_EFF(*frame);
+        }
+        frame->can_dlc = std::min(8u, (unsigned)fdframe.len);
+        frame->data64 = fdframe.data64[0];
+        return 1;
+    }
+
+    /// Send a frame if there is space available.
+    /// @param frame the output CAN frame.
+    /// @return 0 or 1 depending on whether the write happened or not.
+    int write(const struct can_frame *frame) override
+    {
+        if (availableForWrite() == 0)
+        {
+            return 0;
+        }
+        CANFDMessage fdframe;
+        // Populates type.
+        if (IS_CAN_FRAME_RTR(*frame))
+        {
+            fdframe.type = CANFDMessage::CAN_REMOTE;
+        }
+        else if (IS_CAN_FRAME_ERR(*frame))
+        {
+            return 1; // drop to the floor.
+        }
+        else
+        {
+            fdframe.type = CANFDMessage::CAN_DATA;
+        }
+        // Populates ID.
+        if (IS_CAN_FRAME_EFF(*frame))
+        {
+            fdframe.ext = true;
+            fdframe.id = GET_CAN_FRAME_ID_EFF(*frame);
+        }
+        else
+        {
+            fdframe.ext = false;
+            fdframe.id = GET_CAN_FRAME_ID(*frame);
+        }
+        fdframe.len = frame->can_dlc;
+        fdframe.data64[0] = frame->data64;
+        const uint32_t send_status = can().tryToSendReturnStatusFD(fdframe);
+        return (send_status == 0) ? 1 : 0;
+    }
+
+private:
+    // Not used.
+    void enable() override
+    {
+    }
+    // Not used.
+    void disable() override
+    {
+    }
+    // Not used.
+    void tx_msg() override
+    {
+    }
+
+    /// Pointer to the underlying library's CAN implementation.
+    ACANFD_FeatherM4CAN *can_;
+}; // class FeatherM4Can
+
+#endif // _ARDUINO_SAM_FEATHERM4CAN_HXX_

--- a/src/freertos_drivers/st/Stm32Can.hxx
+++ b/src/freertos_drivers/st/Stm32Can.hxx
@@ -39,8 +39,10 @@
 #ifdef ARDUINO
 #include <Arduino.h>
 #include "freertos_drivers/arduino/Can.hxx"
+using CanBase = openmrn_arduino::Can;
 #else
 #include "freertos_drivers/common/Can.hxx"
+using CanBase = ::Can;
 #endif
 
 #include "stm32f_hal_conf.hxx"
@@ -51,7 +53,7 @@
 
 /** Specialization of CAN driver for LPC17xx and LPC40xx CAN.
  */
-class Stm32Can : public Can
+class Stm32Can : public CanBase
 {
 public:
     /** Constructor.

--- a/src/openlcb/DefaultCdi.cxx
+++ b/src/openlcb/DefaultCdi.cxx
@@ -47,7 +47,6 @@ R"cdi(<?xml version="1.0"?>
 <identification/>
 <acdi/>
 <segment origin='0' space='252'>
- <group>
  <name>Manufacturer Information</name>
  <description>Manufacturer-provided fixed node description</description>
  <int size='1'>
@@ -65,10 +64,8 @@ R"cdi(<?xml version="1.0"?>
  <string size='21'>
  <name>Software Version</name>
  </string>
- </group>
 </segment>
 <segment origin='0' space='251'>
- <group>
  <name>User Identification</name>
  <description>Lets the user add his own description</description>
  <int size='1'>
@@ -80,7 +77,6 @@ R"cdi(<?xml version="1.0"?>
  <string size='64'>
  <name>Node Description</name>
  </string>
- </group>
 </segment>
 </cdi>
 )cdi";

--- a/src/openlcb/If.cxx
+++ b/src/openlcb/If.cxx
@@ -37,7 +37,9 @@
 
 /// Ensures that the largest bucket in the main buffer pool at least the size
 /// of a GenMessage, or a DataBuffer<64>.
-static constexpr unsigned BUCKET_SIZE = std::max(sizeof(Buffer<openlcb::GenMessage>), 64u + sizeof(BufferBase));
+static constexpr unsigned BUCKET_SIZE_GENMSG = sizeof(Buffer<openlcb::GenMessage>);
+static constexpr unsigned BUCKET_SIZE_BUFBASE_64 = 64u + sizeof(BufferBase);
+static constexpr unsigned BUCKET_SIZE = BUCKET_SIZE_GENMSG > BUCKET_SIZE_BUFBASE_64 ? BUCKET_SIZE_GENMSG : BUCKET_SIZE_BUFBASE_64;
 // This also verifies that LARGEST_BUFFERPOOL_BUCKET will end up being in
 // rodata instead of being computed at static constructor time. We want to make
 // sure that init_main_buffer_pool can work at any moment.

--- a/src/utils/DirectHub.cxx
+++ b/src/utils/DirectHub.cxx
@@ -39,10 +39,14 @@
 #include "utils/DirectHub.hxx"
 
 #include <algorithm>
+#include <vector>
+
 #include <fcntl.h>
+
+#if OPENMRN_FEATURE_BSD_SOCKETS
 #include <sys/socket.h>
 #include <sys/types.h>
-#include <vector>
+#endif
 
 #include "executor/AsyncNotifiableBlock.hxx"
 #include "executor/StateFlow.hxx"


### PR DESCRIPTION
- Adds a CAN driver wrapper for arduino for ATSAME51's fdcan controller, using an external library.
- Makes the Arduino Can base class have virtual methods.
- Fixes some annoying compile errors due to global namespace symbol conflicts.
- Adds example sketches: one for USB-CAN and one for a clock consumer.