### PR TITLE
Adds a CAN driver for arduino-esp32 that is based on the vanilla TWAI APIs

### DIFF
--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -75,17 +75,8 @@ constexpr UBaseType_t OPENMRN_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO - 1;
 // ESP32-H2 and ESP32-C2 do not have a built-in TWAI controller.
 #if !defined(CONFIG_IDF_TARGET_ESP32H2) && !defined(CONFIG_IDF_TARGET_ESP32C2)
 
-// If we are using ESP-IDF v4.3 (or later) enable the usage of the TWAI device
-// which allows usage of the filesystem based CAN interface methods.
-#include "freertos_drivers/esp32/Esp32HardwareTwai.hxx"
-#define HAVE_CAN_FS_DEVICE
-
-// The ESP-IDF VFS layer has an optional wrapper around the select() interface
-// when disabled we can not use select() for the CAN/TWAI driver. Normally this
-// is enabled for arduino-esp32.
-#if CONFIG_VFS_SUPPORT_SELECT
-#define HAVE_CAN_FS_SELECT
-#endif
+// If we are using ESP-IDF v4.3 (or later) enable the usage of the TWAI device.
+#include "freertos_drivers/esp32/Esp32Can.hxx"
 
 #endif // NOT ESP32-H2 and NOT ESP32-C2
 

--- a/arduino/examples/ESP32/CanLoadTest/CanLoadTest.ino
+++ b/arduino/examples/ESP32/CanLoadTest/CanLoadTest.ino
@@ -46,32 +46,22 @@
 
 
 // Pick an operating mode below, if you select USE_WIFI it will expose this
-// node on WIFI. If USE_TWAI / USE_TWAI_ASYNC are enabled the node
-// will be available on CAN.
+// node on WIFI. If USE_ESP32CAN is enabled the node will be available on CAN.
 //
 // Enabling both options will allow the ESP32 to be accessible from
 // both WiFi and TWAI interfaces.
 
-#define USE_WIFI
-//#define USE_TWAI
-//#define USE_TWAI_ASYNC
+//#define USE_WIFI
+#define USE_ESP32CAN
 
 // uncomment the line below to have all packets printed to the Serial
 // output. This is not recommended for production deployment.
 //#define PRINT_PACKETS
 
-// Configuration option validation
-
-// If USE_TWAI_ASYNC is enabled but USE_TWAI is not, enable USE_TWAI.
-#if defined(USE_TWAI_ASYNC) && !defined(USE_TWAI)
-#define USE_TWAI
-#endif // USE_TWAI_ASYNC && !USE_TWAI
-
-#if defined(USE_TWAI) && ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4,3,0)
-#error Esp32HardwareTwai is not supported on this version of arduino-esp32.
-#endif // USE_TWAI && IDF < v4.3
-
 #include "config.h"
+#if defined(USE_ESP32CAN)
+#include "freertos_drivers/esp32/Esp32Can.hxx"
+#endif
 
 /// This is the node id to assign to this device, this must be unique
 /// on the CAN bus.

--- a/arduino/examples/ESP32/CanLoadTest/CanLoadTest.ino
+++ b/arduino/examples/ESP32/CanLoadTest/CanLoadTest.ino
@@ -59,9 +59,6 @@
 //#define PRINT_PACKETS
 
 #include "config.h"
-#if defined(USE_CAN)
-#include "freertos_drivers/esp32/Esp32Can.hxx"
-#endif
 
 /// This is the node id to assign to this device, this must be unique
 /// on the CAN bus.

--- a/arduino/examples/ESP32/CanLoadTest/config.h
+++ b/arduino/examples/ESP32/CanLoadTest/config.h
@@ -9,8 +9,8 @@
 #include "freertos_drivers/esp32/Esp32WiFiConfiguration.hxx"
 
 // catch invalid configuration at compile time
-#if !defined(USE_TWAI) && !defined(USE_WIFI)
-#error "Invalid configuration detected, USE_TWAI or USE_WIFI must be defined."
+#if !defined(USE_CAN) && !defined(USE_WIFI)
+#error "Invalid configuration detected, USE_CAN or USE_WIFI must be defined."
 #endif
 
 namespace openlcb
@@ -32,11 +32,11 @@ namespace openlcb
 extern const SimpleNodeStaticValues SNIP_STATIC_DATA = {
     4,
     "OpenMRN",
-#if defined(USE_WIFI) && !defined(USE_TWAI)
+#if defined(USE_WIFI) && !defined(USE_CAN)
     "Arduino IO Board (WiFi)",
-#elif defined(USE_TWAI) && !defined(USE_WIFI)
+#elif defined(USE_CAN) && !defined(USE_WIFI)
     "Arduino IO Board (CAN)",
-#elif defined(USE_TWAI) && defined(USE_WIFI)
+#elif defined(USE_CAN) && defined(USE_WIFI)
     "Arduino IO Board (WiFi/CAN)",
 #else
     "Arduino IO Board",

--- a/arduino/examples/ESP32/IOBoard/config.h
+++ b/arduino/examples/ESP32/IOBoard/config.h
@@ -9,8 +9,8 @@
 #include "freertos_drivers/esp32/Esp32WiFiConfiguration.hxx"
 
 // catch invalid configuration at compile time
-#if !defined(USE_TWAI) && !defined(USE_WIFI)
-#error "Invalid configuration detected, USE_TWAI or USE_WIFI must be defined."
+#if !defined(USE_CAN) && !defined(USE_WIFI)
+#error "Invalid configuration detected, USE_CAN or USE_WIFI must be defined."
 #endif
 
 namespace openlcb
@@ -32,12 +32,12 @@ namespace openlcb
 extern const SimpleNodeStaticValues SNIP_STATIC_DATA = {
     4,
     "OpenMRN",
-#if defined(USE_WIFI) && !defined(USE_TWAI)
+#if defined(USE_WIFI) && !defined(USE_CAN)
     "Arduino IO Board (WiFi)",
-#elif defined(USE_TWAI) && !defined(USE_WIFI)
-    "Arduino IO Board (TWAI)",
-#elif defined(USE_TWAI) && defined(USE_WIFI)
-    "Arduino IO Board (WiFi/TWAI)",
+#elif defined(USE_CAN) && !defined(USE_WIFI)
+    "Arduino IO Board (CAN)",
+#elif defined(USE_CAN) && defined(USE_WIFI)
+    "Arduino IO Board (WiFi/CAN)",
 #else
     "Arduino IO Board",
 #endif
@@ -56,7 +56,7 @@ using AllProducers = RepeatedGroup<ProducerConfig, NUM_INPUTS>;
 
 /// Modify this value every time the EEPROM needs to be cleared on the node
 /// after an update.
-static constexpr uint16_t CANONICAL_VERSION = 0x100a;
+static constexpr uint16_t CANONICAL_VERSION = 0x100b;
 
 /// Defines the main segment in the configuration CDI. This is laid out at
 /// origin 128 to give space for the ACDI user data at the beginning.

--- a/arduino/examples/ESP32/WifiCanBridge/WifiCanBridge.ino
+++ b/arduino/examples/ESP32/WifiCanBridge/WifiCanBridge.ino
@@ -106,8 +106,8 @@ static constexpr openlcb::ConfigDef cfg(0);
 
 Esp32WiFiManager wifi_mgr(ssid, password, openmrn.stack(), cfg.seg().wifi());
 
-// @ref Esp32HardwareTwai instance to use for this node.
-static Esp32HardwareTwai twai(CAN_RX_PIN, CAN_TX_PIN);
+// @ref Esp32Can instance to use for this node.
+static Esp32Can can_driver(CAN_TX_PIN, CAN_RX_PIN);
 
 class FactoryResetHelper : public DefaultConfigUpdateListener
 {
@@ -172,10 +172,10 @@ void setup()
     openmrn.stack()->create_config_file_if_needed(cfg.seg().internal_config(),
         openlcb::CANONICAL_VERSION, openlcb::CONFIG_FILE_SIZE);
 
-    // Initialize the TWAI peripheral
-    twai.hw_init();
-    // Add TWAI port to the stack
-    openmrn.add_can_port_select("/dev/twai/twai0");
+    // Initialize the CAN peripheral
+    can_driver.begin();
+    // Add CAN port to the stack
+    openmrn.add_can_port(&can_driver);
 
     // Start the OpenMRN stack
     openmrn.begin();

--- a/arduino/examples/ESP32/WifiCanBridge/config.h
+++ b/arduino/examples/ESP32/WifiCanBridge/config.h
@@ -33,7 +33,7 @@ extern const SimpleNodeStaticValues SNIP_STATIC_DATA = {
 
 /// Modify this value every time the EEPROM needs to be cleared on the node
 /// after an update.
-static constexpr uint16_t CANONICAL_VERSION = 0x1008;
+static constexpr uint16_t CANONICAL_VERSION = 0x1009;
 
 /// Defines the main segment in the configuration CDI. This is laid out at
 /// origin 128 to give space for the ACDI user data at the beginning.

--- a/arduino/examples/ESP32C3/CanLoadTest/CanLoadTest.ino
+++ b/arduino/examples/ESP32C3/CanLoadTest/CanLoadTest.ino
@@ -45,27 +45,17 @@
 #include <freertos_drivers/arduino/CpuLoad.hxx>
 
 // Pick an operating mode below, if you select USE_WIFI it will expose
-// this node on WIFI if you select USE_TWAI, this node will be available
+// this node on WIFI if you select USE_CAN, this node will be available
 // on CAN.
 // Enabling both options will allow the ESP32 to be accessible from
 // both WiFi and CAN interfaces.
 
 #define USE_WIFI
-//#define USE_TWAI
-
-// Uncomment USE_TWAI_SELECT to enable the usage of select() for the TWAI
-// interface.
-//#define USE_TWAI_SELECT
+#define USE_CAN
 
 // uncomment the line below to have all packets printed to the Serial
 // output. This is not recommended for production deployment.
 //#define PRINT_PACKETS
-
-// If USE_TWAI_SELECT or USE_TWAI_ASYNC is enabled but USE_TWAI is not, enable
-// USE_TWAI.
-#if defined(USE_TWAI_SELECT) && !defined(USE_TWAI)
-#define USE_TWAI
-#endif // USE_TWAI_SELECT && !USE_TWAI
 
 #include "config.h"
 
@@ -106,22 +96,22 @@ OVERRIDE_CONST(gridconnect_bridge_max_outgoing_packets, 2);
 
 #endif // USE_WIFI
 
-#if defined(USE_TWAI)
+#if defined(USE_CAN)
 // This is the ESP32-C3 pin connected to the SN65HVD23x/MCP2551 R (RX) pin.
 // Note: Any pin can be used for this other than 11-17 which are connected to
 // the onboard flash.
 // Note: Adjusting this pin assignment will require updating the GPIO_PIN
 // declarations below for input/outputs.
-constexpr gpio_num_t TWAI_RX_PIN = GPIO_NUM_18;
+constexpr gpio_num_t CAN_RX_PIN = GPIO_NUM_18;
 
 // This is the ESP32-C3 pin connected to the SN65HVD23x/MCP2551 D (TX) pin.
 // Note: Any pin can be used for this other than 11-17 which are connected to
 // the onboard flash.
 // Note: Adjusting this pin assignment will require updating the GPIO_PIN
 // declarations below for input/outputs.
-constexpr gpio_num_t TWAI_TX_PIN = GPIO_NUM_19;
+constexpr gpio_num_t CAN_TX_PIN = GPIO_NUM_19;
 
-#endif // USE_TWAI
+#endif // USE_CAN
 
 // This is the primary entrypoint for the OpenMRN/LCC stack.
 OpenMRN openmrn(NODE_ID);
@@ -144,9 +134,9 @@ static constexpr openlcb::ConfigDef cfg(0);
 Esp32WiFiManager wifi_mgr(ssid, password, openmrn.stack(), cfg.seg().wifi());
 #endif // USE_WIFI
 
-#if defined(USE_TWAI)
-Esp32HardwareTwai twai(TWAI_RX_PIN, TWAI_TX_PIN);
-#endif // USE_TWAI
+#if defined(USE_CAN)
+Esp32Can can_driver(CAN_TX_PIN, CAN_RX_PIN);
+#endif // USE_CAN
 
 // This will perform the factory reset procedure for this node's configuration
 // items.
@@ -251,9 +241,10 @@ void setup()
     openmrn.stack()->create_config_file_if_needed(cfg.seg().internal_config(),
         openlcb::CANONICAL_VERSION, openlcb::CONFIG_FILE_SIZE);
 
-#if defined(USE_TWAI)
-    twai.hw_init();
-#endif // USE_TWAI
+#if defined(USE_CAN)
+    can_driver.begin();
+    openmrn.add_can_port(&can_driver);
+#endif // USE_CAN
 
     // Start the OpenMRN stack
     openmrn.begin();
@@ -265,17 +256,7 @@ void setup()
     openmrn.stack()->print_all_packets();
 #endif // PRINT_PACKETS
 
-#if defined(USE_TWAI_SELECT)
-    // add TWAI driver with select() usage
-    openmrn.add_can_port_select("/dev/twai/twai0");
-
-    // start executor thread since this is required for select() to work in the
-    // OpenMRN executor.
     openmrn.start_executor_thread();
-#else
-    // add TWAI driver with non-blocking usage
-    openmrn.add_can_port_async("/dev/twai/twai0");
-#endif // USE_TWAI_SELECT
 }
 
 void loop()

--- a/arduino/examples/ESP32C3/CanLoadTest/config.h
+++ b/arduino/examples/ESP32C3/CanLoadTest/config.h
@@ -9,8 +9,8 @@
 #include "freertos_drivers/esp32/Esp32WiFiConfiguration.hxx"
 
 // catch invalid configuration at compile time
-#if !defined(USE_TWAI) && !defined(USE_WIFI)
-#error "Invalid configuration detected, USE_TWAI or USE_WIFI must be defined."
+#if !defined(USE_CAN) && !defined(USE_WIFI)
+#error "Invalid configuration detected, USE_CAN or USE_WIFI must be defined."
 #endif
 
 namespace openlcb
@@ -33,12 +33,12 @@ extern const SimpleNodeStaticValues SNIP_STATIC_DATA =
 {
     4,
     "OpenMRN",
-#if defined(USE_WIFI) && !defined(USE_TWAI)
+#if defined(USE_WIFI) && !defined(USE_CAN)
     "Arduino Load Test (WiFi)",
-#elif defined(USE_TWAI) && !defined(USE_WIFI)
-    "Arduino Load Test (TWAI)",
+#elif defined(USE_CAN) && !defined(USE_WIFI)
+    "Arduino Load Test (CAN)",
 #else
-    "Arduino Load Test (WiFi/TWAI)",
+    "Arduino Load Test (WiFi/CAN)",
 #endif
     ARDUINO_VARIANT,
     "1.00"

--- a/arduino/examples/ESP32C3/IOBoard/config.h
+++ b/arduino/examples/ESP32C3/IOBoard/config.h
@@ -9,8 +9,8 @@
 #include "freertos_drivers/esp32/Esp32WiFiConfiguration.hxx"
 
 // catch invalid configuration at compile time
-#if !defined(USE_TWAI) && !defined(USE_WIFI)
-#error "Invalid configuration detected, USE_TWAI or USE_WIFI must be defined."
+#if !defined(USE_CAN) && !defined(USE_WIFI)
+#error "Invalid configuration detected, USE_CAN or USE_WIFI must be defined."
 #endif
 
 namespace openlcb
@@ -33,11 +33,11 @@ extern const SimpleNodeStaticValues SNIP_STATIC_DATA =
 {
     4,
     "OpenMRN",
-#if defined(USE_WIFI) && !defined(USE_TWAI)
+#if defined(USE_WIFI) && !defined(USE_CAN)
     "Arduino IO Board (WiFi)",
-#elif defined(USE_TWAI) && !defined(USE_WIFI)
+#elif defined(USE_CAN) && !defined(USE_WIFI)
     "Arduino IO Board (CAN)",
-#elif defined(USE_TWAI) && defined(USE_WIFI)
+#elif defined(USE_CAN) && defined(USE_WIFI)
     "Arduino IO Board (WiFi/CAN)",
 #else
     "Arduino IO Board",
@@ -58,7 +58,7 @@ using AllProducers = RepeatedGroup<ProducerConfig, NUM_INPUTS>;
 
 /// Modify this value every time the EEPROM needs to be cleared on the node
 /// after an update.
-static constexpr uint16_t CANONICAL_VERSION = 0x100a;
+static constexpr uint16_t CANONICAL_VERSION = 0x100b;
 
 /// Defines the main segment in the configuration CDI. This is laid out at
 /// origin 128 to give space for the ACDI user data at the beginning.

--- a/arduino/examples/ESP32S2/CanLoadTest/config.h
+++ b/arduino/examples/ESP32S2/CanLoadTest/config.h
@@ -9,8 +9,8 @@
 #include "freertos_drivers/esp32/Esp32WiFiConfiguration.hxx"
 
 // catch invalid configuration at compile time
-#if !defined(USE_TWAI) && !defined(USE_WIFI)
-#error "Invalid configuration detected, USE_TWAI or USE_WIFI must be defined."
+#if !defined(USE_CAN) && !defined(USE_WIFI)
+#error "Invalid configuration detected, USE_CAN or USE_WIFI must be defined."
 #endif
 
 namespace openlcb
@@ -32,12 +32,12 @@ namespace openlcb
 extern const SimpleNodeStaticValues SNIP_STATIC_DATA = {
     4,
     "OpenMRN",
-#if defined(USE_WIFI) && !defined(USE_TWAI)
+#if defined(USE_WIFI) && !defined(USE_CAN)
     "Arduino Load Test (WiFi)",
-#elif defined(USE_TWAI) && !defined(USE_WIFI)
-    "Arduino Load Test (TWAI)",
+#elif defined(USE_CAN) && !defined(USE_WIFI)
+    "Arduino Load Test (CAN)",
 #else
-    "Arduino Load Test (WiFi/TWAI)",
+    "Arduino Load Test (WiFi/CAN)",
 #endif
     ARDUINO_VARIANT,
     "1.00"};

--- a/arduino/examples/ESP32S2/IOBoard/config.h
+++ b/arduino/examples/ESP32S2/IOBoard/config.h
@@ -9,8 +9,8 @@
 #include "freertos_drivers/esp32/Esp32WiFiConfiguration.hxx"
 
 // catch invalid configuration at compile time
-#if !defined(USE_TWAI) && !defined(USE_WIFI)
-#error "Invalid configuration detected, USE_TWAI or USE_WIFI must be defined."
+#if !defined(USE_CAN) && !defined(USE_WIFI)
+#error "Invalid configuration detected, USE_CAN or USE_WIFI must be defined."
 #endif
 
 namespace openlcb
@@ -32,11 +32,11 @@ namespace openlcb
 extern const SimpleNodeStaticValues SNIP_STATIC_DATA = {
     4,
     "OpenMRN",
-#if defined(USE_WIFI) && !defined(USE_TWAI)
+#if defined(USE_WIFI) && !defined(USE_CAN)
     "Arduino IO Board (WiFi)",
-#elif defined(USE_TWAI) && !defined(USE_WIFI)
+#elif defined(USE_CAN) && !defined(USE_WIFI)
     "Arduino IO Board (CAN)",
-#elif defined(USE_TWAI) && defined(USE_WIFI)
+#elif defined(USE_CAN) && defined(USE_WIFI)
     "Arduino IO Board (WiFi/CAN)",
 #else
     "Arduino IO Board",

--- a/arduino/libify.sh
+++ b/arduino/libify.sh
@@ -222,6 +222,9 @@ copy_file src/freertos_drivers/arduino \
 copy_file src/freertos_drivers/esp32 \
           src/freertos_drivers/esp32/*
 
+# remove HAL style Twai driver that does not compile under arduino
+rm -f ${TARGET_LIB_DIR}/src/freertos_drivers/esp32/*Twai*
+
 copy_file src/freertos_drivers/stm32 \
           src/freertos_drivers/st/Stm32Can.* \
           arduino/stm32f_hal_conf.hxx \

--- a/arduino/library.json
+++ b/arduino/library.json
@@ -21,7 +21,7 @@
       "type": "git",
       "url": "https://github.com/openmrn/OpenMRNLite"
     },
-    "version": "1.0.3",
+    "version": "1.1.0",
     "license": "BSD-2-Clause",
     "frameworks": "arduino",
     "platforms": "espressif32",

--- a/arduino/library.properties
+++ b/arduino/library.properties
@@ -1,5 +1,5 @@
 name=OpenMRNLite
-version=1.0.3
+version=1.1.0
 author=Stuart Baker, Mike Dunston, Balazs Racz
 maintainer=Mike Dunston <m_dunston@comcast.net>, Balazs Racz <balazs.racz@gmail.com>
 includes=OpenMRNLite.h

--- a/src/freertos_drivers/esp32/Esp32Can.hxx
+++ b/src/freertos_drivers/esp32/Esp32Can.hxx
@@ -1,0 +1,181 @@
+/** \copyright
+ * Copyright (c) 2023, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file Esp32Can.hxx
+ *
+ * Wrapper for the ESP32 TWAI driver.
+ *
+ * @author Balazs Racz
+ * @date 18 April 2023
+ */
+
+#ifndef _FREERTOS_DRIVERS_ESP32_ESP32CAN_HXX_
+#define _FREERTOS_DRIVERS_ESP32_ESP32CAN_HXX_
+
+#if !defined(ESP_PLATFORM)
+#error "This driver is for ESP32 only."
+#endif
+
+#include <string.h>
+#include "driver/twai.h"
+#include "freertos_drivers/arduino/Can.hxx"
+
+/// ESP32 TWAI CAN driver.
+class Esp32Can : public openmrn_arduino::Can
+{
+public:
+    /// Constructor.
+    /// @param tx_pin GPIO pin for CAN TX.
+    /// @param rx_pin GPIO pin for CAN RX.
+    Esp32Can(gpio_num_t tx_pin, gpio_num_t rx_pin)
+        : openmrn_arduino::Can("")
+        , tx_pin_(tx_pin)
+        , rx_pin_(rx_pin)
+        , tx_queue_len_(0)
+    {
+    }
+
+    /// Initializes the CAN-bus driver.
+    /// @return true if successful, false on error.
+    bool begin()
+    {
+        twai_general_config_t g_config =
+            TWAI_GENERAL_CONFIG_DEFAULT(tx_pin_, rx_pin_, TWAI_MODE_NORMAL);
+        tx_queue_len_ = g_config.tx_queue_len;
+        twai_timing_config_t t_config = TWAI_TIMING_CONFIG_125KBITS();
+        twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
+
+        esp_err_t result = twai_driver_install(&g_config, &t_config, &f_config);
+        if (result != ESP_OK)
+        {
+            return false;
+        }
+
+        result = twai_start();
+        if (result != ESP_OK)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    int available() override
+    {
+        twai_status_info_t status;
+        if (twai_get_status_info(&status) != ESP_OK)
+        {
+            return 0;
+        }
+        return status.msgs_to_rx;
+    }
+
+    int availableForWrite() override
+    {
+        twai_status_info_t status;
+        if (twai_get_status_info(&status) != ESP_OK)
+        {
+            return 0;
+        }
+        return tx_queue_len_ - status.msgs_to_tx;
+    }
+
+    int read(struct can_frame *frame) override
+    {
+        twai_message_t message;
+        esp_err_t result = twai_receive(&message, 0);
+        if (result != ESP_OK)
+        {
+            return 0;
+        }
+
+        // Copy from twai_message_t to can_frame
+        if (message.extd)
+        {
+            SET_CAN_FRAME_ID_EFF(*frame, message.identifier);
+            SET_CAN_FRAME_EFF(*frame);
+        }
+        else
+        {
+            SET_CAN_FRAME_ID(*frame, message.identifier);
+            CLR_CAN_FRAME_EFF(*frame);
+        }
+
+        if (message.rtr)
+        {
+            SET_CAN_FRAME_RTR(*frame);
+        }
+        else
+        {
+            CLR_CAN_FRAME_RTR(*frame);
+        }
+
+        CLR_CAN_FRAME_ERR(*frame);
+
+        frame->can_dlc = message.data_length_code;
+        memcpy(frame->data, message.data, message.data_length_code);
+
+        return 1;
+    }
+
+    int write(const struct can_frame *frame) override
+    {
+        twai_message_t message;
+        memset(&message, 0, sizeof(message));
+        message.extd = IS_CAN_FRAME_EFF(*frame) ? 1 : 0;
+        message.rtr = IS_CAN_FRAME_RTR(*frame) ? 1 : 0;
+
+        if (IS_CAN_FRAME_ERR(*frame)) {
+            // error frames are not transmitted.
+            return 1;
+        }
+
+        message.identifier = frame->can_id & (IS_CAN_FRAME_EFF(*frame) ? CAN_EFF_MASK : CAN_SFF_MASK);
+        message.data_length_code = frame->can_dlc;
+        memcpy(message.data, frame->data, frame->can_dlc);
+
+        esp_err_t result = twai_transmit(&message, 0);
+        if (result == ESP_OK)
+        {
+            return 1;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+private:
+    void enable() override {}
+    void disable() override {}
+    void tx_msg() override {}
+
+    gpio_num_t tx_pin_;
+    gpio_num_t rx_pin_;
+    size_t tx_queue_len_;
+};
+
+#endif // _FREERTOS_DRIVERS_ESP32_ESP32CAN_HXX_

--- a/src/freertos_drivers/esp32/Esp32Can.hxx
+++ b/src/freertos_drivers/esp32/Esp32Can.hxx
@@ -1,5 +1,5 @@
 /** \copyright
- * Copyright (c) 2023, Balazs Racz
+ * Copyright (c) 2025, Balazs Racz
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,10 +26,10 @@
  *
  * \file Esp32Can.hxx
  *
- * Wrapper for the ESP32 TWAI driver.
+ * Wrapper for the ESP32 TWAI driver fr arduino environments.
  *
  * @author Balazs Racz
- * @date 18 April 2023
+ * @date 2 Aug 2025
  */
 
 #ifndef _FREERTOS_DRIVERS_ESP32_ESP32CAN_HXX_

--- a/src/freertos_drivers/esp32/Esp32Can.hxx
+++ b/src/freertos_drivers/esp32/Esp32Can.hxx
@@ -94,6 +94,10 @@ public:
         {
             return 0;
         }
+        if (status.state == TWAI_STATE_BUS_OFF)
+        {
+            twai_initiate_recovery();
+        }
         return status.msgs_to_rx;
     }
 

--- a/src/freertos_drivers/esp32/Esp32Can.hxx
+++ b/src/freertos_drivers/esp32/Esp32Can.hxx
@@ -153,7 +153,7 @@ public:
             return 1;
         }
 
-        message.identifier = frame->can_id & (IS_CAN_FRAME_EFF(*frame) ? CAN_EFF_MASK : CAN_SFF_MASK);
+        message.identifier = IS_CAN_FRAME_EFF(*frame) ? GET_CAN_FRAME_ID_EFF(*frame) : GET_CAN_FRAME_ID(*frame);
         message.data_length_code = frame->can_dlc;
         memcpy(message.data, frame->data, frame->can_dlc);
 

--- a/src/freertos_drivers/esp32/Esp32Can.hxx
+++ b/src/freertos_drivers/esp32/Esp32Can.hxx
@@ -56,9 +56,9 @@ public:
     /// @param rx_pin GPIO pin for CAN RX.
     Esp32Can(gpio_num_t tx_pin, gpio_num_t rx_pin)
         : openmrn_arduino::Can("")
-        , tx_pin_(tx_pin)
-        , rx_pin_(rx_pin)
-        , tx_queue_len_(0)
+        , txPin_(tx_pin)
+        , rxPin_(rx_pin)
+        , txQueueLen_(0)
     {
     }
 
@@ -67,8 +67,8 @@ public:
     bool begin()
     {
         twai_general_config_t g_config =
-            TWAI_GENERAL_CONFIG_DEFAULT(tx_pin_, rx_pin_, TWAI_MODE_NORMAL);
-        tx_queue_len_ = g_config.tx_queue_len;
+            TWAI_GENERAL_CONFIG_DEFAULT(txPin_, rxPin_, TWAI_MODE_NORMAL);
+        txQueueLen_ = g_config.tx_queue_len;
         twai_timing_config_t t_config = TWAI_TIMING_CONFIG_125KBITS();
         twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
 
@@ -108,7 +108,7 @@ public:
         {
             return 0;
         }
-        return tx_queue_len_ - status.msgs_to_tx;
+        return txQueueLen_ - status.msgs_to_tx;
     }
 
     int read(struct can_frame *frame) override
@@ -181,9 +181,9 @@ private:
     void disable() override {}
     void tx_msg() override {}
 
-    gpio_num_t tx_pin_;
-    gpio_num_t rx_pin_;
-    size_t tx_queue_len_;
+    gpio_num_t txPin_;
+    gpio_num_t rxPin_;
+    size_t txQueueLen_;
 };
 
 #endif // _FREERTOS_DRIVERS_ESP32_ESP32CAN_HXX_

--- a/src/freertos_drivers/esp32/Esp32Can.hxx
+++ b/src/freertos_drivers/esp32/Esp32Can.hxx
@@ -39,6 +39,10 @@
 #error "This driver is for ESP32 only."
 #endif
 
+#if !defined(ARDUINO)
+#error "This driver is for Arduino environment only."
+#endif
+
 #include <string.h>
 #include "driver/twai.h"
 #include "freertos_drivers/arduino/Can.hxx"

--- a/src/os/MDNS.hxx
+++ b/src/os/MDNS.hxx
@@ -35,6 +35,8 @@
 #ifndef _OS_MDNS_HXX_
 #define _OS_MDNS_HXX_
 
+#include <stdint.h>
+
 #if defined (__linux__)
 #include <netdb.h>
 #include <stdio.h>


### PR DESCRIPTION
- Adds a new Arduino driver Esp32Can.hxx, which utilizes the TWAI driver instead of the low-level HAL driver. This should work better across different IDF versions, as the API is simpler and more stable.
- The driver is a vanilla implementation of the available(), availableForRead(), read() and write() functions.
- Updates all arduino examples, ripping out TWAI references.  