### PR TITLE
Fix assert in EspIdfWiFi.cxx when STA loses IP.

### DIFF
--- a/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
+++ b/src/freertos_drivers/esp_idf/EspIdfWiFi.cxx
@@ -1166,14 +1166,16 @@ void EspIdfWiFiBase::ip_event_handler(
         }
         case IP_EVENT_STA_LOST_IP:
         {
-            HASSERT(ipAcquiredSta_ == true);
-            ipAcquiredSta_ = false;
-            mdns_disable_sta();
-            LOG(INFO, "wifi: STA lost IP.");
-            // Register a callback to run on the passed in service executor.
-            CallbackExecutable *e = new CallbackExecutable(std::bind(
-                &EspIdfWiFiBase::ip_acquired, this, IFACE_STA, false));
-            service()->executor()->add(e);
+            if (ipAcquiredSta_)
+            {
+                ipAcquiredSta_ = false;
+                mdns_disable_sta();
+                LOG(INFO, "wifi: STA lost IP.");
+                // Register a callback to run on the passed in service executor.
+                CallbackExecutable *e = new CallbackExecutable(std::bind(
+                    &EspIdfWiFiBase::ip_acquired, this, IFACE_STA, false));
+                service()->executor()->add(e);
+            }
             break;
         }
         case IP_EVENT_AP_STAIPASSIGNED:


### PR DESCRIPTION
In the IP_EVENT_STA_LOST_IP event handler, the code asserted that an IP address was held. However, it's possible to receive this event even if an IP was never acquired (e.g., DHCP timeout). This would cause a crash.

This change wraps the event handler logic in a conditional block that checks if an IP was acquired before proceeding. This prevents the crash and ensures the event is handled gracefully.