### PR TITLE
Fixes crashing bug in FixedQueue.

### DIFF
--- a/src/freertos_drivers/common/FixedQueue.hxx
+++ b/src/freertos_drivers/common/FixedQueue.hxx
@@ -64,7 +64,17 @@ public:
     /// @return true if there is no entry in the queue.
     bool empty() { return size() == 0; }
     /// @return true if the queue cannot accept more elements.
-    bool full() { return size() >= SIZE; }
+    bool full() {
+        auto sz = size();
+        if (sz >= SIZE) {
+            return true;
+        }
+        if (sz != 0 && rdIndex_ == wrIndex_) {
+            // noncommit members make the queue full.
+            return true;
+        }
+        return false;
+    }
     /// @return the current number of entries in the queue.
     size_t size() { return __atomic_load_n(&count_, __ATOMIC_SEQ_CST); }
 


### PR DESCRIPTION
When there were many noncommit_back() writes, the full() function would still return that there is open space at the end of the queue. This would then cause certian append function to overrun the end of the space.