### PR TITLE
Optimizes the implementation of the railcom driver for multi-channel adapters

### DIFF
--- a/src/freertos_drivers/common/DccDecoder.hxx
+++ b/src/freertos_drivers/common/DccDecoder.hxx
@@ -65,6 +65,8 @@
   - SAMPLE_PERIOD_CLOCKS
   - Q_SIZE
   - TICKS_PER_USEC
+  - Output, which is a DccOutput compatible static object for creating
+      Railcom cutout.
   - module_init()
   - module_enable()
   - module_disable()
@@ -112,6 +114,16 @@ public:
 
     /** Handles a software interrupt to FreeRTOS. */
     inline void os_interrupt_handler() __attribute__((always_inline));
+
+    /// How many usec the railcom has before the cutout (measured from the
+    /// packet end 1 bit complete)
+    static const auto RAILCOM_CUTOUT_PRE = 26;
+    /// How many usec the railcom has to the middle of window (measured from the
+    /// packet end 1 bit complete)
+    static const auto RAILCOM_CUTOUT_MID = 185;
+    /// How many usec the railcom has to the end of the window (measured from
+    /// the packet end 1 bit complete)
+    static const auto RAILCOM_CUTOUT_END = 471;
 
 private:
     /** Read from a file or device.
@@ -239,16 +251,6 @@ private:
     /// DCC packet decoder state machine and internal state.
     dcc::DccDecoder decoder_ {Module::get_ticks_per_usec()};
 
-    /// How many usec the railcom has before the cutout (measured from the
-    /// packet end 1 bit complete)
-    static const auto RAILCOM_CUTOUT_PRE = 26;
-    /// How many usec the railcom has to the middle of window (measured from the
-    /// packet end 1 bit complete)
-    static const auto RAILCOM_CUTOUT_MID = 185;
-    /// How many usec the railcom has to the end of the window (measured from
-    /// the packet end 1 bit complete)
-    static const auto RAILCOM_CUTOUT_END = 471;
-
     DISALLOW_COPY_AND_ASSIGN(DccDecoder);
 };
 
@@ -324,9 +326,22 @@ __attribute__((optimize("-O3"))) void DccDecoder<Module>::interrupt_handler()
         debugLog_.add(new_value);
 #endif        
         bool cutout_just_finished = false;
+        Debug::DccDecodeInterrupts::set(false);
         decoder_.process_data(new_value);
+        Debug::DccDecodeInterrupts::set(true);
+        if (decoder_.state() == dcc::DccDecoder::DCC_END_OF_PREAMBLE) {
+            // Resets these state bits in case the state machines have
+            // diverged due to a bug.
+            inCutout_ = false;
+            prepCutout_ = false;
+            cutoutState_ = 0;
+        }
+        if (decoder_.state() == dcc::DccDecoder::DCC_MAYBE_CUTOUT) {
+            Debug::DccInCutoutPin::set(true);
+        }
         if (decoder_.before_dcc_cutout())
         {
+            Debug::RailComBeforeCutoutTiming::set(true);
             prepCutout_ = true;
             auto* p = decoder_.pkt();
             if (p)
@@ -345,6 +360,7 @@ __attribute__((optimize("-O3"))) void DccDecoder<Module>::interrupt_handler()
             true) // Module::NRZ_Pin::get())
         {
             //Debug::RailcomDriverCutout::set(true);
+            Debug::RailComBeforeCutoutTiming::set(false);
             Module::set_cap_timer_time();
             Module::set_cap_timer_delay_usec(
                 RAILCOM_CUTOUT_PRE + Module::time_delta_railcom_pre_usec());
@@ -361,21 +377,24 @@ __attribute__((optimize("-O3"))) void DccDecoder<Module>::interrupt_handler()
             //railcomDriver_->start_cutout();
             //inCutout_ = true;
         }
-        else if (decoder_.state() == dcc::DccDecoder::DCC_PACKET_FINISHED)
+        else if ((decoder_.state() == dcc::DccDecoder::DCC_PACKET_FINISHED &&
+                     !inCutout_) ||
+            (decoder_.state() == dcc::DccDecoder::DCC_PREAMBLE && prepCutout_ &&
+                !inCutout_))
         {
+            // The first partial bit after the cutout is done (for upstream
+            // cutout), or the preamble bit which came after the
+            // locally-generated cutout was finished.
             Debug::DccPacketFinishedHook::set(true);
-            if (inCutout_) {
-                //railcomDriver_->end_cutout();
-                inCutout_ = false;
-            }
             Module::dcc_packet_finished_hook();
             prepCutout_ = false;
             cutout_just_finished = true;
             Debug::DccPacketFinishedHook::set(false);
         }
         lastTimerValue_ = raw_new_value;
-        if (sampleActive_ && Module::NRZ_Pin::get() && !prepCutout_ &&
-            !cutout_just_finished)
+        if (sampleActive_ // && !inCutout_
+            && !prepCutout_ &&
+            !cutout_just_finished && Module::NRZ_Pin::get())
         {
             sampleActive_ = false;
             // The first positive edge after the sample timer expired (but
@@ -384,6 +403,8 @@ __attribute__((optimize("-O3"))) void DccDecoder<Module>::interrupt_handler()
             Module::after_feedback_hook();
         }
     }
+    Debug::DccInCutoutPin::set(inCutout_);
+    Debug::DccDecodeInterrupts::set(false);
 }
 
 template <class Module>
@@ -394,12 +415,23 @@ DccDecoder<Module>::rcom_interrupt_handler()
     if (Module::int_get_and_clear_delay_event())
     {
         // Debug::RailcomDriverCutout::set(false);
+        Module::rcom_cutout_hook(&cutoutState_);
         switch (cutoutState_)
         {
             case 0:
             {
                 Module::set_cap_timer_delay_usec(
                     RAILCOM_CUTOUT_MID + Module::time_delta_railcom_mid_usec());
+                if (Module::Output::need_railcom_cutout()) {
+                    Debug::RailcomTurnonPhase1::set(true);
+                    unsigned delay_usec =
+                        Module::Output::start_railcom_cutout_phase1();
+                    Module::Output::isRailcomCutoutActive_ = 1;
+                    microdelay(delay_usec);
+                    Debug::RailcomTurnonPhase1::set(false);
+                    delay_usec = Module::Output::start_railcom_cutout_phase2();
+                    microdelay(delay_usec);
+                }
                 railcomDriver_->start_cutout();
                 cutoutState_ = 1;
                 break;
@@ -412,17 +444,37 @@ DccDecoder<Module>::rcom_interrupt_handler()
                 cutoutState_ = 2;
                 break;
             }
-            default:
+            case 2:
             {
                 Module::stop_cap_timer_time();
                 Module::set_cap_timer_capture();
                 railcomDriver_->end_cutout();
+            } // fall through
+            case 100:
+            {
+                if (Module::Output::isRailcomCutoutActive_)
+                {
+                    Debug::RailcomTurnonPhase1::set(true);
+                    unsigned delay_usec =
+                        Module::Output::stop_railcom_cutout_phase1();
+                    microdelay(delay_usec);
+                    Debug::RailcomTurnonPhase1::set(false);
+                    Module::Output::stop_railcom_cutout_phase2();
+                    Module::Output::isRailcomCutoutActive_ = 0;
+                }
                 inCutout_ = false;
+                if (Module::Output::should_be_enabled())
+                {
+                    Module::Output::enable_output();
+                }
                 break;
             }
+            default:
+                break;
         }
     }
     Debug::DccDecodeInterrupts::set(false);
+    Debug::DccInCutoutPin::set(inCutout_);
 }
 
 template <class Module>

--- a/src/freertos_drivers/common/DccDecoder.hxx
+++ b/src/freertos_drivers/common/DccDecoder.hxx
@@ -329,14 +329,16 @@ __attribute__((optimize("-O3"))) void DccDecoder<Module>::interrupt_handler()
         Debug::DccDecodeInterrupts::set(false);
         decoder_.process_data(new_value);
         Debug::DccDecodeInterrupts::set(true);
-        if (decoder_.state() == dcc::DccDecoder::DCC_END_OF_PREAMBLE) {
+        if (decoder_.state() == dcc::DccDecoder::DCC_END_OF_PREAMBLE)
+        {
             // Resets these state bits in case the state machines have
             // diverged due to a bug.
             inCutout_ = false;
             prepCutout_ = false;
             cutoutState_ = 0;
         }
-        if (decoder_.state() == dcc::DccDecoder::DCC_MAYBE_CUTOUT) {
+        if (decoder_.state() == dcc::DccDecoder::DCC_MAYBE_CUTOUT)
+        {
             Debug::DccInCutoutPin::set(true);
         }
         if (decoder_.before_dcc_cutout())
@@ -393,8 +395,7 @@ __attribute__((optimize("-O3"))) void DccDecoder<Module>::interrupt_handler()
         }
         lastTimerValue_ = raw_new_value;
         if (sampleActive_ // && !inCutout_
-            && !prepCutout_ &&
-            !cutout_just_finished && Module::NRZ_Pin::get())
+            && !prepCutout_ && !cutout_just_finished && Module::NRZ_Pin::get())
         {
             sampleActive_ = false;
             // The first positive edge after the sample timer expired (but
@@ -422,7 +423,8 @@ DccDecoder<Module>::rcom_interrupt_handler()
             {
                 Module::set_cap_timer_delay_usec(
                     RAILCOM_CUTOUT_MID + Module::time_delta_railcom_mid_usec());
-                if (Module::Output::need_railcom_cutout()) {
+                if (Module::Output::need_railcom_cutout())
+                {
                     Debug::RailcomTurnonPhase1::set(true);
                     unsigned delay_usec =
                         Module::Output::start_railcom_cutout_phase1();

--- a/src/freertos_drivers/common/FixedQueue.hxx
+++ b/src/freertos_drivers/common/FixedQueue.hxx
@@ -134,6 +134,23 @@ public:
         __atomic_fetch_add(&count_, 1, __ATOMIC_SEQ_CST);
     }
 
+    /// Checks if there is space in the back. If yes, allocates one entry as
+    /// noncommit space and returns the pointer. If full, returns nullptr.
+    /// @return nullptr if the queue is full, otherwise a noncommit entry.
+    T* noncommit_back_or_null() {
+        auto sz = size();
+        if (sz >= SIZE) {
+            return nullptr;
+        }
+        if (sz != 0 && rdIndex_ == wrIndex_) {
+            // noncommit members make the queue full.
+            return nullptr;
+        }
+        auto* ret = &storage_[wrIndex_];
+        if (++wrIndex_ >= SIZE) wrIndex_ = 0;
+        return ret;
+    }
+    
 private:
     /// Payload of elements stored.
     T storage_[SIZE];

--- a/src/freertos_drivers/common/FixedQueue.hxx
+++ b/src/freertos_drivers/common/FixedQueue.hxx
@@ -137,20 +137,24 @@ public:
     /// Checks if there is space in the back. If yes, allocates one entry as
     /// noncommit space and returns the pointer. If full, returns nullptr.
     /// @return nullptr if the queue is full, otherwise a noncommit entry.
-    T* noncommit_back_or_null() {
+    T *noncommit_back_or_null()
+    {
         auto sz = size();
-        if (sz >= SIZE) {
+        if (sz >= SIZE)
+        {
             return nullptr;
         }
-        if (sz != 0 && rdIndex_ == wrIndex_) {
+        if (sz != 0 && rdIndex_ == wrIndex_)
+        {
             // noncommit members make the queue full.
             return nullptr;
         }
-        auto* ret = &storage_[wrIndex_];
-        if (++wrIndex_ >= SIZE) wrIndex_ = 0;
+        auto *ret = &storage_[wrIndex_];
+        if (++wrIndex_ >= SIZE)
+            wrIndex_ = 0;
         return ret;
     }
-    
+
 private:
     /// Payload of elements stored.
     T storage_[SIZE];

--- a/src/freertos_drivers/common/RailcomImpl.hxx
+++ b/src/freertos_drivers/common/RailcomImpl.hxx
@@ -222,13 +222,12 @@ public:
         }
     }
 
-private:
+protected:
     void set_feedback_key(uint32_t key) OVERRIDE
     {
         feedbackKey_ = key;
     }
 
-protected:
     /** Takes a new empty packet at the front of the queue, fills in feedback
      * key and channel information.
      * @param channel is which channel to set the packet for.
@@ -236,12 +235,11 @@ protected:
      * nullptr.*/
     dcc::Feedback *alloc_new_packet(uint8_t channel)
     {
-        if (!feedbackQueue_.has_noncommit_space())
+        dcc::Feedback *entry = feedbackQueue_.noncommit_back_or_null();
+        if (!entry)
         {
             return nullptr;
         }
-        dcc::Feedback *entry = &feedbackQueue_.back();
-        feedbackQueue_.noncommit_back();
         entry->reset(feedbackKey_);
         entry->channel = channel;
         return entry;

--- a/src/freertos_drivers/st/Stm32DCCDecoder.hxx
+++ b/src/freertos_drivers/st/Stm32DCCDecoder.hxx
@@ -117,7 +117,7 @@ template <class HW> class Stm32DccTimerModule
 public:
     // Declaration matching the DccOutput static class pattern.
     using Output = typename HW::Output;
-    
+
     /// Exports the input pin to the driver on the module interface.
     using NRZ_Pin = typename HW::NRZ_Pin;
 
@@ -269,8 +269,8 @@ public:
     /// sequence of handlers are not matching the desired
     /// functionality. Additional wakeups can be scheduled with
     /// set_cap_timer_delay_usec(...). An empty implementation is acceptable.
-    static inline void rcom_cutout_hook(uint32_t* cutout_state);
-    
+    static inline void rcom_cutout_hook(uint32_t *cutout_state);
+
 private:
     static TIM_HandleTypeDef captureTimerHandle_;
     static TIM_HandleTypeDef usecTimerHandle_;

--- a/src/freertos_drivers/st/Stm32Railcom.hxx
+++ b/src/freertos_drivers/st/Stm32Railcom.hxx
@@ -288,7 +288,8 @@ private:
                 uint8_t data = uart(i)->RDR;
                 (void)data;
             }
-            if (!returnedPackets_[i]) {
+            if (!returnedPackets_[i])
+            {
                 returnedPackets_[i] = this->alloc_new_packet(i);
             }
             if (need_ch1_cutout && returnedPackets_[i])
@@ -428,7 +429,8 @@ private:
         RailcomDriverBase<HW>::set_feedback_key(key);
         for (unsigned i = 0; i < HW::CHANNEL_COUNT; ++i)
         {
-            if (!returnedPackets_[i]) {
+            if (!returnedPackets_[i])
+            {
                 returnedPackets_[i] = this->alloc_new_packet(i);
             }
         }


### PR DESCRIPTION
- reduces the number of lock-unlock sequences needed for a packet allocation
Adjusts for new overrides:
- moves some symbols to public which different implementations will need
- Adds a hook for the cutout behavior on a per-hardware basis.

In Stm32 implementation:
- Makes the time window for sampling resistor smaller during occupancy sample measurement.
- Adds support for allocating feedback packets slightly earlier because this takes a lot of time.
- removes redundant code when no cutout is present.