### PR TITLE
Cleanup arduino's freertos_drivers/common includes

### DIFF
--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -40,8 +40,8 @@
 
 #include "CDIXMLGenerator.hxx"
 #include "executor/Notifiable.hxx"
-#include "freertos_drivers/arduino/Can.hxx"
-#include "freertos_drivers/arduino/WifiDefs.hxx"
+#include "freertos_drivers/common/Can.hxx"
+#include "freertos_drivers/common/WifiDefs.hxx"
 #include "openlcb/SimpleStack.hxx"
 #include "utils/FileUtils.hxx"
 #include "utils/GridConnectHub.hxx"
@@ -89,18 +89,14 @@ constexpr UBaseType_t OPENMRN_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO - 1;
 
 #endif // ESP32
 
+#include "freertos_drivers/common/ArduinoGpio.hxx"
+
 #ifdef ARDUINO_ARCH_STM32
-
-#include "freertos_drivers/arduino/ArduinoGpio.hxx"
 #include "freertos_drivers/stm32/Stm32Can.hxx"
-
 #endif
 
 #ifdef ARDUINO_FEATHER_M4_CAN
-
-#include "freertos_drivers/arduino/ArduinoGpio.hxx"
 #include "freertos_drivers/sam/FeatherM4Can.hxx"
-
 #endif
 
 

--- a/arduino/OpenMRNLite.h
+++ b/arduino/OpenMRNLite.h
@@ -89,14 +89,14 @@ constexpr UBaseType_t OPENMRN_TASK_PRIORITY = ESP_TASK_TCPIP_PRIO - 1;
 
 #endif // ESP32
 
-#include "freertos_drivers/common/ArduinoGpio.hxx"
-
 #ifdef ARDUINO_ARCH_STM32
 #include "freertos_drivers/stm32/Stm32Can.hxx"
+#include "freertos_drivers/arduino/ArduinoGpio.hxx"
 #endif
 
 #ifdef ARDUINO_FEATHER_M4_CAN
 #include "freertos_drivers/sam/FeatherM4Can.hxx"
+#include "freertos_drivers/arduino/ArduinoGpio.hxx"
 #endif
 
 

--- a/arduino/examples/ESP32/CanLoadTest/CanLoadTest.ino
+++ b/arduino/examples/ESP32/CanLoadTest/CanLoadTest.ino
@@ -42,7 +42,7 @@
 
 #include <openlcb/MultiConfiguredConsumer.hxx>
 #include <utils/GpioInitializer.hxx>
-#include <freertos_drivers/arduino/CpuLoad.hxx>
+#include <freertos_drivers/common/CpuLoad.hxx>
 
 
 // Pick an operating mode below, if you select USE_WIFI it will expose this

--- a/arduino/examples/ESP32C3/CanLoadTest/CanLoadTest.ino
+++ b/arduino/examples/ESP32C3/CanLoadTest/CanLoadTest.ino
@@ -42,7 +42,7 @@
 
 #include <openlcb/MultiConfiguredConsumer.hxx>
 #include <utils/GpioInitializer.hxx>
-#include <freertos_drivers/arduino/CpuLoad.hxx>
+#include <freertos_drivers/common/CpuLoad.hxx>
 
 // Pick an operating mode below, if you select USE_WIFI it will expose
 // this node on WIFI if you select USE_CAN, this node will be available

--- a/arduino/examples/ESP32S2/CanLoadTest/CanLoadTest.ino
+++ b/arduino/examples/ESP32S2/CanLoadTest/CanLoadTest.ino
@@ -42,8 +42,8 @@
 #include <openlcb/TcpDefs.hxx>
 
 #include <openlcb/MultiConfiguredConsumer.hxx>
-#include <utils/GpioInitializer.hxx>
-#include <freertos_drivers/arduino/CpuLoad.hxx>
+#include "utils/GpioInitializer.hxx"
+#include <freertos_drivers/common/CpuLoad.hxx>
 
 // Pick an operating mode below, if you select USE_WIFI it will expose
 // this node on WIFI if you select USE_CAN this node will be available on

--- a/arduino/idf/CMakeLists.txt
+++ b/arduino/idf/CMakeLists.txt
@@ -2,7 +2,7 @@ set(SOURCE_DIRS
     src/dcc
     src/executor
     src/freertos_drivers/esp32
-    src/freertos_drivers/arduino
+    src/freertos_drivers/common
     src/openlcb
     src/os
     src/utils

--- a/arduino/idf/CMakeLists.txt
+++ b/arduino/idf/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCE_DIRS
     src/executor
     src/freertos_drivers/esp32
     src/freertos_drivers/common
+    src/freertos_drivers/arduino
     src/openlcb
     src/os
     src/utils

--- a/arduino/libify.sh
+++ b/arduino/libify.sh
@@ -209,7 +209,10 @@ rm -f ${TARGET_LIB_DIR}/src/openlcb/CompileCdiMain.cxx \
     ${TARGET_LIB_DIR}/src/openlcb/BLE* \
 
 copy_file src/freertos_drivers/arduino \
-          src/freertos_drivers/arduino/* \
+          src/freertos_drivers/arduino/*
+
+copy_file src/freertos_drivers/common \
+          src/freertos_drivers/arduino/Can.{hxx,cxx} \
           src/freertos_drivers/common/DeviceBuffer.{hxx,cxx} \
           src/freertos_drivers/common/DummyGPIO.hxx \
           src/freertos_drivers/common/GpioWrapper.hxx \

--- a/include/freertos/freertos_includes.h
+++ b/include/freertos/freertos_includes.h
@@ -54,7 +54,7 @@
 #define xQueueHandle                  QueueHandle_t
 #define xSemaphoreHandle              SemaphoreHandle_t
 
-// used in freertos_drivers/arduino/CpuLoad.hxx and os/os.c
+// used in freertos_drivers/common/CpuLoad.hxx and os/os.c
 #define pcTaskGetTaskName             pcTaskGetName
 
 #endif // IDF v5.0+ and !CONFIG_FREERTOS_ENABLE_BACKWARD_COMPATIBILITY

--- a/src/freertos_drivers/arduino/ArduinoGpio.hxx
+++ b/src/freertos_drivers/arduino/ArduinoGpio.hxx
@@ -36,7 +36,7 @@
 #define _DRIVERS_ARDUINOGPIO_HXX_
 
 #include "os/Gpio.hxx"
-#include "GpioWrapper.hxx"
+#include "freertos_drivers/common/GpioWrapper.hxx"
 #ifdef ESP_PLATFORM
 #include <esp32-hal.h>
 #include <driver/gpio.h>

--- a/src/freertos_drivers/arduino/Can.hxx
+++ b/src/freertos_drivers/arduino/Can.hxx
@@ -37,7 +37,7 @@
 #ifndef _FREERTOS_DRIVERS_ARDUINO_CAN_HXX_
 #define _FREERTOS_DRIVERS_ARDUINO_CAN_HXX_
 
-#include "DeviceBuffer.hxx"
+#include "freertos_drivers/common/DeviceBuffer.hxx"
 #include "can_frame.h"
 #include "nmranet_config.h"
 #include "os/OS.hxx"

--- a/src/freertos_drivers/esp32/Esp32Can.hxx
+++ b/src/freertos_drivers/esp32/Esp32Can.hxx
@@ -45,7 +45,7 @@
 
 #include <string.h>
 #include "driver/twai.h"
-#include "freertos_drivers/arduino/Can.hxx"
+#include "freertos_drivers/common/Can.hxx"
 
 /// ESP32 TWAI CAN driver.
 class Esp32Can : public openmrn_arduino::Can

--- a/src/freertos_drivers/esp32/Esp32Gpio.hxx
+++ b/src/freertos_drivers/esp32/Esp32Gpio.hxx
@@ -35,14 +35,7 @@
 #ifndef _DRIVERS_ESP32GPIO_HXX_
 #define _DRIVERS_ESP32GPIO_HXX_
 
-// TODO: clean this up as part of https://github.com/bakerstu/openmrn/issues/778
-// as this file should be coming in from common and not arduino ideally.
-#if defined(__has_include) && \
-    __has_include("freertos_drivers/common/GpioWrapper.hxx")
 #include "freertos_drivers/common/GpioWrapper.hxx"
-#else
-#include "freertos_drivers/arduino/GpioWrapper.hxx"
-#endif
 #include "freertos_drivers/esp32/Esp32AdcOneShot.hxx"
 #include "os/Gpio.hxx"
 #include "utils/logging.h"

--- a/src/freertos_drivers/esp32/Esp32HardwareTwai.cxx
+++ b/src/freertos_drivers/esp32/Esp32HardwareTwai.cxx
@@ -73,14 +73,7 @@
 #include "can_frame.h"
 #include "can_ioctl.h"
 #include "executor/Notifiable.hxx"
-// TODO: clean this up as part of https://github.com/bakerstu/openmrn/issues/778
-// as this file should be coming in from common and not arduino ideally.
-#if defined(__has_include) && \
-    __has_include("freertos_drivers/common/DeviceBuffer.hxx")
 #include "freertos_drivers/common/DeviceBuffer.hxx"
-#else
-#include "freertos_drivers/arduino/DeviceBuffer.hxx"
-#endif
 #include "freertos_drivers/esp32/Esp32HardwareTwai.hxx"
 #include "utils/Atomic.hxx"
 #include "utils/logging.h"

--- a/src/freertos_drivers/esp32/Esp32Ledc.hxx
+++ b/src/freertos_drivers/esp32/Esp32Ledc.hxx
@@ -35,14 +35,7 @@
 #ifndef _DRIVERS_ESP32LEDC_HXX_
 #define _DRIVERS_ESP32LEDC_HXX_
 
-// TODO: clean this up as part of https://github.com/bakerstu/openmrn/issues/778
-// as this file should be coming in from common and not arduino ideally.
-#if defined(__has_include) && \
-    __has_include("freertos_drivers/common/PWM.hxx")
 #include "freertos_drivers/common/PWM.hxx"
-#else
-#include "freertos_drivers/arduino/PWM.hxx"
-#endif
 #include "utils/logging.h"
 #include "utils/macros.h"
 #include "utils/Uninitialized.hxx"

--- a/src/freertos_drivers/sam/FeatherM4Can.hxx
+++ b/src/freertos_drivers/sam/FeatherM4Can.hxx
@@ -42,7 +42,7 @@
 
 #include <ACANFD_FeatherM4CAN-from-cpp.h>
 
-#include "freertos_drivers/arduino/Can.hxx"
+#include "freertos_drivers/common/Can.hxx"
 
 /// Wrapper for Arduino CAN driver for the Feather M4 CAN board using the
 /// external ACANFD_FeatherM4CAN library.

--- a/src/freertos_drivers/st/Stm32Can.hxx
+++ b/src/freertos_drivers/st/Stm32Can.hxx
@@ -36,12 +36,11 @@
 
 #include <cstdint>
 
+#include "freertos_drivers/common/Can.hxx"
 #ifdef ARDUINO
 #include <Arduino.h>
-#include "freertos_drivers/arduino/Can.hxx"
 using CanBase = openmrn_arduino::Can;
 #else
-#include "freertos_drivers/common/Can.hxx"
 using CanBase = ::Can;
 #endif
 

--- a/src/openlcb/ServoConsumer.hxx
+++ b/src/openlcb/ServoConsumer.hxx
@@ -1,13 +1,8 @@
 #ifndef _OPENLCB_SERVOCONSUMER_HXX_
 #define _OPENLCB_SERVOCONSUMER_HXX_
 
-#if defined(ARDUINO) || defined(ESP_PLATFORM)
-#include "freertos_drivers/arduino/DummyGPIO.hxx"
-#include "freertos_drivers/arduino/PWM.hxx"
-#else
 #include "freertos_drivers/common/DummyGPIO.hxx"
 #include "freertos_drivers/common/PWM.hxx"
-#endif
 #include "openlcb/ServoConsumerConfig.hxx"
 #include "os/MmapGpio.hxx"
 #include <memory>


### PR DESCRIPTION
- Updates libify to move files from freertos_drivers/common to freertos_drivers/common in the arduino library
- removes a bunch of conditional compilation
- updates includes to point to freertos_drivers/common
- Adds some missing directory qualifications.

Note that there are still files in freertos_drivers/arduino. These are truly arduino specific.