### PR TITLE
Fix mutex lock allocation during static initialization.

### DIFF
--- a/src/os/os.h
+++ b/src/os/os.h
@@ -535,9 +535,9 @@ OS_INLINE int os_mutex_lock(os_mutex_t *mutex)
 #if OPENMRN_FEATURE_MUTEX_FREERTOS
     if (mutex->sem == NULL)
     {
-        bool need_scheduler =
+        bool task_scheduler_running =
             (xTaskGetSchedulerState() == taskSCHEDULER_RUNNING);
-        if (need_scheduler)
+        if (task_scheduler_running)
         {
             vTaskSuspendAll();
         }
@@ -552,7 +552,7 @@ OS_INLINE int os_mutex_lock(os_mutex_t *mutex)
                 mutex->sem = xSemaphoreCreateMutex();
             }
         }
-        if (need_scheduler)
+        if (task_scheduler_running)
         {
             xTaskResumeAll();
         }


### PR DESCRIPTION
This PR avoids the starting/stopping the scheduler when the scheduler is not running yet. This is typically the case in code that is running at static initialization time.

More recent freertos versions crash with an assert when we were doing that.

As a byside, makes this code more efficient to run by not even attempting to manipulate the scheduler when the mutex is already allocated. Since there is exactly one moment when sem goes from NULL to non-NULL, there is no race condition if we observe it being non-NULL.