### PR TITLE
[Do Not Merge] Traction Modem Reset Link Timeout on Any Rx

### DIFF
--- a/src/traction_modem/Link.cxxtest
+++ b/src/traction_modem/Link.cxxtest
@@ -298,6 +298,7 @@ TEST_F(LinkTest, LinkUpMaxDelay)
         Defs::append_uint8(&b->data()->payload, 0);
         Defs::append_uint8(&b->data()->payload, 0);
         Defs::append_crc(&b->data()->payload);
+        mRxFlow_.trigger_packet_rx_callback();
         static_cast<PacketFlowInterface*>(&linkManager_)->send(b);
         wait_for_main_executor();
         testing::Mock::VerifyAndClearExpectations(&mTxFlow_);

--- a/src/traction_modem/RxFlow.hxx
+++ b/src/traction_modem/RxFlow.hxx
@@ -83,9 +83,18 @@ public:
     {
         return resyncCount_;
     }
+
+    /// Register for a callback when any packet is received.
+    virtual void register_packet_rx_callback(std::function<void()> callback)
+    {
+        pktRxCallback_ = callback;
+    }
+
 protected:
     /// Track the number of times that we try to resync.
     unsigned resyncCount_{0};
+    /// Callback for when any packet is received.
+    std::function<void()> pktRxCallback_;
 };
 
 /// Object responsible for reading in a stream of bytes over the modem
@@ -323,6 +332,10 @@ private:
 
         auto *b = dispatcher_.alloc();
         b->data()->payload = std::move(payload_);
+        if (pktRxCallback_)
+        {
+            pktRxCallback_();
+        }
         dispatcher_.send(b);
 
         if (payload_tmp.size())

--- a/src/traction_modem/modem_test_helper.hxx
+++ b/src/traction_modem/modem_test_helper.hxx
@@ -19,6 +19,14 @@ public:
         void(PacketFlowInterface*, Message::id_type, Message::id_type));
     MOCK_METHOD1(unregister_handler_all, void(PacketFlowInterface*));
     MOCK_METHOD1(register_fallback_handler, void(PacketFlowInterface*));
+
+    void trigger_packet_rx_callback()
+    {
+        if (pktRxCallback_)
+        {
+            pktRxCallback_();
+        }
+    }
 };
 
 class MyMockRxFlow : public MockRxFlow
@@ -104,6 +112,7 @@ protected:
                     Defs::append_uint8(&b->data()->payload, 0);
                     Defs::append_uint8(&b->data()->payload, 0);
                     Defs::append_crc(&b->data()->payload);
+                    mRxFlow_.trigger_packet_rx_callback();
                     static_cast<PacketFlowInterface*>(&linkManager_)->send(b);
                 }
             }
@@ -147,6 +156,7 @@ protected:
             Defs::append_uint8(&b->data()->payload, 0);
             Defs::append_uint8(&b->data()->payload, 0);
             Defs::append_crc(&b->data()->payload);
+            mRxFlow_.trigger_packet_rx_callback();
             static_cast<PacketFlowInterface*>(&linkManager_)->send(b);
             wait_for_main_executor();
             EXPECT_TRUE(link_.is_link_up());


### PR DESCRIPTION
I found an issue when doing firmware updates on the main decoder MCU. Basically, execution stalls whenever FLASH is erased/programmed. This causes the main decoder MCU to miss an occasional ping, and since we only reset the link timeout on a pong response, this results in a link down, eventually.

This could also be an issue for other memory space writes, such as CVs.

- Adds a callback registration to the RxInterface that is called whenever any packet is received.
- Adds callback to the the LinkManager to reset the link timeout.
  - This logic is moved from the PING_RESP handler.
- Fixes unit tests.