### PR TITLE
Refactor `HubDevice` constants to conform to style guide

### DIFF
--- a/src/utils/HubDevice.cxx
+++ b/src/utils/HubDevice.cxx
@@ -36,13 +36,13 @@
 #include <stdlib.h>
 
 template <>
-const int FdHubPort<CanHubFlow>::ReadThread::kUnit = sizeof(struct can_frame);
+const int FdHubPort<CanHubFlow>::ReadThread::UNIT = sizeof(struct can_frame);
 template <>
-const int FdHubPort<CanHubFlow>::ReadThread::kBufSize = sizeof(
+const int FdHubPort<CanHubFlow>::ReadThread::BUF_SIZE = sizeof(
     struct can_frame);
 #if defined(__FreeRTOS__) || defined(ESP_PLATFORM)
 template <>
-const int FdHubPort<CanHubFlow>::ReadThread::kReadThreadPriority =
+const int FdHubPort<CanHubFlow>::ReadThread::READ_THREAD_PRIORITY =
     OSThread::get_priority_max();
 #endif
 
@@ -63,9 +63,9 @@ void FdHubPort<CanHubFlow>::ReadThread::send_message(const void *buf, int size)
     port()->hub_->send(b, 0);
 }
 
-template <> const int FdHubPort<HubFlow>::ReadThread::kUnit = 1;
-template <> const int FdHubPort<HubFlow>::ReadThread::kBufSize = 64;
-template <> const int FdHubPort<HubFlow>::ReadThread::kReadThreadPriority = 0;
+template <> const int FdHubPort<HubFlow>::ReadThread::UNIT = 1;
+template <> const int FdHubPort<HubFlow>::ReadThread::BUF_SIZE = 64;
+template <> const int FdHubPort<HubFlow>::ReadThread::READ_THREAD_PRIORITY = 0;
 
 
 template <>
@@ -97,14 +97,14 @@ void FdHubPort<HubFlow>::ReadThread::send_message(const void *buf, int size)
 }
 
 /// Prefix for thread names created by the FdHubPort for reading and writing.
-static const char kThreadPrefix[] = "thread_fd_";
+static const char THREAD_PREFIX[] = "thread_fd_";
 
 void FdHubPortBase::fill_thread_name(char *buf, char mode, int fd)
 {
-    memcpy(buf, kThreadPrefix, sizeof(kThreadPrefix));
+    memcpy(buf, THREAD_PREFIX, sizeof(THREAD_PREFIX));
     static_assert(
-        sizeof(kThreadPrefix) == 11, "size of thread prefix incorrect");
-    char *p = buf + sizeof(kThreadPrefix) - 1;
+        sizeof(THREAD_PREFIX) == 11, "size of thread prefix incorrect");
+    char *p = buf + sizeof(THREAD_PREFIX) - 1;
     *p++ = mode;
     *p++ = '_';
     char *q = p;

--- a/src/utils/HubDevice.hxx
+++ b/src/utils/HubDevice.hxx
@@ -51,14 +51,14 @@ public:
 #ifdef ESP_PLATFORM
     // TODO: shrink these if possible
     /// How many bytes of stack should we allocate to the write thread's stack.
-    static const int kWriteThreadStackSize = 2048;
+    static const int WRITE_THREAD_STACK_SIZE = 2048;
     /// How many bytes of stack should we allocate to the read thread's stack.
-    static const int kReadThreadStackSize = 2048;
+    static const int READ_THREAD_STACK_SIZE = 2048;
 #else
     /// How many bytes of stack should we allocate to the write thread's stack.
-    static const int kWriteThreadStackSize = 1000;
+    static const int WRITE_THREAD_STACK_SIZE = 1000;
     /// How many bytes of stack should we allocate to the read thread's stack.
-    static const int kReadThreadStackSize = 1000;
+    static const int READ_THREAD_STACK_SIZE = 1000;
 #endif // ESP_PLATFORM
 
     /// Constructor.
@@ -67,7 +67,7 @@ public:
     /// the hub (usually due to an error).
     FdHubPortBase(int fd, Notifiable *done)
         : FdHubPortInterface(fd)
-        , writeThread_(fill_thread_name('W', fd), 3, kWriteThreadStackSize)
+        , writeThread_(fill_thread_name('W', fd), 3, WRITE_THREAD_STACK_SIZE)
         , writeService_(&writeThread_)
         , barrier_(done)
         , hasError_(0)
@@ -327,7 +327,7 @@ public:
         {
             init();
             start(port->fill_thread_name('R', port->fd_),
-                  kReadThreadPriority, port->kReadThreadStackSize);
+                  READ_THREAD_PRIORITY, port->READ_THREAD_STACK_SIZE);
         }
         
         ~ReadThread() {
@@ -343,13 +343,13 @@ public:
         /** @param this is the minimum number of bytes that we will send. */
         int unit() OVERRIDE
         {
-            return kUnit;
+            return UNIT;
         }
         /** @return We will allocate this many bytes for read buffer. This is
          * the maximum number of bytes that we'll send. */
         int buf_size() OVERRIDE
         {
-            return kBufSize;
+            return BUF_SIZE;
         }
         /** Sends off a buffer */
         void send_message(const void *buf, int size) OVERRIDE;
@@ -361,12 +361,12 @@ public:
         SemaphoreNotifiableBlock* semaphores_{nullptr};
 
         /** This is the minimum number of bytes that we will send. */
-        static const int kUnit;
+        static const int UNIT;
         /** We will allocate this many bytes for read buffer. This is the
          * maximum number of bytes that we'll send. */
-        static const int kBufSize;
+        static const int BUF_SIZE;
         /** Priority to use for read thread; 0 is default priority. */
-        static const int kReadThreadPriority;
+        static const int READ_THREAD_PRIORITY;
     };
 
 private:


### PR DESCRIPTION
Updates the naming convention of several constants in `src/utils/HubDevice.hxx` and `src/utils/HubDevice.cxx` to adhere to the project style guide (documented in `doc/style_guide.dox`), which requires all constants to use `UPPER_CASE`.

Changed constants:
- `kWriteThreadStackSize` -> `WRITE_THREAD_STACK_SIZE`
- `kReadThreadStackSize` -> `READ_THREAD_STACK_SIZE`
- `kUnit` -> `UNIT`
- `kBufSize` -> `BUF_SIZE`
- `kReadThreadPriority` -> `READ_THREAD_PRIORITY`
- `kThreadPrefix` -> `THREAD_PREFIX`