### PR TITLE
[Do not merge] Traction Modem Program Track Message Support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -267,8 +267,10 @@ set(TESTS ${TESTS}
     ${OPENMRNPATH}/src/traction_modem/Defs.cxxtest
     ${OPENMRNPATH}/src/traction_modem/Link.cxxtest
     ${OPENMRNPATH}/src/traction_modem/MemorySpace.cxxtest
+    ${OPENMRNPATH}/src/traction_modem/MemorySpaceServer.cxxtest
     ${OPENMRNPATH}/src/traction_modem/ModemTrain.cxxtest
     ${OPENMRNPATH}/src/traction_modem/Output.cxxtest
+    ${OPENMRNPATH}/src/traction_modem/ProgramTrack.cxxtest
     ${OPENMRNPATH}/src/traction_modem/RxTxFlow.cxxtest
 
     ${OPENMRNPATH}/src/utils/async_if_test_helper.cxxtest

--- a/src/traction_modem/Defs.hxx
+++ b/src/traction_modem/Defs.hxx
@@ -81,6 +81,7 @@ struct Defs
         CMD_SPEED_SET          = 0x0100, ///< set velocity
         CMD_FN_SET             = 0x0101, ///< set function
         CMD_ESTOP_SET          = 0x0102, ///< emergency stop request
+        CMD_PROGRAM_TRACK      = 0x0103, ///< program track mode
         CMD_SPEED_QUERY        = 0x0110, ///< query current speed
         CMD_FN_QUERY           = 0x0111, ///< query function status
         CMD_DC_DCC_PRESENT     = 0x0200, ///< DC/DCC present
@@ -104,6 +105,8 @@ struct Defs
         RESP_FN_SET             = RESPONSE | CMD_FN_SET,
         /// emergency stop response
         RESP_ESTOP_SET          = RESPONSE | CMD_ESTOP_SET,
+        /// program track mode response
+        RESP_PROGRAM_TRACK      = RESPONSE | CMD_PROGRAM_TRACK,
         /// query current speed response
         RESP_SPEED_QUERY        = RESPONSE | CMD_SPEED_QUERY,
         /// query function status response
@@ -162,6 +165,10 @@ struct Defs
     static constexpr unsigned LEN_SPEED_SET = 1;
     /// Length of the data payload of a set estop packet.
     static constexpr unsigned LEN_ESTOP_SET = 0;
+    /// Length of the data payload of a program track packet.
+    static constexpr unsigned LEN_PROGRAM_TRACK = 1;
+    /// Length of the data payload of a program track response packet.
+    static constexpr unsigned LEN_PROGRAM_TRACK_RESP = 0;
     /// Length of the data payload of a wireless present packet.
     static constexpr unsigned LEN_WIRELESS_PRESENT = 1;
     /// Length of the data payload of an output state packet.
@@ -291,6 +298,19 @@ struct Defs
     static_assert(offsetof(OutputRestart, end) == (LEN_HEADER + LEN_OUTPUT_RESTART),
         "OutputRestart struct length or alignment mismatch.");
     static_assert(std::is_standard_layout<OutputRestart>::value == true);
+
+    /// Structure of a program track command.
+    struct ProgramTrackCmd
+    {
+        Header header_; ///< packet header
+        uint8_t mode_;  ///< 0 = exit program track mode, 1 = enter program
+                        ///<   track mode
+        uint8_t end;    ///< used for alignment and length validation only
+    };
+    static_assert(
+        offsetof(ProgramTrackCmd, end) == (LEN_HEADER + LEN_PROGRAM_TRACK),
+        "ProgramTrackCmd struct length or alignment mismatch.");
+    static_assert(std::is_standard_layout<ProgramTrackCmd>::value == true);
 
     /// Structure of a write packet.
     struct Write
@@ -424,6 +444,28 @@ struct Defs
         Payload p;
         prepare(&p, CMD_ESTOP_SET, LEN_ESTOP_SET);
         // no data in the payload
+        append_crc(&p);
+        return p;
+    }
+
+    /// Computes payload for a program track mode command.
+    /// @param mode 0 = exit program track mode, 1 = enter program track mode
+    /// @return wire formatted payload
+    static Payload get_program_track_payload(uint8_t mode)
+    {
+        Payload p;
+        prepare(&p, CMD_PROGRAM_TRACK, LEN_PROGRAM_TRACK);
+        append_uint8(&p, mode);
+        append_crc(&p);
+        return p;
+    }
+
+    /// Computes payload for a program track mode response.
+    /// @return wire formatted payload
+    static Payload get_program_track_resp_payload()
+    {
+        Payload p;
+        prepare(&p, RESP_PROGRAM_TRACK, LEN_PROGRAM_TRACK_RESP);
         append_crc(&p);
         return p;
     }

--- a/src/traction_modem/ModemTrain.cxxtest
+++ b/src/traction_modem/ModemTrain.cxxtest
@@ -23,6 +23,8 @@ protected:
             register_handler(_, Defs::RESP_OUTPUT_STATE_QUERY, _)).Times(1);
         EXPECT_CALL(mRxFlow_, register_handler(_, Defs::CMD_MEM_W, _)).Times(1);
         EXPECT_CALL(mRxFlow_, register_handler(_, Defs::CMD_MEM_R, _)).Times(1);
+        EXPECT_CALL(mRxFlow_,
+            register_handler(_, Defs::CMD_PROGRAM_TRACK, _)).Times(1);
         train_ = new ModemTrain(&g_service, &mTxFlow_, &mRxFlow_, &mHwIf_);
         testing::Mock::VerifyAndClearExpectations(&mRxFlow_);
     }
@@ -32,7 +34,7 @@ protected:
     {
         testing::Mock::VerifyAndClearExpectations(&mRxFlow_);
         using ::testing::_;
-        EXPECT_CALL(mRxFlow_, unregister_handler_all(_)).Times(2);
+        EXPECT_CALL(mRxFlow_, unregister_handler_all(_)).Times(3);
         delete train_;
     }
 

--- a/src/traction_modem/ModemTrain.hxx
+++ b/src/traction_modem/ModemTrain.hxx
@@ -40,6 +40,7 @@
 #include "traction_modem/MemorySpace.hxx"
 #include "traction_modem/MemorySpaceServer.hxx"
 #include "traction_modem/Output.hxx"
+#include "traction_modem/ProgramTrack.hxx"
 #include "traction_modem/Link.hxx"
 
 namespace traction_modem
@@ -67,6 +68,7 @@ public:
         , fuSpace_(service, &link_)
         , output_(tx_flow, rx_flow, hw_interface)
         , memorySpaceServer_(tx_flow, rx_flow, hw_interface)
+        , programTrack_(tx_flow, rx_flow, hw_interface)
         , isActive_(false)
     {
     }
@@ -221,8 +223,10 @@ private:
     CvSpace fuSpace_;
     /// Output handler.
     Output output_;
-    // Memory space handler for the modem.
+    /// Memory space handler for the modem.
     MemorySpaceServer memorySpaceServer_;
+    /// Program track mode handler.
+    ProgramTrack programTrack_;
     /// True if the last set was estop, false if it was a speed.
     bool inEStop_ = false;
     /// Is the wireless active.

--- a/src/traction_modem/ModemTrainHwInterface.hxx
+++ b/src/traction_modem/ModemTrainHwInterface.hxx
@@ -76,6 +76,13 @@ public:
         OUT_OF_BOUNDS     = openlcb::MemoryConfigDefs::ERROR_OUT_OF_BOUNDS,
     };
 
+    /// Program track mode.
+    enum class ProgramTrackMode : uint8_t
+    {
+        EXIT  = 0, ///< exit program track mode
+        ENTRY = 1, ///< enter program track mode
+    };
+
     /// Set an output state.
     /// @param output output number
     /// @param state 0 = off, 0xFFFF = on
@@ -86,6 +93,13 @@ public:
     /// Restart an output (synchronize lighting effect).
     /// @param output output number
     virtual void output_restart(uint16_t output)
+    {
+    }
+
+    /// Handle a program track mode change request from the decoder.
+    /// @param mode EXIT = leave program track mode, ENTRY = enter program
+    ///        track mode
+    virtual void program_track(ProgramTrackMode mode)
     {
     }
 

--- a/src/traction_modem/ProgramTrack.cxxtest
+++ b/src/traction_modem/ProgramTrack.cxxtest
@@ -1,0 +1,124 @@
+#include "utils/test_main.hxx"
+
+#include "traction_modem/modem_test_helper.hxx"
+
+#include "traction_modem/ProgramTrack.hxx"
+
+using namespace std::string_literals;
+
+namespace traction_modem
+{
+
+/// Test object for ProgramTrack.
+class ProgramTrackTest : public ::testing::Test
+{
+protected:
+    /// Constructor.
+    ProgramTrackTest()
+    {
+        using ::testing::_;
+        EXPECT_CALL(
+            mRxFlow_, register_handler(_, Defs::CMD_PROGRAM_TRACK, _))
+            .Times(1);
+        programTrack_ = new ProgramTrack(&mTxFlow_, &mRxFlow_, &mHwIf_);
+        testing::Mock::VerifyAndClearExpectations(&mRxFlow_);
+    }
+
+    /// Destructor.
+    ~ProgramTrackTest()
+    {
+    }
+
+    ::testing::StrictMock<MyMockRxFlow> mRxFlow_; ///< mock receive flow
+    ::testing::StrictMock<MockTxFlow> mTxFlow_; ///< mock transmit flow
+    ::testing::StrictMock<MockTrainHwInterface> mHwIf_; ///< mock train hardware
+    ProgramTrack *programTrack_; ///< program track instance
+};
+
+/// Append the expected CRC value.
+/// @param payload packet payload
+/// @param all crc of all bytes
+/// @param even crc of even index bytes
+/// @param odd crc of odd index bytes
+static void append_expected_crc(
+    Defs::Payload *payload, uint16_t all, uint16_t even, uint16_t odd)
+{
+    payload->push_back(all >> 8);
+    payload->push_back(all & 0xFF);
+    payload->push_back(even >> 8);
+    payload->push_back(even & 0xFF);
+    payload->push_back(odd >> 8);
+    payload->push_back(odd & 0xFF);
+}
+
+/// Append the expected CRC value.
+/// @param payload packet payload, including a prepended preamble
+static void append_expected_crc(Defs::Payload *payload)
+{
+    Defs::CRC crc;
+    crc3_crc16_ccitt(payload->data() + sizeof(uint32_t),
+         payload->size() - sizeof(uint32_t), crc.crc);
+    append_expected_crc(payload, crc.all_, crc.even_, crc.odd_);
+}
+
+TEST_F(ProgramTrackTest, Create)
+{
+}
+
+TEST_F(ProgramTrackTest, Exit)
+{
+    using ::testing::Sequence;
+    using ::testing::Eq;
+
+    Sequence s1;
+    std::string tx_data;
+
+    EXPECT_CALL(mHwIf_, program_track(
+        ModemTrainHwInterface::ProgramTrackMode::EXIT))
+        .Times(1)
+        .InSequence(s1);
+    tx_data = "\x41\xd2\xc3\x7a"s "\x81\x03"s "\x00\x00"s;
+    append_expected_crc(&tx_data);
+    EXPECT_CALL(mTxFlow_, send_packet(Eq(tx_data))).InSequence(s1);
+    {
+        auto *b = mRxFlow_.dispatcher_.alloc();
+        Defs::prepare(&b->data()->payload, Defs::CMD_PROGRAM_TRACK,
+            Defs::LEN_PROGRAM_TRACK);
+        Defs::append_uint8(&b->data()->payload, 0);
+        Defs::append_crc(&b->data()->payload);
+        mRxFlow_.dispatcher_.send(b);
+        wait_for_main_executor();
+    }
+    testing::Mock::VerifyAndClearExpectations(&mHwIf_);
+    testing::Mock::VerifyAndClearExpectations(&mTxFlow_);
+}
+
+TEST_F(ProgramTrackTest, Entry)
+{
+    using ::testing::Sequence;
+    using ::testing::Eq;
+
+    Sequence s1;
+    std::string tx_data;
+
+    EXPECT_CALL(mHwIf_, program_track(
+        ModemTrainHwInterface::ProgramTrackMode::ENTRY))
+        .Times(1)
+        .InSequence(s1);
+    tx_data = "\x41\xd2\xc3\x7a"s "\x81\x03"s "\x00\x00"s;
+    append_expected_crc(&tx_data);
+    EXPECT_CALL(mTxFlow_, send_packet(Eq(tx_data))).InSequence(s1);
+    {
+        auto *b = mRxFlow_.dispatcher_.alloc();
+        Defs::prepare(&b->data()->payload, Defs::CMD_PROGRAM_TRACK,
+            Defs::LEN_PROGRAM_TRACK);
+        Defs::append_uint8(&b->data()->payload, 1);
+        Defs::append_crc(&b->data()->payload);
+        mRxFlow_.dispatcher_.send(b);
+        wait_for_main_executor();
+    }
+    testing::Mock::VerifyAndClearExpectations(&mHwIf_);
+    testing::Mock::VerifyAndClearExpectations(&mTxFlow_);
+}
+
+} // namespace traction_modem

--- a/src/traction_modem/ProgramTrack.hxx
+++ b/src/traction_modem/ProgramTrack.hxx
@@ -1,0 +1,103 @@
+/** @copyright
+ * Copyright (c) 2026, Stuart Baker
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file ProgramTrack.hxx
+ *
+ * Logic for handling program track mode requests from the decoder.
+ *
+ * @author Stuart Baker
+ * @date 17 Apr 2026
+ */
+
+#ifndef _TRACTION_MODEM_PROGRAMTRACK_HXX_
+#define _TRACTION_MODEM_PROGRAMTRACK_HXX_
+
+#include "traction_modem/RxFlow.hxx"
+#include "traction_modem/TxFlow.hxx"
+#include "traction_modem/Message.hxx"
+#include "traction_modem/ModemTrainHwInterface.hxx"
+
+namespace traction_modem
+{
+
+/// Handler for program track mode requests from the decoder. When a
+/// CMD_PROGRAM_TRACK command is received, the hardware interface
+/// program_track() method is called and a RESP_PROGRAM_TRACK response with
+/// no data payload is sent back to the decoder.
+class ProgramTrack : public PacketFlowInterface
+{
+public:
+    /// Constructor.
+    /// @param tx_flow reference to the transmit flow
+    /// @param rx_flow reference to the receive flow
+    /// @param hw_interface hardware specific interface to the modem train
+    ProgramTrack(TxInterface *tx_flow, RxInterface *rx_flow,
+        ModemTrainHwInterface *hw_interface)
+        : txFlow_(tx_flow)
+        , rxFlow_(rx_flow)
+        , hwIf_(hw_interface)
+    {
+        rxFlow_->register_handler(this, Defs::CMD_PROGRAM_TRACK);
+    }
+
+    /// Destructor.
+    ~ProgramTrack()
+    {
+        rxFlow_->unregister_handler_all(this);
+    }
+
+private:
+    /// Shortcut for accessing the ModemTrainHwInterface::ProgramTrackMode.
+    using ProgramTrackMode = ModemTrainHwInterface::ProgramTrackMode;
+
+    /// Receive for program track commands.
+    /// @param buf incoming message
+    /// @param prio message priority
+    void send(Buffer<Message> *buf, unsigned prio) override
+    {
+        auto b = get_buffer_deleter(buf);
+        switch (b->data()->command())
+        {
+            case Defs::CMD_PROGRAM_TRACK:
+            {
+                Defs::ProgramTrackCmd *pt =
+                    (Defs::ProgramTrackCmd*)b->data()->payload.data();
+                hwIf_->program_track(
+                    static_cast<ProgramTrackMode>(pt->mode_));
+                txFlow_->send_packet(Defs::get_program_track_resp_payload());
+                break;
+            }
+        }
+    }
+
+    TxInterface *txFlow_; ///< reference to the transmit flow
+    RxInterface *rxFlow_; ///< reference to the receive flow
+    ModemTrainHwInterface *hwIf_; ///< hardware specific interface
+};
+
+} // namespace traction_modem
+
+#endif // _TRACTION_MODEM_PROGRAMTRACK_HXX_

--- a/src/traction_modem/modem_test_helper.hxx
+++ b/src/traction_modem/modem_test_helper.hxx
@@ -52,6 +52,7 @@ class MockTrainHwInterface : public ModemTrainHwInterface
 public:
     MOCK_METHOD2(output_state, void(uint16_t, uint16_t));
     MOCK_METHOD1(output_restart, void(uint16_t));
+    MOCK_METHOD1(program_track, void(ProgramTrackMode));
     MOCK_METHOD4(memory_write, MemoryWriteError(
         uint8_t, uint32_t, Defs::Payload, size_t *));
     MOCK_METHOD4(memory_read, MemoryReadError(


### PR DESCRIPTION
Needed to shutdown modem when on the program track.

An alternative method has been proposed that holds the modem UART RX line low. This pull request will likely be closed without merging.