### PR TITLE
Fix handling of CAN frames with priority bit zero

### DIFF
--- a/src/openlcb/Bootloader.cxxtest
+++ b/src/openlcb/Bootloader.cxxtest
@@ -606,6 +606,19 @@ TEST_F(BootloaderTest, VerifyGlobal)
     exit_bootloader();
 }
 
+TEST_F(BootloaderTest, PriorityBitZeroBootloader)
+{
+    proper_startup();
+
+    // Verify Addressed with priority 0 (X09...) instead of normal priority 1 (X19...)
+    expect_packet(":X191704AAN1A2A3A4A5A6A;");
+    send_packet(":X09488321N04AA;");
+    wait();
+    Mock::VerifyAndClear(&canBus_);
+
+    exit_bootloader();
+}
+
 TEST_F(BootloaderTest, StartWriteAtOffsetZero)
 {
     print_all_packets();

--- a/src/openlcb/Bootloader.hxx
+++ b/src/openlcb/Bootloader.hxx
@@ -762,13 +762,7 @@ void handle_input_frame()
     }
     uint32_t can_id = GET_CAN_FRAME_ID_EFF(state_.input_frame);
     int dlc = state_.input_frame.can_dlc;
-    if (CanDefs::get_priority(can_id) != CanDefs::NORMAL_PRIORITY)
-    {
-        // Non-OpenLCB frame. Ignore.
-        state_.input_frame_full = 0;
-        return;
-    }
-    else if ((can_id & 0xfff) == state_.alias)
+    if ((can_id & 0xfff) == state_.alias)
     {
         // Alias conflict.
         if (CanDefs::is_cid_frame(can_id))
@@ -809,8 +803,8 @@ void handle_input_frame()
         state_.input_frame_full = 0;
         return;
     }
-    else if ((can_id >> 12) == (0x1A000 | state_.alias) ||
-        (can_id >> 12) == (0x1B000 | state_.alias))
+    else if (((can_id >> 12) & ~0x10000) == (0x0A000 | state_.alias) ||
+             ((can_id >> 12) & ~0x10000) == (0x0B000 | state_.alias))
     {
         // Datagram start frame.
 
@@ -831,8 +825,8 @@ void handle_input_frame()
         }
     }
 #ifdef BOOTLOADER_DATAGRAM
-    else if ((can_id >> 12) == (0x1C000 | state_.alias) ||
-        (can_id >> 12) == (0x1D000 | state_.alias))
+    else if (((can_id >> 12) & ~0x10000) == (0x0C000 | state_.alias) ||
+             ((can_id >> 12) & ~0x10000) == (0x0D000 | state_.alias))
     {
         if (!state_.incoming_datagram_pending ||
             CanDefs::get_src(can_id) != state_.write_src_alias)
@@ -863,12 +857,12 @@ void handle_input_frame()
     }
 #endif
 #ifdef BOOTLOADER_STREAM
-    else if ((can_id >> 12) == (0x1F000 | state_.alias) && dlc > 1)
+    else if (((can_id >> 12) & ~0x10000) == (0x0F000 | state_.alias) && dlc > 1)
     {
         return handle_stream_data();
     }
 #endif
-    else if ((can_id >> 24) == 0x19)
+    else if (((can_id >> 24) & ~0x10) == 0x09)
     {
         // global or addressed message
         Defs::MTI mti = (Defs::MTI)CanDefs::get_mti(can_id);

--- a/src/openlcb/DatagramCan.cxx
+++ b/src/openlcb/DatagramCan.cxx
@@ -134,11 +134,9 @@ public:
     enum
     {
         CAN_FILTER = CanMessageData::CAN_EXT_FRAME_FILTER |
-            (CanDefs::NMRANET_MSG << CanDefs::FRAME_TYPE_SHIFT) |
-            (CanDefs::NORMAL_PRIORITY << CanDefs::PRIORITY_SHIFT),
+            (CanDefs::NMRANET_MSG << CanDefs::FRAME_TYPE_SHIFT),
         CAN_MASK = CanMessageData::CAN_EXT_FRAME_MASK |
-            CanDefs::FRAME_TYPE_MASK | CanDefs::PRIORITY_MASK |
-            CanDefs::CAN_FRAME_TYPE_MASK,
+            CanDefs::FRAME_TYPE_MASK | CanDefs::CAN_FRAME_TYPE_MASK,
     };
 
     CanDatagramParser(IfCan *iface);

--- a/src/openlcb/DatagramCan.cxxtest
+++ b/src/openlcb/DatagramCan.cxxtest
@@ -87,6 +87,21 @@ TEST_F(AsyncRawDatagramTest, SingleFrameDatagramArrivesRightTarget)
     send_packet(":X1A22A555NFF01020304050607;");
 }
 
+TEST_F(AsyncRawDatagramTest, PriorityBitZeroDatagram)
+{
+    EXPECT_CALL(
+        handler_,
+        handle_message(
+            Pointee(AllOf(Field(&GenMessage::mti, Defs::MTI_DATAGRAM),
+                          Field(&GenMessage::dstNode, node_),
+                          Field(&GenMessage::payload,
+                                IsBufferValue(0xEE01020304050607ULL))
+                          )),
+            _));
+    // Priority 0 (X0A...) instead of normal priority 1 (X1A...)
+    send_packet(":X0A22A555NEE01020304050607;");
+}
+
 TEST_F(AsyncRawDatagramTest, MultiFrameDatagramArrivesRightTarget)
 {
     EXPECT_CALL(

--- a/src/openlcb/IfCan.cxx
+++ b/src/openlcb/IfCan.cxx
@@ -113,12 +113,6 @@ public:
     {
         uint32_t id = GET_CAN_FRAME_ID_EFF(*message()->data());
         release();
-        if (CanDefs::get_priority(id) != CanDefs::NORMAL_PRIORITY)
-        {
-            // Probably not an OpenLCB frame.
-            /// @TODO(balazs.racz) this is wrong. it IS an openlcb frame.
-            return exit();
-        }
         NodeAlias alias = CanDefs::get_src(id);
         // If the caller comes with alias 000, we ignore that.
         NodeID node = alias ? if_can()->local_aliases()->lookup(alias) : 0;
@@ -492,11 +486,9 @@ public:
     {
         CAN_FILTER = CanMessageData::CAN_EXT_FRAME_FILTER |
             (CanDefs::GLOBAL_ADDRESSED << CanDefs::CAN_FRAME_TYPE_SHIFT) |
-            (CanDefs::NMRANET_MSG << CanDefs::FRAME_TYPE_SHIFT) |
-            (CanDefs::NORMAL_PRIORITY << CanDefs::PRIORITY_SHIFT),
+            (CanDefs::NMRANET_MSG << CanDefs::FRAME_TYPE_SHIFT),
         CAN_MASK = CanMessageData::CAN_EXT_FRAME_MASK |
             CanDefs::CAN_FRAME_TYPE_MASK | CanDefs::FRAME_TYPE_MASK |
-            CanDefs::PRIORITY_MASK |
             (Defs::MTI_ADDRESS_MASK << CanDefs::MTI_SHIFT)
     };
 
@@ -571,11 +563,9 @@ public:
         CAN_FILTER = CanMessageData::CAN_EXT_FRAME_FILTER |
             (CanDefs::GLOBAL_ADDRESSED << CanDefs::CAN_FRAME_TYPE_SHIFT) |
             (CanDefs::NMRANET_MSG << CanDefs::FRAME_TYPE_SHIFT) |
-            (CanDefs::NORMAL_PRIORITY << CanDefs::PRIORITY_SHIFT) |
             (Defs::MTI_ADDRESS_MASK << CanDefs::MTI_SHIFT),
         CAN_MASK = CanMessageData::CAN_EXT_FRAME_MASK |
             CanDefs::CAN_FRAME_TYPE_MASK | CanDefs::FRAME_TYPE_MASK |
-            CanDefs::PRIORITY_MASK |
             (Defs::MTI_ADDRESS_MASK << CanDefs::MTI_SHIFT)
     };
 

--- a/src/openlcb/IfCan.cxxtest
+++ b/src/openlcb/IfCan.cxxtest
@@ -58,6 +58,20 @@ TEST_F(AsyncIfTest, InjectFrameAndExpectHandler)
     ifCan_->frame_dispatcher()->unregister_handler(&h, 0x195B4000, 0x1FFFF000);
 }
 
+// Per the OpenLCB standard, the priority bit (bit 28) should be "send as 1,
+// don't check on receipt." CAN frames with priority bit = 0 must still be
+// dispatched to the correct handler.
+TEST_F(AsyncIfTest, InjectFrameAndExpectHandlerPriorityBitZero)
+{
+    StrictMock<MockCanFrameHandler> h;
+    ifCan_->frame_dispatcher()->register_handler(&h, 0x195B4000, 0x0FFFF000);
+    // Priority bit cleared: 0x195B432D -> 0x095B432D
+    EXPECT_CALL(h, handle_message(IsExtCanFrameWithId(0x095B432D), _));
+    send_packet(":X095B432DN05010103;");
+    wait();
+    ifCan_->frame_dispatcher()->unregister_handler(&h, 0x195B4000, 0x0FFFF000);
+}
+
 TEST_F(AsyncIfTest, WriteFrame)
 {
     print_all_packets();
@@ -124,6 +138,20 @@ TEST_F(AsyncIfTest, RemoteAliasLearned)
     });
 }
 
+// AMD frame with priority bit cleared must still be learned.
+TEST_F(AsyncIfTest, RemoteAliasLearnedPriorityBitZero)
+{
+    // Priority bit cleared: 0x10701782 -> 0x00701782
+    send_packet(":X00701782N010203040506;");
+    wait();
+    RX({
+        EXPECT_EQ(
+            0x782U, ifCan_->remote_aliases()->lookup(UINT64_C(0x010203040506)));
+        EXPECT_EQ(UINT64_C(0x010203040506),
+            ifCan_->remote_aliases()->lookup(NodeAlias(0x782U)));
+    });
+}
+
 TEST_F(AsyncIfTest, AMEReceiveSupport)
 {
     // Example virtual node.
@@ -134,11 +162,18 @@ TEST_F(AsyncIfTest, AMEReceiveSupport)
     send_packet_and_expect_response(":X10702643N050101011877;",
                                     ":X10701729N050101011877;");
     wait();
+    send_packet_and_expect_response(":X00702643N050101011877;",
+                                    ":X10701729N050101011877;");
+    wait();
     send_packet(":X10702643N050101011878;");
     wait();
     expect_packet(":X1070122AN02010D000003;");
     expect_packet(":X10701729N050101011877;");
     send_packet(":X10702643N;");
+    wait();
+    expect_packet(":X1070122AN02010D000003;");
+    expect_packet(":X10701729N050101011877;");
+    send_packet(":X00702643N;");
     wait();
 }
 

--- a/src/openlcb/IfCan.cxxtest
+++ b/src/openlcb/IfCan.cxxtest
@@ -630,6 +630,32 @@ TEST_F(AsyncIfTest, PassGlobalMessageToIf)
     wait();
 }
 
+TEST_F(AsyncIfTest, PriorityBitZero)
+{
+    static const NodeAlias alias = 0x210U;
+    static const NodeID id = 0x050101FFFFDDULL;
+    StrictMock<MockMessageHandler> h;
+    EXPECT_CALL(
+        h,
+        handle_message(
+            Pointee(AllOf(
+                Field(&GenMessage::mti, Defs::MTI_EVENT_REPORT),
+                Field(&GenMessage::src, Field(&NodeHandle::alias, alias)),
+                Field(&GenMessage::src, Field(&NodeHandle::id, id)),
+                Field(&GenMessage::dst, NodeHandle({0, 0})),
+                Field(&GenMessage::dstNode, IsNull()),
+                Field(&GenMessage::payload,
+                      IsBufferValue(UINT64_C(0x0102030405060708))))),
+            _));
+    ifCan_->dispatcher()->register_handler(&h, 0x5B4, 0xffff);
+
+    RX(ifCan_->remote_aliases()->add(id, alias));
+
+    // Priority 0 (X09...) instead of normal priority 1 (X19...)
+    send_packet(":X095B4210N0102030405060708;");
+    wait();
+}
+
 TEST_F(AsyncIfTest, PassGlobalMessageToIfUnknownSource)
 {
     static const NodeAlias alias = 0x210U;
@@ -677,6 +703,34 @@ TEST_F(AsyncNodeTest, PassAddressedMessageToIf)
 
     // The "verify nodeid handler" will respond.
     send_packet_and_expect_response(":X19488210N022A;",
+                                    ":X1917022AN02010d000003;");
+    wait();
+}
+
+TEST_F(AsyncNodeTest, PassAddressedMessageToIfPriorityZero)
+{
+    print_all_packets();
+    static const NodeAlias alias = 0x210U;
+    static const NodeID id = 0x050101FFFFDDULL;
+    StrictMock<MockMessageHandler> h;
+    EXPECT_CALL(
+        h,
+        handle_message(
+            Pointee(AllOf(
+                Field(&GenMessage::mti, Defs::MTI_VERIFY_NODE_ID_ADDRESSED),
+                Field(&GenMessage::src, Field(&NodeHandle::alias, alias)),
+                Field(&GenMessage::src, Field(&NodeHandle::id, id)),
+                Field(&GenMessage::dst, Field(&NodeHandle::alias, 0x22A)),
+                Field(&GenMessage::dst,
+                      Field(&NodeHandle::id, TEST_NODE_ID)),
+                Field(&GenMessage::dstNode, node_))),
+            _));
+    ifCan_->dispatcher()->register_handler(&h, 0x488, 0xffff);
+
+    RX(ifCan_->remote_aliases()->add(id, alias));
+
+    // Priority 0 (X09...) instead of normal priority 1 (X19...)
+    send_packet_and_expect_response(":X09488210N022A;",
                                     ":X1917022AN02010d000003;");
     wait();
 }

--- a/src/openlcb/IfCanImpl.hxx
+++ b/src/openlcb/IfCanImpl.hxx
@@ -396,14 +396,14 @@ protected:
         enum
         {
             // AMD frames
-            CAN_FILTER1 = CanMessageData::CAN_EXT_FRAME_FILTER | 0x10701000,
-            CAN_MASK1 = CanMessageData::CAN_EXT_FRAME_MASK | 0x1FFFF000,
+            CAN_FILTER1 = CanMessageData::CAN_EXT_FRAME_FILTER | 0x00701000,
+            CAN_MASK1 = CanMessageData::CAN_EXT_FRAME_MASK | 0x0FFFF000,
             // Initialization complete
-            CAN_FILTER2 = CanMessageData::CAN_EXT_FRAME_FILTER | 0x19100000,
-            CAN_MASK2 = CanMessageData::CAN_EXT_FRAME_MASK | 0x1FFFF000,
+            CAN_FILTER2 = CanMessageData::CAN_EXT_FRAME_FILTER | 0x09100000,
+            CAN_MASK2 = CanMessageData::CAN_EXT_FRAME_MASK | 0x0FFFF000,
             // Verified node ID number
-            CAN_FILTER3 = CanMessageData::CAN_EXT_FRAME_FILTER | 0x19170000,
-            CAN_MASK3 = CanMessageData::CAN_EXT_FRAME_MASK | 0x1FFFF000,
+            CAN_FILTER3 = CanMessageData::CAN_EXT_FRAME_FILTER | 0x09170000,
+            CAN_MASK3 = CanMessageData::CAN_EXT_FRAME_MASK | 0x0FFFF000,
         };
 
         IfCan* if_can() { return parent_->if_can(); }


### PR DESCRIPTION
Fixes #715.

Updates CAN frame registration masks and various other checks for the topmost bit of the CAN identifier.

The standard says that this bit (the priority bit) should be "send as 1, ignore upon receipt". Previously the code was checking at receipt, which is incorrect.