### PR TITLE
Fixes compile errors from armgcc 15.

### DIFF
--- a/etc/freertos.armv6m.mk
+++ b/etc/freertos.armv6m.mk
@@ -57,7 +57,7 @@ CFLAGS += -c $(CORECFLAGS) -std=c99 -Wstrict-prototypes  \
 CXXFLAGS += -c $(CORECFLAGS) -std=c++14 -D_ISOC99_SOURCE \
             -D__USE_LIBSTDCPP__ -D__STDC_FORMAT_MACROS -D__LINEAR_MAP__ \
             -fno-exceptions -fno-rtti \
-            -Wsuggest-override -Wno-psabi \
+            -Wsuggest-override -Wno-psabi -Wno-overloaded-virtual \
             $(CXXFLAGSENV) $(CXXFLAGSEXTRA)
 
 LDFLAGS += -g -fdata-sections -ffunction-sections -T target.ld \

--- a/etc/freertos.armv7m.exc.mk
+++ b/etc/freertos.armv7m.exc.mk
@@ -58,6 +58,7 @@ CFLAGS += -c $(ARCHOPTIMIZATION) $(CORECFLAGS) -std=c99 \
 
 CXXFLAGS += -c $(ARCHOPTIMIZATION) $(CORECFLAGS) -std=c++14  \
             -D_ISOC99_SOURCE -D__STDC_FORMAT_MACROS \
+            -Wsuggest-override -Wno-psabi -Wno-overloaded-virtual \
             $(CXXFLAGSENV) $(CXXFLAGSEXTRA) \
             -fno-exceptions
 

--- a/etc/freertos.armv7m.mk
+++ b/etc/freertos.armv7m.mk
@@ -65,7 +65,7 @@ CFLAGS += $(COMPILEOPT) $(ARCHOPTIMIZATION) $(CORECFLAGS) -std=c99 \
 CXXFLAGS += $(COMPILEOPT) $(ARCHOPTIMIZATION) $(CORECFLAGS) -std=c++14  \
             -D_ISOC99_SOURCE -D__STDC_FORMAT_MACROS \
             -fno-exceptions -fno-rtti \
-            -Wsuggest-override -Wno-psabi \
+            -Wsuggest-override -Wno-psabi -Wno-overloaded-virtual \
             $(CXXFLAGSENV) $(CXXFLAGSEXTRA) \
 
 #            -Wsuggest-override \

--- a/src/freertos_drivers/common/PCA9685PWM.hxx
+++ b/src/freertos_drivers/common/PCA9685PWM.hxx
@@ -31,6 +31,7 @@
  * @date 6 January 2018
  */
 
+#include <array>
 #include <fcntl.h>
 #include <unistd.h>
 #include "stropts.h"
@@ -294,8 +295,8 @@ private:
             ctl.off.counts = (counts + (channel * 256)) % 0x1000;
         }
 
-        htole16(ctl.on.word);
-        htole16(ctl.off.word);
+        ctl.on.word = htole16(ctl.on.word);
+        ctl.off.word = htole16(ctl.off.word);
 
         Registers offset = (Registers)(LED0_ON_L + (channel * 4));
         register_write_multiple(offset, &ctl, sizeof(ctl));

--- a/src/utils/Debouncer.hxx
+++ b/src/utils/Debouncer.hxx
@@ -61,6 +61,8 @@
 #ifndef _UTILS_DEBOUNCER_HXX_
 #define _UTILS_DEBOUNCER_HXX_
 
+#include <cstdint>
+
 /** This debouncer will update state if for N consecutive attempts the input
  * value is the same. */
 class QuiesceDebouncer


### PR DESCRIPTION
- there were some missing includes.
- the Device infrastructure generates a new warning due to having both static ::open and virtual ::open functions on the same classes in the hierarchy. This warning needs to be disabled at this point.
- there was a legit bug discovered in PCA8685PWM that impacts only big endian processors.