### PR TITLE
Tune optimization flags on CDI macros.

### DIFF
--- a/src/openlcb/ConfigRepresentation.hxx
+++ b/src/openlcb/ConfigRepresentation.hxx
@@ -232,7 +232,7 @@ public:
         return entry(openlcb::EntryMarker<LINE>());                            \
     }                                                                          \
     static constexpr typename decltype(TYPE::config_renderer())::OptionsType   \
-        NAME##_options()                                                       \
+            __attribute__((always_inline)) NAME##_options()              \
     {                                                                          \
         using SelfType = TYPE;                                                 \
         using OptionsType =                                                    \

--- a/src/utils/macros.h
+++ b/src/utils/macros.h
@@ -204,7 +204,7 @@ extern const char* g_death_file;
 /// @param BASE_CLASS the name of the immediate base class
 #define INHERIT_CONSTEXPR_CONSTRUCTOR(CURRENT_CLASS, BASE_CLASS)               \
     template <typename... Args>                                                \
-    explicit constexpr CURRENT_CLASS(Args... args)                             \
+    explicit constexpr __attribute__((always_inline)) CURRENT_CLASS(Args... args) \
         : BASE_CLASS(args...)                                                  \
     {                                                                          \
     }


### PR DESCRIPTION
Marks certain constexpr constructors and functions as always-inline.

Armgcc that is newer than 2018 makes a strange optimization decision with our CDI macros; one of the helper classes gets instantiated in the codebase, which pulls in a ton of dependencies. The resulting code is much much bigger.

By marking these constexpr functions as always inline the code size of gcc 15 is competitive with that of gcc 8.