### PR TITLE
Add ARCHOPTIMIZATIONEXTRA hook to linux.armv7a target.

### DIFF
--- a/etc/linux.armv7a.mk
+++ b/etc/linux.armv7a.mk
@@ -27,7 +27,7 @@ HOST_TARGET := 1
 STARTGROUP := -Wl,--start-group
 ENDGROUP := -Wl,--end-group
 
-ARCHOPTIMIZATION = -g3 -O0 -march=armv7-a
+ARCHOPTIMIZATION = -g3 -O0 -march=armv7-a $(ARCHOPTIMIZATIONEXTRA)
 
 CSHAREDFLAGS = -c $(ARCHOPTIMIZATION) -Wall -Werror -Wno-unknown-pragmas \
                -MD -MP -fno-stack-protector -D_GNU_SOURCE


### PR DESCRIPTION
Some toolchains targeting armv7-a require an explicit FPU/ABI choice. Notably, gcc-arm-linux-gnueabihf (the default Ubuntu/Debian armhf cross-toolchain) defaults to -mfloat-abi=hard but a bare -march=armv7-a errors with "selected architecture lacks an FPU" because no FPU is specified.

Add an ARCHOPTIMIZATIONEXTRA hook in the same style as the existing CFLAGSEXTRA / CXXFLAGSEXTRA / SYSLIBRARIESEXTRA hooks so projects can extend ARCHOPTIMIZATION without modifying this file. Projects that need an FPU baseline set ARCHOPTIMIZATIONEXTRA in their per-target Makefile before including etc/prog.mk. E.g. ARCHOPTIMIZATIONEXTRA += -mfpu=vfpv3-d16 -mfloat-abi=hard