### PR TITLE
Fixes a logic error in the railcom broadcast decoder.

### DIFF
--- a/src/dcc/RailcomBroadcastDecoder.cxx
+++ b/src/dcc/RailcomBroadcastDecoder.cxx
@@ -55,8 +55,7 @@ bool RailcomBroadcastDecoder::process_packet(const dcc::Feedback &packet)
     }
     if (packet.ch1Size)
     {
-        return process_data(packet.ch1Data, packet.ch1Size) &&
-            (packet.ch2Size == 0);
+        return process_data(packet.ch1Data, packet.ch1Size);
     }
     else
     {


### PR DESCRIPTION
The return value was incorrect for packets that had both channel1 and channel2 data in the same cutout. These should be considered as valid channel1 packets.