### PR TITLE
Makes Factory reset perform factory reset on all eventID variables.

### DIFF
--- a/src/openlcb/ConfigUpdateFlow.cxx
+++ b/src/openlcb/ConfigUpdateFlow.cxx
@@ -69,7 +69,8 @@ void ConfigUpdateFlow::factory_reset()
 void ConfigUpdateFlow::register_update_listener(ConfigUpdateListener *listener)
 {
     AtomicHolder h(this);
-    pendingListeners_.push_front(listener);
+    pendingListeners_.insert(pendingLast_, listener);
+    ++pendingLast_;
     if (is_state(exit().next_state()))
     {
         start_flow(STATE(do_initial_load));
@@ -85,6 +86,10 @@ void ConfigUpdateFlow::unregister_update_listener(
         if (it.operator->() == listener)
         {
             listeners_.erase(it);
+            if (it == listeners_.end())
+            {
+                last_ = it;
+            }
             continue;
         }
         ++it;
@@ -94,6 +99,10 @@ void ConfigUpdateFlow::unregister_update_listener(
         if (it.operator->() == listener)
         {
             pendingListeners_.erase(it);
+            if (it == pendingListeners_.end())
+            {
+                pendingLast_ = it;
+            }
             continue;
         }
         ++it;

--- a/src/openlcb/ConfigUpdateFlow.cxxtest
+++ b/src/openlcb/ConfigUpdateFlow.cxxtest
@@ -176,50 +176,50 @@ TEST_F(ConfigUpdateFlowTest, InitializerListAndFIFOTest)
     BlockExecutor block(nullptr);
     new (&updateFlow_) ConfigUpdateFlow(ifCan_.get(), {&l1});
     updateFlow_.open_file("/dev/zero");
-    
+
     StrictMock<MockConfigListener> l3;
     updateFlow_.register_update_listener(&l2);
     updateFlow_.register_update_listener(&l3);
-    
+
     testing::InSequence seq;
     EXPECT_CALL(l1, apply_configuration(::testing::Gt(0), true, _))
         .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
-                        Return(ConfigUpdateListener::UPDATED)));
+            Return(ConfigUpdateListener::UPDATED)));
     EXPECT_CALL(l2, apply_configuration(::testing::Gt(0), true, _))
         .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
-                        Return(ConfigUpdateListener::UPDATED)));
+            Return(ConfigUpdateListener::UPDATED)));
     EXPECT_CALL(l3, apply_configuration(::testing::Gt(0), true, _))
         .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
-                        Return(ConfigUpdateListener::UPDATED)));
-                        
+            Return(ConfigUpdateListener::UPDATED)));
+
     updateFlow_.init_flow();
     block.release_block();
     wait_for_main_executor();
     Mock::VerifyAndClear(&l1);
     Mock::VerifyAndClear(&l2);
     Mock::VerifyAndClear(&l3);
-    
+
     EXPECT_CALL(l1, factory_reset(::testing::Gt(0)));
     EXPECT_CALL(l2, factory_reset(::testing::Gt(0)));
     EXPECT_CALL(l3, factory_reset(::testing::Gt(0)));
-    
+
     updateFlow_.factory_reset();
 }
 
 TEST_F(ConfigUpdateFlowTest, RegisterLaterFIFOTest)
 {
     updateFlow_.TEST_set_fd(23);
-    
+
     EXPECT_CALL(l1, apply_configuration(23, true, _))
         .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
-                        Return(ConfigUpdateListener::UPDATED)));
+            Return(ConfigUpdateListener::UPDATED)));
     updateFlow_.register_update_listener(&l1);
     wait_for_main_executor();
     Mock::VerifyAndClear(&l1);
 
     EXPECT_CALL(l2, apply_configuration(23, true, _))
         .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
-                        Return(ConfigUpdateListener::UPDATED)));
+            Return(ConfigUpdateListener::UPDATED)));
     updateFlow_.register_update_listener(&l2);
     wait_for_main_executor();
     Mock::VerifyAndClear(&l2);
@@ -227,7 +227,7 @@ TEST_F(ConfigUpdateFlowTest, RegisterLaterFIFOTest)
     testing::InSequence seq;
     EXPECT_CALL(l1, factory_reset(23));
     EXPECT_CALL(l2, factory_reset(23));
-    
+
     updateFlow_.factory_reset();
 }
 

--- a/src/openlcb/ConfigUpdateFlow.cxxtest
+++ b/src/openlcb/ConfigUpdateFlow.cxxtest
@@ -170,5 +170,66 @@ TEST_F(ConfigUpdateFlowTest, InitialLoad)
     wait_for_main_executor();
 }
 
+TEST_F(ConfigUpdateFlowTest, InitializerListAndFIFOTest)
+{
+    updateFlow_.~ConfigUpdateFlow();
+    BlockExecutor block(nullptr);
+    new (&updateFlow_) ConfigUpdateFlow(ifCan_.get(), {&l1});
+    updateFlow_.open_file("/dev/zero");
+    
+    StrictMock<MockConfigListener> l3;
+    updateFlow_.register_update_listener(&l2);
+    updateFlow_.register_update_listener(&l3);
+    
+    testing::InSequence seq;
+    EXPECT_CALL(l1, apply_configuration(::testing::Gt(0), true, _))
+        .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
+                        Return(ConfigUpdateListener::UPDATED)));
+    EXPECT_CALL(l2, apply_configuration(::testing::Gt(0), true, _))
+        .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
+                        Return(ConfigUpdateListener::UPDATED)));
+    EXPECT_CALL(l3, apply_configuration(::testing::Gt(0), true, _))
+        .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
+                        Return(ConfigUpdateListener::UPDATED)));
+                        
+    updateFlow_.init_flow();
+    block.release_block();
+    wait_for_main_executor();
+    Mock::VerifyAndClear(&l1);
+    Mock::VerifyAndClear(&l2);
+    Mock::VerifyAndClear(&l3);
+    
+    EXPECT_CALL(l1, factory_reset(::testing::Gt(0)));
+    EXPECT_CALL(l2, factory_reset(::testing::Gt(0)));
+    EXPECT_CALL(l3, factory_reset(::testing::Gt(0)));
+    
+    updateFlow_.factory_reset();
+}
+
+TEST_F(ConfigUpdateFlowTest, RegisterLaterFIFOTest)
+{
+    updateFlow_.TEST_set_fd(23);
+    
+    EXPECT_CALL(l1, apply_configuration(23, true, _))
+        .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
+                        Return(ConfigUpdateListener::UPDATED)));
+    updateFlow_.register_update_listener(&l1);
+    wait_for_main_executor();
+    Mock::VerifyAndClear(&l1);
+
+    EXPECT_CALL(l2, apply_configuration(23, true, _))
+        .WillOnce(DoAll(WithArg<2>(Invoke(&InvokeNotification)),
+                        Return(ConfigUpdateListener::UPDATED)));
+    updateFlow_.register_update_listener(&l2);
+    wait_for_main_executor();
+    Mock::VerifyAndClear(&l2);
+
+    testing::InSequence seq;
+    EXPECT_CALL(l1, factory_reset(23));
+    EXPECT_CALL(l2, factory_reset(23));
+    
+    updateFlow_.factory_reset();
+}
+
 } // namespace
 } // namespace openlcb

--- a/src/openlcb/ConfigUpdateFlow.hxx
+++ b/src/openlcb/ConfigUpdateFlow.hxx
@@ -37,11 +37,11 @@
 #ifndef _OPENLCB_CONFIGUPDATEFLOW_HXX_
 #define _OPENLCB_CONFIGUPDATEFLOW_HXX_
 
+#include "executor/StateFlow.hxx"
+#include "openlcb/NodeInitializeFlow.hxx"
 #include "openmrn_features.h"
 #include "utils/ConfigUpdateListener.hxx"
 #include "utils/ConfigUpdateService.hxx"
-#include "openlcb/NodeInitializeFlow.hxx"
-#include "executor/StateFlow.hxx"
 #include <initializer_list>
 
 #if OPENMRN_FEATURE_REBOOT
@@ -66,7 +66,8 @@ public:
     /// Constructor.
     /// @param iface OpenLCB interface this flow belongs to.
     /// @param initial_listeners listeners to register at initialization time.
-    ConfigUpdateFlow(If *iface, std::initializer_list<ConfigUpdateListener*> initial_listeners = {})
+    ConfigUpdateFlow(If *iface,
+        std::initializer_list<ConfigUpdateListener *> initial_listeners = {})
         : StateFlowBase(iface)
         , nextRefresh_(listeners_.begin())
         , last_(listeners_.begin())
@@ -233,7 +234,8 @@ private:
     typename queue_type::iterator nextRefresh_;
     /// Iterator pointing to the next pointer of the last element in listeners_.
     typename queue_type::iterator last_;
-    /// Iterator pointing to the next pointer of the last element in pendingListeners_.
+    /// Iterator pointing to the next pointer of the last element in
+    /// pendingListeners_.
     typename queue_type::iterator pendingLast_;
     /// did anybody request a reboot to happen?
     unsigned needsReboot_ : 1;

--- a/src/openlcb/ConfigUpdateFlow.hxx
+++ b/src/openlcb/ConfigUpdateFlow.hxx
@@ -42,6 +42,7 @@
 #include "utils/ConfigUpdateService.hxx"
 #include "openlcb/NodeInitializeFlow.hxx"
 #include "executor/StateFlow.hxx"
+#include <initializer_list>
 
 #if OPENMRN_FEATURE_REBOOT
 extern "C" {
@@ -62,13 +63,23 @@ class ConfigUpdateFlow : public StateFlowBase,
                          private Atomic
 {
 public:
-    ConfigUpdateFlow(If *iface)
+    /// Constructor.
+    /// @param iface OpenLCB interface this flow belongs to.
+    /// @param initial_listeners listeners to register at initialization time.
+    ConfigUpdateFlow(If *iface, std::initializer_list<ConfigUpdateListener*> initial_listeners = {})
         : StateFlowBase(iface)
         , nextRefresh_(listeners_.begin())
+        , last_(listeners_.begin())
+        , pendingLast_(pendingListeners_.begin())
         , needsReboot_(0)
         , needsReInit_(0)
         , fd_(-1)
     {
+        for (auto *l : initial_listeners)
+        {
+            pendingListeners_.insert(pendingLast_, l);
+            ++pendingLast_;
+        }
     }
 
     /// Must be called once (only) before calling anything else. Returns the
@@ -172,7 +183,11 @@ private:
             if (!pendingListeners_.empty())
             {
                 l = pendingListeners_.pop_front();
-                listeners_.push_front(l);
+                push_back(l);
+                if (pendingListeners_.empty())
+                {
+                    pendingLast_ = pendingListeners_.begin();
+                }
             }
         }
         if (!l)
@@ -200,6 +215,15 @@ private:
     }
 
     typedef TypedQueue<ConfigUpdateListener> queue_type;
+
+    /// Appends a listener to the back of the active listeners list.
+    /// @param l listener to append.
+    void push_back(ConfigUpdateListener *l)
+    {
+        listeners_.insert(last_, l);
+        ++last_;
+    }
+
     /// All registered update listeners. Protected by Atomic *this.
     queue_type listeners_;
     /// All listeners that have not yet been added to listeners_ and their
@@ -207,6 +231,10 @@ private:
     queue_type pendingListeners_;
     /// Where are we in the refresh cycle.
     typename queue_type::iterator nextRefresh_;
+    /// Iterator pointing to the next pointer of the last element in listeners_.
+    typename queue_type::iterator last_;
+    /// Iterator pointing to the next pointer of the last element in pendingListeners_.
+    typename queue_type::iterator pendingLast_;
     /// did anybody request a reboot to happen?
     unsigned needsReboot_ : 1;
     /// did anybody request a node reinit to happen?

--- a/src/openlcb/ConfigUpdateFlow.hxx
+++ b/src/openlcb/ConfigUpdateFlow.hxx
@@ -58,6 +58,12 @@ namespace openlcb
 /// to the registered ConfigUpdateListener descendants. This flow also handles
 /// any necessary action such as reboot or factory reset. This flow keeps the
 /// file descriptor for the config file that's currently open.
+///
+/// NOTE: This implementation guarantees that the registered listeners are
+/// invoked in the same order in which they were registered. Specifically, the
+/// initial_listeners coming in the constructor are always going to be at the
+/// beginning of the list of listeners to invoke. SimpleStack depends on this
+/// property.
 class ConfigUpdateFlow : public StateFlowBase,
                          public ConfigUpdateService,
                          private Atomic
@@ -232,10 +238,13 @@ private:
     queue_type pendingListeners_;
     /// Where are we in the refresh cycle.
     typename queue_type::iterator nextRefresh_;
-    /// Iterator pointing to the next pointer of the last element in listeners_.
+    /// Iterator pointing to the next pointer of the last element in
+    /// listeners_. This is used for FIFO semantics on the listeners_
+    /// structure.
     typename queue_type::iterator last_;
     /// Iterator pointing to the next pointer of the last element in
-    /// pendingListeners_.
+    /// pendingListeners_.  This is used for FIFO semantics on the
+    /// pendingListeners_ structure.
     typename queue_type::iterator pendingLast_;
     /// did anybody request a reboot to happen?
     unsigned needsReboot_ : 1;

--- a/src/openlcb/SimpleStack.cxx
+++ b/src/openlcb/SimpleStack.cxx
@@ -341,7 +341,7 @@ int SimpleStackBase::create_config_file_if_needed(const InternalConfigData &cfg,
     // though.
     HASSERT(SNIP_DYNAMIC_FILENAME == CONFIG_FILENAME);
     Uint8ConfigEntry(0).write(fd, 2);
-    factory_reset_all_events(cfg, node()->node_id(), fd);
+    factoryResetEventsHelper_.set_cfg(cfg);
     configUpdateFlow_.factory_reset();
     return fd;
 }
@@ -355,6 +355,8 @@ int SimpleStackBase::check_version_and_factory_reset(
     {
         fd = configUpdateFlow_.open_file(CONFIG_FILENAME);
     }
+
+    factoryResetEventsHelper_.set_cfg(cfg);
 
     if (cfg.version().read(fd) != expected_version)
     {
@@ -371,7 +373,6 @@ int SimpleStackBase::check_version_and_factory_reset(
     }
     if (force)
     {
-        factory_reset_all_events(cfg, node()->node_id(), fd);
         configUpdateFlow_.factory_reset();
         cfg.version().write(fd, expected_version);
     }

--- a/src/openlcb/SimpleStack.cxxtest
+++ b/src/openlcb/SimpleStack.cxxtest
@@ -4,13 +4,19 @@
 #include "openlcb/SimpleStack.hxx"
 #include "utils/async_if_test_helper.hxx"
 
-openlcb::MockSNIPUserFile snip_user_file(
-    "Default user name", "Default user description");
-const char *const openlcb::SNIP_DYNAMIC_FILENAME =
-    openlcb::MockSNIPUserFile::snip_user_file_path;
-
 namespace openlcb
 {
+MockSNIPUserFile snip_user_file(
+    "Default user name", "Default user description");
+const char *const SNIP_DYNAMIC_FILENAME =
+    MockSNIPUserFile::snip_user_file_path;
+
+const char *const CONFIG_FILENAME = SNIP_DYNAMIC_FILENAME;
+const size_t CONFIG_FILE_SIZE = 256;
+extern const uint16_t CDI_EVENT_OFFSETS[] = {
+    16, 24, 0
+};
+
 
 /// This class ensures that the g_init_flow object is not live while the tests
 /// are running. That's necessary because InitializeFlow is a singleton and the
@@ -95,5 +101,85 @@ TEST_F(SimpleTcpStackTest, create)
 {
 }
 
+class SimpleStackFactoryResetTest : public AsyncCanTest
+{
+protected:
+    SimpleStackFactoryResetTest()
+    {
+        unlink(openlcb::CONFIG_FILENAME);
+        int fd = ::open(openlcb::CONFIG_FILENAME, O_CREAT | O_TRUNC | O_RDWR, S_IRUSR | S_IWUSR);
+        HASSERT(fd >= 0);
+        uint8_t buf[256];
+        memset(buf, 0xFF, sizeof(buf));
+        HASSERT(write(fd, buf, sizeof(buf)) == sizeof(buf));
+        ::close(fd);
+    }
+
+    ~SimpleStackFactoryResetTest()
+    {
+        unlink(openlcb::CONFIG_FILENAME);
+    }
+
+    SimpleCanStack stack_ {TEST_NODE_ID};
+};
+
+class OrderVerifyingListener : public ConfigUpdateListener
+{
+public:
+    OrderVerifyingListener(int fd) : fd_(fd), called_(false) {}
+
+    UpdateAction apply_configuration(int fd, bool initial_load, BarrierNotifiable *done) override
+    {
+        done->notify();
+        return UPDATED;
+    }
+
+    void factory_reset(int fd) override
+    {
+        called_ = true;
+        uint64_t event1 = 0;
+        uint64_t event2 = 0;
+        
+        lseek(fd, 16, SEEK_SET);
+        HASSERT(read(fd, &event1, 8) == 8);
+        
+        lseek(fd, 24, SEEK_SET);
+        HASSERT(read(fd, &event2, 8) == 8);
+
+        event1 = __builtin_bswap64(event1);
+        event2 = __builtin_bswap64(event2);
+
+        EXPECT_NE(0xffffffffffffffffULL, event1);
+        EXPECT_NE(0xffffffffffffffffULL, event2);
+        
+        EXPECT_EQ(TEST_NODE_ID, event1 >> 16);
+        EXPECT_EQ(TEST_NODE_ID, event2 >> 16);
+
+        EXPECT_EQ(2U, event1 & 0xFFFF);
+        EXPECT_EQ(3U, event2 & 0xFFFF);
+    }
+
+    int fd_;
+    bool called_;
+};
+
+TEST_F(SimpleStackFactoryResetTest, FactoryResetOrderAndEventReset)
+{
+    InternalConfigData cfg(0);
+
+    int fd = stack_.check_version_and_factory_reset(cfg, 12, true);
+    ASSERT_GT(fd, 0);
+
+    EXPECT_EQ(2U, cfg.next_event().read(fd));
+
+    OrderVerifyingListener listener(fd);
+    stack_.config_service()->register_update_listener(&listener);
+
+    static_cast<ConfigUpdateFlow *>(stack_.config_service())->factory_reset();
+
+    EXPECT_TRUE(listener.called_);
+
+    EXPECT_EQ(4U, cfg.next_event().read(fd));
+}
 
 } // namespace openlcb

--- a/src/openlcb/SimpleStack.cxxtest
+++ b/src/openlcb/SimpleStack.cxxtest
@@ -8,15 +8,11 @@ namespace openlcb
 {
 MockSNIPUserFile snip_user_file(
     "Default user name", "Default user description");
-const char *const SNIP_DYNAMIC_FILENAME =
-    MockSNIPUserFile::snip_user_file_path;
+const char *const SNIP_DYNAMIC_FILENAME = MockSNIPUserFile::snip_user_file_path;
 
 const char *const CONFIG_FILENAME = SNIP_DYNAMIC_FILENAME;
 const size_t CONFIG_FILE_SIZE = 256;
-extern const uint16_t CDI_EVENT_OFFSETS[] = {
-    16, 24, 0
-};
-
+extern const uint16_t CDI_EVENT_OFFSETS[] = {16, 24, 0};
 
 /// This class ensures that the g_init_flow object is not live while the tests
 /// are running. That's necessary because InitializeFlow is a singleton and the
@@ -107,7 +103,8 @@ protected:
     SimpleStackFactoryResetTest()
     {
         unlink(openlcb::CONFIG_FILENAME);
-        int fd = ::open(openlcb::CONFIG_FILENAME, O_CREAT | O_TRUNC | O_RDWR, S_IRUSR | S_IWUSR);
+        int fd = ::open(openlcb::CONFIG_FILENAME, O_CREAT | O_TRUNC | O_RDWR,
+            S_IRUSR | S_IWUSR);
         HASSERT(fd >= 0);
         uint8_t buf[256];
         memset(buf, 0xFF, sizeof(buf));
@@ -126,9 +123,14 @@ protected:
 class OrderVerifyingListener : public ConfigUpdateListener
 {
 public:
-    OrderVerifyingListener(int fd) : fd_(fd), called_(false) {}
+    OrderVerifyingListener(int fd)
+        : fd_(fd)
+        , called_(false)
+    {
+    }
 
-    UpdateAction apply_configuration(int fd, bool initial_load, BarrierNotifiable *done) override
+    UpdateAction apply_configuration(
+        int fd, bool initial_load, BarrierNotifiable *done) override
     {
         done->notify();
         return UPDATED;
@@ -139,10 +141,10 @@ public:
         called_ = true;
         uint64_t event1 = 0;
         uint64_t event2 = 0;
-        
+
         lseek(fd, 16, SEEK_SET);
         HASSERT(read(fd, &event1, 8) == 8);
-        
+
         lseek(fd, 24, SEEK_SET);
         HASSERT(read(fd, &event2, 8) == 8);
 
@@ -151,7 +153,7 @@ public:
 
         EXPECT_NE(0xffffffffffffffffULL, event1);
         EXPECT_NE(0xffffffffffffffffULL, event2);
-        
+
         EXPECT_EQ(TEST_NODE_ID, event1 >> 16);
         EXPECT_EQ(TEST_NODE_ID, event2 >> 16);
 

--- a/src/openlcb/SimpleStack.hxx
+++ b/src/openlcb/SimpleStack.hxx
@@ -302,7 +302,8 @@ protected:
     /// The datagram service bound to the interface object. Owned by
     /// ifaceHolder_;
     DatagramService *datagramService_ {ifaceHolder_->datagram_service()};
-    /// Config update listener responsible for executing factory reset on all events.
+    /// Config update listener responsible for executing factory reset on all
+    /// events.
     struct FactoryResetEventsHelper : public ConfigUpdateListener
     {
         /// Constructor.
@@ -323,8 +324,8 @@ protected:
         }
 
         /// {@inheritdoc}
-        UpdateAction apply_configuration(int fd, bool initial_load,
-                                         BarrierNotifiable *done) override
+        UpdateAction apply_configuration(
+            int fd, bool initial_load, BarrierNotifiable *done) override
         {
             done->notify();
             return UPDATED;
@@ -335,7 +336,8 @@ protected:
         {
             if (hasCfg_)
             {
-                parent_->factory_reset_all_events(cfg_, parent_->node()->node_id(), fd);
+                parent_->factory_reset_all_events(
+                    cfg_, parent_->node()->node_id(), fd);
             }
         }
 
@@ -345,7 +347,7 @@ protected:
         InternalConfigData cfg_;
         /// True if configuration data has been set.
         bool hasCfg_;
-    } factoryResetEventsHelper_{this};
+    } factoryResetEventsHelper_ {this};
 
     /// Calls the config listeners with the configuration FD.
     ConfigUpdateFlow configUpdateFlow_ {iface(), {&factoryResetEventsHelper_}};

--- a/src/openlcb/SimpleStack.hxx
+++ b/src/openlcb/SimpleStack.hxx
@@ -303,7 +303,11 @@ protected:
     /// ifaceHolder_;
     DatagramService *datagramService_ {ifaceHolder_->datagram_service()};
     /// Config update listener responsible for executing factory reset on all
-    /// events.
+    /// events. It is important that this gets added to the config update
+    /// service at the first position so that any other configuration handler
+    /// would already see the updated event IDs. Some event listeners depend on
+    /// this to be able to override the automatically generated sequential
+    /// event IDs with well-known event IDs.
     struct FactoryResetEventsHelper : public ConfigUpdateListener
     {
         /// Constructor.
@@ -349,7 +353,11 @@ protected:
         bool hasCfg_;
     } factoryResetEventsHelper_ {this};
 
-    /// Calls the config listeners with the configuration FD.
+    /// Iplementation of the ConfigUpdateService, which is a singleton. Calls
+    /// the config listeners with the configuration FD to load the config,
+    /// perform update complete, and perform factory reset. The event factory
+    /// reset implementation is added here to guarantee it is the first entry
+    /// in the registered listeners list.
     ConfigUpdateFlow configUpdateFlow_ {iface(), {&factoryResetEventsHelper_}};
     /// The initialization flow takes care for node startup duties.
     InitializeFlow initFlow_ {&service_};

--- a/src/openlcb/SimpleStack.hxx
+++ b/src/openlcb/SimpleStack.hxx
@@ -302,8 +302,53 @@ protected:
     /// The datagram service bound to the interface object. Owned by
     /// ifaceHolder_;
     DatagramService *datagramService_ {ifaceHolder_->datagram_service()};
+    /// Config update listener responsible for executing factory reset on all events.
+    struct FactoryResetEventsHelper : public ConfigUpdateListener
+    {
+        /// Constructor.
+        /// @param parent pointer to parent stack base.
+        FactoryResetEventsHelper(SimpleStackBase *parent)
+            : parent_(parent)
+            , cfg_(0)
+            , hasCfg_(false)
+        {
+        }
+
+        /// Sets the internal configuration data.
+        /// @param cfg internal configuration data.
+        void set_cfg(InternalConfigData cfg)
+        {
+            cfg_ = cfg;
+            hasCfg_ = true;
+        }
+
+        /// {@inheritdoc}
+        UpdateAction apply_configuration(int fd, bool initial_load,
+                                         BarrierNotifiable *done) override
+        {
+            done->notify();
+            return UPDATED;
+        }
+
+        /// {@inheritdoc}
+        void factory_reset(int fd) override
+        {
+            if (hasCfg_)
+            {
+                parent_->factory_reset_all_events(cfg_, parent_->node()->node_id(), fd);
+            }
+        }
+
+        /// Pointer to the parent stack base.
+        SimpleStackBase *parent_;
+        /// Internal configuration data.
+        InternalConfigData cfg_;
+        /// True if configuration data has been set.
+        bool hasCfg_;
+    } factoryResetEventsHelper_{this};
+
     /// Calls the config listeners with the configuration FD.
-    ConfigUpdateFlow configUpdateFlow_ {iface()};
+    ConfigUpdateFlow configUpdateFlow_ {iface(), {&factoryResetEventsHelper_}};
     /// The initialization flow takes care for node startup duties.
     InitializeFlow initFlow_ {&service_};
     /// Dispatches event protocol requests to the event handlers.


### PR DESCRIPTION
- Adds a helper in the SimpleStack that calls factory_reset_all_events when factory_reset() is invoked by the config update flow.
- Changes the config update flow to be FIFO in its member addition mechanism. Since it's a single linked list, we have to keep a last_ pointer around for this purpose.
- Adds a constructor argument to configupdateflow that registers listeners.

These all together ensure that events gets factory reset first, then configured objects get their factory reset method called. This means that a configured object can override what any given event ID would be after factory reset.