### PR TITLE
Adds a helper function on dcc packet to generate a NOOP.

### DIFF
--- a/src/dcc/Packet.cxx
+++ b/src/dcc/Packet.cxx
@@ -78,6 +78,12 @@ void Packet::add_dcc_checksum()
     packet_header.skip_ec = 1;
 }
 
+void Packet::add_dcc_noop()
+{
+    payload[dlc++] = 0;
+    add_dcc_checksum();
+}
+
 void Packet::set_dcc_idle()
 {
     start_dcc_packet();
@@ -90,8 +96,7 @@ void Packet::set_dcc_idle()
 void Packet::set_dcc_noop()
 {
     add_dcc_address(DccLongAddress(10239));
-    payload[dlc++] = 0;
-    add_dcc_checksum();
+    add_dcc_noop();
 }
 
 void Packet::set_dcc_reset_all_decoders()

--- a/src/dcc/Packet.cxx
+++ b/src/dcc/Packet.cxx
@@ -87,6 +87,13 @@ void Packet::set_dcc_idle()
     packet_header.skip_ec = 1;
 }
 
+void Packet::set_dcc_noop()
+{
+    add_dcc_address(DccLongAddress(10239));
+    payload[dlc++] = 0;
+    add_dcc_checksum();
+}
+
 void Packet::set_dcc_reset_all_decoders()
 {
     start_dcc_packet();

--- a/src/dcc/Packet.cxxtest
+++ b/src/dcc/Packet.cxxtest
@@ -201,6 +201,14 @@ TEST_F(PacketTest, DccIdle)
     EXPECT_THAT(get_packet(), ElementsAre(0xff, 0, 0xff));
 }
 
+TEST_F(PacketTest, AddDccNoop)
+{
+    pkt_.add_dcc_address(DccShortAddress(55));
+    pkt_.add_dcc_noop();
+    EXPECT_THAT(get_packet(), ElementsAre(55, 0, 55));
+    EXPECT_TRUE(check_checksum());
+}
+
 TEST_F(PacketTest, DccNoop)
 {
     pkt_.set_dcc_noop();

--- a/src/dcc/Packet.cxxtest
+++ b/src/dcc/Packet.cxxtest
@@ -201,6 +201,13 @@ TEST_F(PacketTest, DccIdle)
     EXPECT_THAT(get_packet(), ElementsAre(0xff, 0, 0xff));
 }
 
+TEST_F(PacketTest, DccNoop)
+{
+    pkt_.set_dcc_noop();
+    EXPECT_THAT(get_packet(), ElementsAre(0xe7, 0xff, 0, 0x18));
+    EXPECT_TRUE(check_checksum());
+}
+
 TEST_F(PacketTest, DccReset)
 {
     pkt_.set_dcc_reset_all_decoders();

--- a/src/dcc/Packet.hxx
+++ b/src/dcc/Packet.hxx
@@ -346,6 +346,9 @@ struct Packet : public DCCPacket
     /** Creates a DCC idle packet. (Includes the checksum.) */
     void set_dcc_idle();
 
+    /** Creates a DCC address-10239 NOOP packet. (Includes the checksum.) */
+    void set_dcc_noop();
+
     /** Creates a DCC reset-all-decoders packet. (Includes the checksum.) */
     void set_dcc_reset_all_decoders();
 

--- a/src/dcc/Packet.hxx
+++ b/src/dcc/Packet.hxx
@@ -343,6 +343,10 @@ struct Packet : public DCCPacket
      * for DCC. */
     void add_dcc_checksum();
 
+    /** Adds a DCC NOP command to the packet. This should be called after
+     * add_dcc_address. (Includes the checksum.) */
+    void add_dcc_noop();
+
     /** Creates a DCC idle packet. (Includes the checksum.) */
     void set_dcc_idle();
 


### PR DESCRIPTION
A NOOP is a long-address=10239 NOP packet: 0xE7 0xFF 0x00 XOR. This falls into the mobile decoder address range.