### PR TITLE
utils: Add StringPool data structure for dynamic C-string storage

### DIFF
--- a/src/openlcb/RailcomBroadcastClient.cxx
+++ b/src/openlcb/RailcomBroadcastClient.cxx
@@ -65,6 +65,12 @@ bool RailcomBroadcastClient::is_our_event(uint64_t event_id) const
     return (event_id & ~0xFFFFULL) == railcomEventBase_;
 }
 
+void RailcomBroadcastClient::query()
+{
+    openlcb::send_message(node_, openlcb::Defs::MTI_PRODUCER_IDENTIFY,
+        openlcb::eventid_to_buffer(railcomEventBase_));
+}
+
 RailcomBroadcastClient::LocoInfo RailcomBroadcastClient::parse_event(
     uint64_t event)
 {

--- a/src/openlcb/RailcomBroadcastClient.cxxtest
+++ b/src/openlcb/RailcomBroadcastClient.cxxtest
@@ -105,6 +105,15 @@ TEST_F(RailcomBroadcastClientTest, CreateDestroy)
     EXPECT_TRUE(client_->current_locos().empty());
 }
 
+TEST_F(RailcomBroadcastClientTest, Query)
+{
+    EXPECT_TRUE(client_->current_locos().empty());
+    clear_expect(true);
+    expect_packet(make_outgoing_event_packet(
+        Defs::MTI_PRODUCER_IDENTIFY, base_ | 0x0000ULL));
+    client_->query();
+}
+
 TEST_F(RailcomBroadcastClientTest, AddLoco)
 {
     uint64_t event = entry_event(3);

--- a/src/openlcb/RailcomBroadcastClient.hxx
+++ b/src/openlcb/RailcomBroadcastClient.hxx
@@ -132,6 +132,10 @@ public:
         return railcomEventBase_;
     }
 
+    /// Sends out a query to the bus. This does synchronous allocation of the
+    /// message, but does not wait for the query to get any replies.
+    void query();
+    
     void handle_event_report(const EventRegistryEntry &registry_entry,
         EventReport *event, BarrierNotifiable *done) override;
 

--- a/src/utils/StringPool.cxx
+++ b/src/utils/StringPool.cxx
@@ -34,8 +34,8 @@
 
 #include "utils/StringPool.hxx"
 
-#include <cstring>
 #include <algorithm>
+#include <cstring>
 
 constexpr size_t StringPool::BLOCK_SIZE;
 constexpr size_t StringPool::MAX_BLOCKS;
@@ -50,38 +50,46 @@ StringPool::StringPool()
     blocks_.reserve(MAX_BLOCKS);
 }
 
-StringPool::~StringPool() {
-    for (char* block : blocks_) {
+StringPool::~StringPool()
+{
+    for (char *block : blocks_)
+    {
         delete[] block;
     }
 }
 
-StringPool::key_t StringPool::alloc(const char* value) {
-    if (!value || value[0] == '\0') {
+StringPool::key_t StringPool::alloc(const char *value)
+{
+    if (!value || value[0] == '\0')
+    {
         return EMPTY_KEY;
     }
 
     size_t len = strlen(value) + 1; // Include null terminator
-    if (len > MAX_STRING_LEN) {
+    if (len > MAX_STRING_LEN)
+    {
         return INVALID_KEY;
     }
 
     // Try to find a hole in existing blocks.
     key_t hole_key = find_hole(len);
-    if (hole_key != INVALID_KEY) {
+    if (hole_key != INVALID_KEY)
+    {
         // Found a hole. Use it.
         uint16_t block_idx = block_idx_from_key(hole_key);
         uint16_t offset = block_offset_from_key(hole_key);
-        char* ptr = blocks_[block_idx] + offset;
+        char *ptr = blocks_[block_idx] + offset;
         memcpy(ptr, value, len);
         return hole_key;
     }
 
     // Try to append to the current block if we have blocks and space
-    if (!blocks_.empty()) {
-        if (currentBlockOffset_ + len <= BLOCK_SIZE) {
+    if (!blocks_.empty())
+    {
+        if (currentBlockOffset_ + len <= BLOCK_SIZE)
+        {
             // Fits in current block at current offset
-            char* ptr = blocks_[currentBlockIdx_] + currentBlockOffset_;
+            char *ptr = blocks_[currentBlockIdx_] + currentBlockOffset_;
             memcpy(ptr, value, len);
             key_t key = compute_key(currentBlockIdx_, currentBlockOffset_);
             currentBlockOffset_ += len;
@@ -90,103 +98,125 @@ StringPool::key_t StringPool::alloc(const char* value) {
     }
 
     // No hole found and didn't fit in current block. Need a new block.
-    if (blocks_.size() >= MAX_BLOCKS) {
+    if (blocks_.size() >= MAX_BLOCKS)
+    {
         return INVALID_KEY;
     }
 
     // Allocate new block
-    char* new_block = new char[BLOCK_SIZE];
+    char *new_block = new char[BLOCK_SIZE];
     memset(new_block, 0, BLOCK_SIZE); // Zero initialize for invariant
     blocks_.push_back(new_block);
-    
+
     currentBlockIdx_ = blocks_.size() - 1;
     currentBlockOffset_ = 0;
 
-    // We know it fits because len <= MAX_STRING_LEN (127) and BLOCK_SIZE is 1024.
+    // We know it fits because len <= MAX_STRING_LEN (127) and BLOCK_SIZE is
+    // 1024.
     memcpy(new_block, value, len);
     key_t key = compute_key(currentBlockIdx_, currentBlockOffset_);
     currentBlockOffset_ += len;
-    
+
     return key;
 }
 
-void StringPool::free(key_t key) {
-    if (key == INVALID_KEY || key == EMPTY_KEY) {
+void StringPool::free(key_t key)
+{
+    if (key == INVALID_KEY || key == EMPTY_KEY)
+    {
         return;
     }
 
     uint16_t block_idx = block_idx_from_key(key);
     uint16_t offset = block_offset_from_key(key);
 
-    if (block_idx >= blocks_.size()) {
+    if (block_idx >= blocks_.size())
+    {
         return; // Out of bounds
     }
 
-    char* ptr = blocks_[block_idx] + offset;
+    char *ptr = blocks_[block_idx] + offset;
     // Determine length from storage
     size_t len = strlen(ptr);
-    if (len == 0) {
+    if (len == 0)
+    {
         // Already free or empty?
         return;
     }
-    
+
     // Zero out the string (invariant: consecutive zeros are free space)
     // We must zero out len + 1 bytes (the string + null terminator)
     memset(ptr, 0, len + 1);
 }
 
-const char* StringPool::lookup(key_t key) const {
-    if (key == EMPTY_KEY) {
+const char *StringPool::lookup(key_t key) const
+{
+    if (key == EMPTY_KEY)
+    {
         return "";
     }
-    if (key == INVALID_KEY) {
+    if (key == INVALID_KEY)
+    {
         return nullptr;
     }
 
     uint16_t block_idx = block_idx_from_key(key);
     uint16_t offset = block_offset_from_key(key);
 
-    if (block_idx >= blocks_.size()) {
+    if (block_idx >= blocks_.size())
+    {
         return nullptr;
     }
-    
+
     return blocks_[block_idx] + offset;
 }
 
-StringPool::key_t StringPool::find_hole(size_t size) {
+StringPool::key_t StringPool::find_hole(size_t size)
+{
     // Iterate through all blocks
-    for (size_t b = 0; b < blocks_.size(); ++b) {
-        char* block = blocks_[b];
+    for (size_t b = 0; b < blocks_.size(); ++b)
+    {
+        char *block = blocks_[b];
         size_t search_limit = BLOCK_SIZE;
-        
-        if (b == currentBlockIdx_) {
+
+        if (b == currentBlockIdx_)
+        {
             search_limit = currentBlockOffset_;
         }
-        
+
         size_t i = 0;
-        while (i < search_limit) {
-            if (block[i] == '\0') {
+        while (i < search_limit)
+        {
+            if (block[i] == '\0')
+            {
                 // Potential hole
                 size_t free_len = 0;
                 size_t start = i;
-                
+
                 // Count consecutive zeros
-                while (i < search_limit && block[i] == '\0') {
+                while (i < search_limit && block[i] == '\0')
+                {
                     free_len++;
                     i++;
-                    
-                    if (free_len >= size) {
+
+                    if (free_len >= size)
+                    {
                         return compute_key(b, start);
                     }
                 }
-            } else {
+            }
+            else
+            {
                 // Found a non-zero byte (part of a string)
-                while (i < search_limit && block[i] != '\0') {
+                while (i < search_limit && block[i] != '\0')
+                {
                     i++;
                 }
-                // Skip the null terminator too if we haven't reached search_limit
-                if (i < search_limit && block[i] == '\0') {
-                    i++; 
+                // Skip the null terminator too if we haven't reached
+                // search_limit
+                if (i < search_limit && block[i] == '\0')
+                {
+                    i++;
                 }
             }
         }

--- a/src/utils/StringPool.cxx
+++ b/src/utils/StringPool.cxx
@@ -71,18 +71,6 @@ StringPool::key_t StringPool::alloc(const char *value)
         return INVALID_KEY;
     }
 
-    // Try to find a hole in existing blocks.
-    key_t hole_key = find_hole(len);
-    if (hole_key != INVALID_KEY)
-    {
-        // Found a hole. Use it.
-        uint16_t block_idx = block_idx_from_key(hole_key);
-        uint16_t offset = block_offset_from_key(hole_key);
-        char *ptr = blocks_[block_idx] + offset;
-        memcpy(ptr, value, len);
-        return hole_key;
-    }
-
     // Try to append to the current block if we have blocks and space
     if (!blocks_.empty())
     {
@@ -95,6 +83,19 @@ StringPool::key_t StringPool::alloc(const char *value)
             currentBlockOffset_ += len;
             return key;
         }
+    }
+
+    // Did not fit at the end of the current block (or no blocks yet).
+    // Try to find a hole in existing blocks.
+    key_t hole_key = find_hole(len);
+    if (hole_key != INVALID_KEY)
+    {
+        // Found a hole. Use it.
+        uint16_t block_idx = block_idx_from_key(hole_key);
+        uint16_t offset = block_offset_from_key(hole_key);
+        char *ptr = blocks_[block_idx] + offset;
+        memcpy(ptr, value, len);
+        return hole_key;
     }
 
     // No hole found and didn't fit in current block. Need a new block.

--- a/src/utils/StringPool.cxx
+++ b/src/utils/StringPool.cxx
@@ -66,32 +66,30 @@ StringPool::key_t StringPool::alloc(const char* value) {
         return INVALID_KEY;
     }
 
+    // Try to find a hole in existing blocks.
+    key_t hole_key = find_hole(len);
+    if (hole_key != INVALID_KEY) {
+        // Found a hole. Use it.
+        uint16_t block_idx = block_idx_from_key(hole_key);
+        uint16_t offset = block_offset_from_key(hole_key);
+        char* ptr = blocks_[block_idx] + offset;
+        memcpy(ptr, value, len);
+        return hole_key;
+    }
+
     // Try to append to the current block if we have blocks and space
     if (!blocks_.empty()) {
         if (currentBlockOffset_ + len <= BLOCK_SIZE) {
             // Fits in current block at current offset
             char* ptr = blocks_[currentBlockIdx_] + currentBlockOffset_;
             memcpy(ptr, value, len);
-            
-            key_t key = (static_cast<key_t>(currentBlockIdx_) << 10) | currentBlockOffset_;
+            key_t key = compute_key(currentBlockIdx_, currentBlockOffset_);
             currentBlockOffset_ += len;
             return key;
         }
     }
 
-    // Did not fit at the end of the current block (or no blocks yet).
-    // Try to find a hole in existing blocks.
-    key_t hole_key = find_hole(len);
-    if (hole_key != INVALID_KEY) {
-        // Found a hole. Use it.
-        uint16_t block_idx = hole_key >> 10;
-        uint16_t offset = hole_key & 0x03FF;
-        char* ptr = blocks_[block_idx] + offset;
-        memcpy(ptr, value, len);
-        return hole_key;
-    }
-
-    // No hole found. Need a new block.
+    // No hole found and didn't fit in current block. Need a new block.
     if (blocks_.size() >= MAX_BLOCKS) {
         return INVALID_KEY;
     }
@@ -106,8 +104,7 @@ StringPool::key_t StringPool::alloc(const char* value) {
 
     // We know it fits because len <= MAX_STRING_LEN (127) and BLOCK_SIZE is 1024.
     memcpy(new_block, value, len);
-    
-    key_t key = (static_cast<key_t>(currentBlockIdx_) << 10) | currentBlockOffset_;
+    key_t key = compute_key(currentBlockIdx_, currentBlockOffset_);
     currentBlockOffset_ += len;
     
     return key;
@@ -118,8 +115,8 @@ void StringPool::free(key_t key) {
         return;
     }
 
-    uint16_t block_idx = key >> 10;
-    uint16_t offset = key & 0x03FF;
+    uint16_t block_idx = block_idx_from_key(key);
+    uint16_t offset = block_offset_from_key(key);
 
     if (block_idx >= blocks_.size()) {
         return; // Out of bounds
@@ -146,8 +143,8 @@ const char* StringPool::lookup(key_t key) const {
         return nullptr;
     }
 
-    uint16_t block_idx = key >> 10;
-    uint16_t offset = key & 0x03FF;
+    uint16_t block_idx = block_idx_from_key(key);
+    uint16_t offset = block_offset_from_key(key);
 
     if (block_idx >= blocks_.size()) {
         return nullptr;
@@ -179,7 +176,7 @@ StringPool::key_t StringPool::find_hole(size_t size) {
                     i++;
                     
                     if (free_len >= size) {
-                        return (static_cast<key_t>(b) << 10) | start;
+                        return compute_key(b, start);
                     }
                 }
             } else {
@@ -187,8 +184,10 @@ StringPool::key_t StringPool::find_hole(size_t size) {
                 while (i < search_limit && block[i] != '\0') {
                     i++;
                 }
-                // Skip the null terminator too
-                i++; 
+                // Skip the null terminator too if we haven't reached search_limit
+                if (i < search_limit && block[i] == '\0') {
+                    i++; 
+                }
             }
         }
     }

--- a/src/utils/StringPool.cxx
+++ b/src/utils/StringPool.cxx
@@ -1,0 +1,196 @@
+/** @copyright
+ * Copyright (c) 2024, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file StringPool.cxx
+ *
+ * Implementation of StringPool.
+ *
+ * @author Balazs Racz
+ * @date 2026-01-11
+ */
+
+#include "utils/StringPool.hxx"
+
+#include <cstring>
+#include <algorithm>
+
+constexpr size_t StringPool::BLOCK_SIZE;
+constexpr size_t StringPool::MAX_BLOCKS;
+constexpr StringPool::key_t StringPool::INVALID_KEY;
+constexpr StringPool::key_t StringPool::EMPTY_KEY;
+constexpr size_t StringPool::MAX_STRING_LEN;
+
+StringPool::StringPool()
+    : currentBlockIdx_(0)
+    , currentBlockOffset_(BLOCK_SIZE) // Force alloc first block
+{
+    blocks_.reserve(MAX_BLOCKS);
+}
+
+StringPool::~StringPool() {
+    for (char* block : blocks_) {
+        delete[] block;
+    }
+}
+
+StringPool::key_t StringPool::alloc(const char* value) {
+    if (!value || value[0] == '\0') {
+        return EMPTY_KEY;
+    }
+
+    size_t len = strlen(value) + 1; // Include null terminator
+    if (len > MAX_STRING_LEN) {
+        return INVALID_KEY;
+    }
+
+    // Try to append to the current block if we have blocks and space
+    if (!blocks_.empty()) {
+        if (currentBlockOffset_ + len <= BLOCK_SIZE) {
+            // Fits in current block at current offset
+            char* ptr = blocks_[currentBlockIdx_] + currentBlockOffset_;
+            memcpy(ptr, value, len);
+            
+            key_t key = (static_cast<key_t>(currentBlockIdx_) << 10) | currentBlockOffset_;
+            currentBlockOffset_ += len;
+            return key;
+        }
+    }
+
+    // Did not fit at the end of the current block (or no blocks yet).
+    // Try to find a hole in existing blocks.
+    key_t hole_key = find_hole(len);
+    if (hole_key != INVALID_KEY) {
+        // Found a hole. Use it.
+        uint16_t block_idx = hole_key >> 10;
+        uint16_t offset = hole_key & 0x03FF;
+        char* ptr = blocks_[block_idx] + offset;
+        memcpy(ptr, value, len);
+        return hole_key;
+    }
+
+    // No hole found. Need a new block.
+    if (blocks_.size() >= MAX_BLOCKS) {
+        return INVALID_KEY;
+    }
+
+    // Allocate new block
+    char* new_block = new char[BLOCK_SIZE];
+    memset(new_block, 0, BLOCK_SIZE); // Zero initialize for invariant
+    blocks_.push_back(new_block);
+    
+    currentBlockIdx_ = blocks_.size() - 1;
+    currentBlockOffset_ = 0;
+
+    // We know it fits because len <= MAX_STRING_LEN (127) and BLOCK_SIZE is 1024.
+    memcpy(new_block, value, len);
+    
+    key_t key = (static_cast<key_t>(currentBlockIdx_) << 10) | currentBlockOffset_;
+    currentBlockOffset_ += len;
+    
+    return key;
+}
+
+void StringPool::free(key_t key) {
+    if (key == INVALID_KEY || key == EMPTY_KEY) {
+        return;
+    }
+
+    uint16_t block_idx = key >> 10;
+    uint16_t offset = key & 0x03FF;
+
+    if (block_idx >= blocks_.size()) {
+        return; // Out of bounds
+    }
+
+    char* ptr = blocks_[block_idx] + offset;
+    // Determine length from storage
+    size_t len = strlen(ptr);
+    if (len == 0) {
+        // Already free or empty?
+        return;
+    }
+    
+    // Zero out the string (invariant: consecutive zeros are free space)
+    // We must zero out len + 1 bytes (the string + null terminator)
+    memset(ptr, 0, len + 1);
+}
+
+const char* StringPool::lookup(key_t key) const {
+    if (key == EMPTY_KEY) {
+        return "";
+    }
+    if (key == INVALID_KEY) {
+        return nullptr;
+    }
+
+    uint16_t block_idx = key >> 10;
+    uint16_t offset = key & 0x03FF;
+
+    if (block_idx >= blocks_.size()) {
+        return nullptr;
+    }
+    
+    return blocks_[block_idx] + offset;
+}
+
+StringPool::key_t StringPool::find_hole(size_t size) {
+    // Iterate through all blocks
+    for (size_t b = 0; b < blocks_.size(); ++b) {
+        char* block = blocks_[b];
+        size_t search_limit = BLOCK_SIZE;
+        
+        if (b == currentBlockIdx_) {
+            search_limit = currentBlockOffset_;
+        }
+        
+        size_t i = 0;
+        while (i < search_limit) {
+            if (block[i] == '\0') {
+                // Potential hole
+                size_t free_len = 0;
+                size_t start = i;
+                
+                // Count consecutive zeros
+                while (i < search_limit && block[i] == '\0') {
+                    free_len++;
+                    i++;
+                    
+                    if (free_len >= size) {
+                        return (static_cast<key_t>(b) << 10) | start;
+                    }
+                }
+            } else {
+                // Found a non-zero byte (part of a string)
+                while (i < search_limit && block[i] != '\0') {
+                    i++;
+                }
+                // Skip the null terminator too
+                i++; 
+            }
+        }
+    }
+    return INVALID_KEY;
+}

--- a/src/utils/StringPool.cxxtest
+++ b/src/utils/StringPool.cxxtest
@@ -35,204 +35,227 @@
 #include "utils/StringPool.hxx"
 #include "utils/test_main.hxx"
 
-#include <string>
 #include <map>
-#include <vector>
 #include <random>
+#include <string>
+#include <vector>
 
-class StringPoolTest : public ::testing::Test {
+class StringPoolTest : public ::testing::Test
+{
 protected:
     StringPool pool_;
 };
 
-TEST_F(StringPoolTest, alloc_lookup_basic) {
+TEST_F(StringPoolTest, alloc_lookup_basic)
+{
     auto k1 = pool_.alloc("Hello");
     auto k2 = pool_.alloc("World");
-    
+
     EXPECT_NE(k1, StringPool::INVALID_KEY);
     EXPECT_NE(k2, StringPool::INVALID_KEY);
     EXPECT_NE(k1, k2);
-    
+
     EXPECT_STREQ("Hello", pool_.lookup(k1));
     EXPECT_STREQ("World", pool_.lookup(k2));
 }
 
-TEST_F(StringPoolTest, alloc_empty) {
+TEST_F(StringPoolTest, alloc_empty)
+{
     auto k = pool_.alloc("");
     EXPECT_EQ(StringPool::EMPTY_KEY, k);
     EXPECT_STREQ("", pool_.lookup(k));
-    
+
     auto k2 = pool_.alloc(nullptr);
     EXPECT_EQ(StringPool::EMPTY_KEY, k2);
     EXPECT_STREQ("", pool_.lookup(k2));
 }
 
-TEST_F(StringPoolTest, invalid_key) {
+TEST_F(StringPoolTest, invalid_key)
+{
     EXPECT_EQ(nullptr, pool_.lookup(StringPool::INVALID_KEY));
 }
 
-TEST_F(StringPoolTest, max_len) {
+TEST_F(StringPoolTest, max_len)
+{
     std::string s126(126, 'a');
     auto k1 = pool_.alloc(s126.c_str());
     EXPECT_NE(StringPool::INVALID_KEY, k1);
     EXPECT_STREQ(s126.c_str(), pool_.lookup(k1));
-    
+
     std::string s127(127, 'a'); // 128 bytes with null
     auto k2 = pool_.alloc(s127.c_str());
     EXPECT_EQ(StringPool::INVALID_KEY, k2);
 }
 
-TEST_F(StringPoolTest, boundary_crossing) {
+TEST_F(StringPoolTest, boundary_crossing)
+{
     // Fill first block almost to the end
     // Block size 1024.
     // 1022 bytes. 2 bytes left.
     // Alloc 1022 bytes is too large (max 127).
-    
+
     // We need to fill it using multiple strings.
     // 1024 / 127 = ~8.
-    
+
     // Fill up to 1022.
     // Let's use 10-byte strings (11 with null).
     // 1024 % 11 = 1. So 93 strings. 93 * 11 = 1023.
     // Wait, 1024 % 11: 1024 = 93 * 11 + 1.
     // So if we alloc 93 strings of len 10, we occupy 1023 bytes. 1 byte left.
-    
+
     // Let's target exactly 1022 bytes used.
     // 1022 / 2 = 511. String "A" is 2 bytes.
     // Alloc 511 "A"s.
-    for (int i = 0; i < 511; ++i) {
+    for (int i = 0; i < 511; ++i)
+    {
         pool_.alloc("A");
     }
     // Used: 511 * 2 = 1022.
     // Remaining in block 0: 2 bytes (offsets 1022, 1023).
-    
+
     // Alloc "B" (2 bytes). Should fit.
     auto k1 = pool_.alloc("B");
-    EXPECT_EQ(0, k1 >> 10); // Still block 0
+    EXPECT_EQ(0, k1 >> 10);       // Still block 0
     EXPECT_EQ(1022, k1 & 0x03FF); // Offset 1022
-    
+
     // Now block 0 is full (1024 bytes).
     // Alloc "C" (2 bytes). Should go to block 1.
     auto k2 = pool_.alloc("C");
-    EXPECT_EQ(1, k2 >> 10); // Block 1
+    EXPECT_EQ(1, k2 >> 10);    // Block 1
     EXPECT_EQ(0, k2 & 0x03FF); // Offset 0
-    
+
     // Verify content
     EXPECT_STREQ("B", pool_.lookup(k1));
     EXPECT_STREQ("C", pool_.lookup(k2));
 }
 
-TEST_F(StringPoolTest, reuse_hole) {
+TEST_F(StringPoolTest, reuse_hole)
+{
     // Alloc A, B, C.
     auto ka = pool_.alloc("AAAA"); // 5 bytes
     auto kb = pool_.alloc("BBBB"); // 5 bytes
     auto kc = pool_.alloc("CCCC"); // 5 bytes
-    
+
     // Offsets: 0, 5, 10.
     EXPECT_EQ(5, kb & 0x03FF);
-    
+
     // Free B.
     pool_.free(kb);
-    
+
     // Alloc D (fits in B's spot).
     auto kd = pool_.alloc("DDDD"); // 5 bytes
-    EXPECT_EQ(kb, kd); // Should reuse the same spot
-    
+    EXPECT_EQ(kb, kd);             // Should reuse the same spot
+
     EXPECT_STREQ("AAAA", pool_.lookup(ka));
     EXPECT_STREQ("DDDD", pool_.lookup(kd));
     EXPECT_STREQ("CCCC", pool_.lookup(kc));
 }
 
-TEST_F(StringPoolTest, reuse_hole_too_small) {
+TEST_F(StringPoolTest, reuse_hole_too_small)
+{
     // Alloc A, B, C.
     auto ka = pool_.alloc("AAAA"); // 5 bytes
     auto kb = pool_.alloc("BBBB"); // 5 bytes
     auto kc = pool_.alloc("CCCC"); // 5 bytes
-    
+
     pool_.free(kb);
-    
+
     // Alloc E (6 bytes with null). Too big for B's spot (5 bytes).
     auto ke = pool_.alloc("EEEEE");
     EXPECT_NE(kb, ke);
     EXPECT_GT(ke, kc); // Should be after C
-    
+
     EXPECT_STREQ("AAAA", pool_.lookup(ka));
     EXPECT_STREQ("EEEEE", pool_.lookup(ke));
     EXPECT_STREQ("CCCC", pool_.lookup(kc));
 }
 
-TEST_F(StringPoolTest, fuzz_test) {
+TEST_F(StringPoolTest, fuzz_test)
+{
     // Keep allocating and freeing strings of 3-15 bytes.
     // Total live strings ~ 8 KB.
     // 8 KB = 8192 bytes.
-    // Average size = (3+15)/2 = 9 bytes + null? 
+    // Average size = (3+15)/2 = 9 bytes + null?
     // Say avg 10 bytes. ~800 strings.
-    
+
     std::map<StringPool::key_t, std::string> active_strings;
     size_t current_bytes = 0;
     const size_t TARGET_BYTES = 8192;
-    
+
     std::mt19937 rng(12345);
     std::uniform_int_distribution<int> len_dist(3, 15);
     std::uniform_int_distribution<int> char_dist('a', 'z');
-    
+
     int operations = 20000;
-    
-    for (int i = 0; i < operations; ++i) {
+
+    for (int i = 0; i < operations; ++i)
+    {
         bool do_alloc = true;
-        
-        if (active_strings.empty()) {
+
+        if (active_strings.empty())
+        {
             do_alloc = true;
-        } else if (current_bytes > TARGET_BYTES) {
+        }
+        else if (current_bytes > TARGET_BYTES)
+        {
             do_alloc = false;
-        } else {
+        }
+        else
+        {
             // Random choice, bias towards balance
             do_alloc = (rng() % 2) == 0;
         }
-        
-        if (do_alloc) {
+
+        if (do_alloc)
+        {
             int len = len_dist(rng);
             std::string s;
             s.reserve(len);
-            for (int j = 0; j < len; ++j) {
+            for (int j = 0; j < len; ++j)
+            {
                 s.push_back(static_cast<char>(char_dist(rng)));
             }
-            
+
             auto key = pool_.alloc(s.c_str());
-            ASSERT_NE(StringPool::INVALID_KEY, key) << "Allocation failed at iter " << i << " bytes " << current_bytes;
-            
+            ASSERT_NE(StringPool::INVALID_KEY, key)
+                << "Allocation failed at iter " << i << " bytes "
+                << current_bytes;
+
             active_strings[key] = s;
             current_bytes += (len + 1);
-            
+
             // Verify
-            const char* stored = pool_.lookup(key);
+            const char *stored = pool_.lookup(key);
             ASSERT_STREQ(s.c_str(), stored);
-            
-        } else {
+        }
+        else
+        {
             // Free random
             auto it = active_strings.begin();
             std::advance(it, rng() % active_strings.size());
-            
+
             StringPool::key_t key = it->first;
             size_t len = it->second.length();
-            
+
             // Verify before free
-            const char* stored = pool_.lookup(key);
+            const char *stored = pool_.lookup(key);
             ASSERT_STREQ(it->second.c_str(), stored);
-            
+
             pool_.free(key);
             active_strings.erase(it);
             current_bytes -= (len + 1);
         }
     }
-    
+
     // Final verification
-    for (const auto& pair : active_strings) {
+    for (const auto &pair : active_strings)
+    {
         ASSERT_STREQ(pair.second.c_str(), pool_.lookup(pair.first));
     }
 }
 
-TEST_F(StringPoolTest, free_edge_cases) {
+TEST_F(StringPoolTest, free_edge_cases)
+{
     // Freeing invalid or empty keys should not crash
     pool_.free(StringPool::INVALID_KEY);
     pool_.free(StringPool::EMPTY_KEY);
@@ -248,12 +271,14 @@ TEST_F(StringPoolTest, free_edge_cases) {
     pool_.free(k); // Second free should be safely ignored
 }
 
-TEST_F(StringPoolTest, lookup_out_of_bounds) {
+TEST_F(StringPoolTest, lookup_out_of_bounds)
+{
     StringPool::key_t oob_key = (50 << 10) | 0;
     EXPECT_EQ(nullptr, pool_.lookup(oob_key));
 }
 
-TEST_F(StringPoolTest, coalesce_adjacent_holes) {
+TEST_F(StringPoolTest, coalesce_adjacent_holes)
+{
     auto ka = pool_.alloc("AAAA"); // 5 bytes (0..4)
     auto kb = pool_.alloc("BBBB"); // 5 bytes (5..9)
     auto kc = pool_.alloc("CCCC"); // 5 bytes (10..14)
@@ -273,14 +298,17 @@ TEST_F(StringPoolTest, coalesce_adjacent_holes) {
     EXPECT_STREQ("DDDD", pool_.lookup(kd));
 }
 
-TEST_F(StringPoolTest, max_blocks_exhaustion) {
+TEST_F(StringPoolTest, max_blocks_exhaustion)
+{
     // Fill up all MAX_BLOCKS (63) blocks completely
     std::string s126(126, 'x');
     std::string s7(7, 'y');
 
     std::vector<StringPool::key_t> keys;
-    for (size_t b = 0; b < StringPool::MAX_BLOCKS; ++b) {
-        for (int i = 0; i < 8; ++i) {
+    for (size_t b = 0; b < StringPool::MAX_BLOCKS; ++b)
+    {
+        for (int i = 0; i < 8; ++i)
+        {
             auto k = pool_.alloc(s126.c_str());
             ASSERT_NE(StringPool::INVALID_KEY, k);
             keys.push_back(k);

--- a/src/utils/StringPool.cxxtest
+++ b/src/utils/StringPool.cxxtest
@@ -231,3 +231,67 @@ TEST_F(StringPoolTest, fuzz_test) {
         ASSERT_STREQ(pair.second.c_str(), pool_.lookup(pair.first));
     }
 }
+
+TEST_F(StringPoolTest, free_edge_cases) {
+    // Freeing invalid or empty keys should not crash
+    pool_.free(StringPool::INVALID_KEY);
+    pool_.free(StringPool::EMPTY_KEY);
+
+    // Freeing an out-of-bounds key
+    StringPool::key_t oob_key = (50 << 10) | 0;
+    pool_.free(oob_key);
+
+    // Double free test
+    auto k = pool_.alloc("Test");
+    EXPECT_STREQ("Test", pool_.lookup(k));
+    pool_.free(k);
+    pool_.free(k); // Second free should be safely ignored
+}
+
+TEST_F(StringPoolTest, lookup_out_of_bounds) {
+    StringPool::key_t oob_key = (50 << 10) | 0;
+    EXPECT_EQ(nullptr, pool_.lookup(oob_key));
+}
+
+TEST_F(StringPoolTest, coalesce_adjacent_holes) {
+    auto ka = pool_.alloc("AAAA"); // 5 bytes (0..4)
+    auto kb = pool_.alloc("BBBB"); // 5 bytes (5..9)
+    auto kc = pool_.alloc("CCCC"); // 5 bytes (10..14)
+    auto kd = pool_.alloc("DDDD"); // 5 bytes (15..19)
+
+    // Free B and C
+    pool_.free(kb);
+    pool_.free(kc);
+
+    // Alloc E of 10 bytes ("123456789", 10 bytes with null)
+    // Should fit into coalesced spot of B + C (indices 5..14)
+    auto ke = pool_.alloc("123456789");
+    EXPECT_EQ(kb, ke);
+
+    EXPECT_STREQ("AAAA", pool_.lookup(ka));
+    EXPECT_STREQ("123456789", pool_.lookup(ke));
+    EXPECT_STREQ("DDDD", pool_.lookup(kd));
+}
+
+TEST_F(StringPoolTest, max_blocks_exhaustion) {
+    // Fill up all MAX_BLOCKS (63) blocks completely
+    std::string s126(126, 'x');
+    std::string s7(7, 'y');
+
+    std::vector<StringPool::key_t> keys;
+    for (size_t b = 0; b < StringPool::MAX_BLOCKS; ++b) {
+        for (int i = 0; i < 8; ++i) {
+            auto k = pool_.alloc(s126.c_str());
+            ASSERT_NE(StringPool::INVALID_KEY, k);
+            keys.push_back(k);
+        }
+        auto k_tail = pool_.alloc(s7.c_str());
+        ASSERT_NE(StringPool::INVALID_KEY, k_tail);
+        keys.push_back(k_tail);
+    }
+
+    // Now all 63 blocks are 100% full (63 * 1024 bytes).
+    // Allocating one more string should return INVALID_KEY
+    auto k_overflow = pool_.alloc("overflow");
+    EXPECT_EQ(StringPool::INVALID_KEY, k_overflow);
+}

--- a/src/utils/StringPool.cxxtest
+++ b/src/utils/StringPool.cxxtest
@@ -1,0 +1,233 @@
+/** @copyright
+ * Copyright (c) 2024, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file StringPool.cxxtest
+ *
+ * Tests for StringPool.
+ *
+ * @author Balazs Racz
+ * @date 2026-01-11
+ */
+
+#include "utils/StringPool.hxx"
+#include "utils/test_main.hxx"
+
+#include <string>
+#include <map>
+#include <vector>
+#include <random>
+
+class StringPoolTest : public ::testing::Test {
+protected:
+    StringPool pool_;
+};
+
+TEST_F(StringPoolTest, alloc_lookup_basic) {
+    auto k1 = pool_.alloc("Hello");
+    auto k2 = pool_.alloc("World");
+    
+    EXPECT_NE(k1, StringPool::INVALID_KEY);
+    EXPECT_NE(k2, StringPool::INVALID_KEY);
+    EXPECT_NE(k1, k2);
+    
+    EXPECT_STREQ("Hello", pool_.lookup(k1));
+    EXPECT_STREQ("World", pool_.lookup(k2));
+}
+
+TEST_F(StringPoolTest, alloc_empty) {
+    auto k = pool_.alloc("");
+    EXPECT_EQ(StringPool::EMPTY_KEY, k);
+    EXPECT_STREQ("", pool_.lookup(k));
+    
+    auto k2 = pool_.alloc(nullptr);
+    EXPECT_EQ(StringPool::EMPTY_KEY, k2);
+    EXPECT_STREQ("", pool_.lookup(k2));
+}
+
+TEST_F(StringPoolTest, invalid_key) {
+    EXPECT_EQ(nullptr, pool_.lookup(StringPool::INVALID_KEY));
+}
+
+TEST_F(StringPoolTest, max_len) {
+    std::string s126(126, 'a');
+    auto k1 = pool_.alloc(s126.c_str());
+    EXPECT_NE(StringPool::INVALID_KEY, k1);
+    EXPECT_STREQ(s126.c_str(), pool_.lookup(k1));
+    
+    std::string s127(127, 'a'); // 128 bytes with null
+    auto k2 = pool_.alloc(s127.c_str());
+    EXPECT_EQ(StringPool::INVALID_KEY, k2);
+}
+
+TEST_F(StringPoolTest, boundary_crossing) {
+    // Fill first block almost to the end
+    // Block size 1024.
+    // 1022 bytes. 2 bytes left.
+    // Alloc 1022 bytes is too large (max 127).
+    
+    // We need to fill it using multiple strings.
+    // 1024 / 127 = ~8.
+    
+    // Fill up to 1022.
+    // Let's use 10-byte strings (11 with null).
+    // 1024 % 11 = 1. So 93 strings. 93 * 11 = 1023.
+    // Wait, 1024 % 11: 1024 = 93 * 11 + 1.
+    // So if we alloc 93 strings of len 10, we occupy 1023 bytes. 1 byte left.
+    
+    // Let's target exactly 1022 bytes used.
+    // 1022 / 2 = 511. String "A" is 2 bytes.
+    // Alloc 511 "A"s.
+    for (int i = 0; i < 511; ++i) {
+        pool_.alloc("A");
+    }
+    // Used: 511 * 2 = 1022.
+    // Remaining in block 0: 2 bytes (offsets 1022, 1023).
+    
+    // Alloc "B" (2 bytes). Should fit.
+    auto k1 = pool_.alloc("B");
+    EXPECT_EQ(0, k1 >> 10); // Still block 0
+    EXPECT_EQ(1022, k1 & 0x03FF); // Offset 1022
+    
+    // Now block 0 is full (1024 bytes).
+    // Alloc "C" (2 bytes). Should go to block 1.
+    auto k2 = pool_.alloc("C");
+    EXPECT_EQ(1, k2 >> 10); // Block 1
+    EXPECT_EQ(0, k2 & 0x03FF); // Offset 0
+    
+    // Verify content
+    EXPECT_STREQ("B", pool_.lookup(k1));
+    EXPECT_STREQ("C", pool_.lookup(k2));
+}
+
+TEST_F(StringPoolTest, reuse_hole) {
+    // Alloc A, B, C.
+    auto ka = pool_.alloc("AAAA"); // 5 bytes
+    auto kb = pool_.alloc("BBBB"); // 5 bytes
+    auto kc = pool_.alloc("CCCC"); // 5 bytes
+    
+    // Offsets: 0, 5, 10.
+    EXPECT_EQ(5, kb & 0x03FF);
+    
+    // Free B.
+    pool_.free(kb);
+    
+    // Alloc D (fits in B's spot).
+    auto kd = pool_.alloc("DDDD"); // 5 bytes
+    EXPECT_EQ(kb, kd); // Should reuse the same spot
+    
+    EXPECT_STREQ("AAAA", pool_.lookup(ka));
+    EXPECT_STREQ("DDDD", pool_.lookup(kd));
+    EXPECT_STREQ("CCCC", pool_.lookup(kc));
+}
+
+TEST_F(StringPoolTest, reuse_hole_too_small) {
+    // Alloc A, B, C.
+    auto ka = pool_.alloc("AAAA"); // 5 bytes
+    auto kb = pool_.alloc("BBBB"); // 5 bytes
+    auto kc = pool_.alloc("CCCC"); // 5 bytes
+    
+    pool_.free(kb);
+    
+    // Alloc E (6 bytes with null). Too big for B's spot (5 bytes).
+    auto ke = pool_.alloc("EEEEE");
+    EXPECT_NE(kb, ke);
+    EXPECT_GT(ke, kc); // Should be after C
+    
+    EXPECT_STREQ("AAAA", pool_.lookup(ka));
+    EXPECT_STREQ("EEEEE", pool_.lookup(ke));
+    EXPECT_STREQ("CCCC", pool_.lookup(kc));
+}
+
+TEST_F(StringPoolTest, fuzz_test) {
+    // Keep allocating and freeing strings of 3-15 bytes.
+    // Total live strings ~ 8 KB.
+    // 8 KB = 8192 bytes.
+    // Average size = (3+15)/2 = 9 bytes + null? 
+    // Say avg 10 bytes. ~800 strings.
+    
+    std::map<StringPool::key_t, std::string> active_strings;
+    size_t current_bytes = 0;
+    const size_t TARGET_BYTES = 8192;
+    
+    std::mt19937 rng(12345);
+    std::uniform_int_distribution<int> len_dist(3, 15);
+    std::uniform_int_distribution<int> char_dist('a', 'z');
+    
+    int operations = 20000;
+    
+    for (int i = 0; i < operations; ++i) {
+        bool do_alloc = true;
+        
+        if (active_strings.empty()) {
+            do_alloc = true;
+        } else if (current_bytes > TARGET_BYTES) {
+            do_alloc = false;
+        } else {
+            // Random choice, bias towards balance
+            do_alloc = (rng() % 2) == 0;
+        }
+        
+        if (do_alloc) {
+            int len = len_dist(rng);
+            std::string s;
+            s.reserve(len);
+            for (int j = 0; j < len; ++j) {
+                s.push_back(static_cast<char>(char_dist(rng)));
+            }
+            
+            auto key = pool_.alloc(s.c_str());
+            ASSERT_NE(StringPool::INVALID_KEY, key) << "Allocation failed at iter " << i << " bytes " << current_bytes;
+            
+            active_strings[key] = s;
+            current_bytes += (len + 1);
+            
+            // Verify
+            const char* stored = pool_.lookup(key);
+            ASSERT_STREQ(s.c_str(), stored);
+            
+        } else {
+            // Free random
+            auto it = active_strings.begin();
+            std::advance(it, rng() % active_strings.size());
+            
+            StringPool::key_t key = it->first;
+            size_t len = it->second.length();
+            
+            // Verify before free
+            const char* stored = pool_.lookup(key);
+            ASSERT_STREQ(it->second.c_str(), stored);
+            
+            pool_.free(key);
+            active_strings.erase(it);
+            current_bytes -= (len + 1);
+        }
+    }
+    
+    // Final verification
+    for (const auto& pair : active_strings) {
+        ASSERT_STREQ(pair.second.c_str(), pool_.lookup(pair.first));
+    }
+}

--- a/src/utils/StringPool.cxxtest
+++ b/src/utils/StringPool.cxxtest
@@ -142,7 +142,15 @@ TEST_F(StringPoolTest, reuse_hole)
     // Free B.
     pool_.free(kb);
 
-    // Alloc D (fits in B's spot).
+    // Fill block 0 so that remaining space at end is smaller than 5 bytes.
+    // Used: 15. Remaining: 1009. 504 * 2 = 1008 bytes. Offset becomes 1023.
+    for (int i = 0; i < 504; ++i)
+    {
+        pool_.alloc("A");
+    }
+
+    // Alloc D (5 bytes). Does not fit at currentBlockOffset_ (1023 + 5 > 1024),
+    // so find_hole is called and finds B's spot at offset 5.
     auto kd = pool_.alloc("DDDD"); // 5 bytes
     EXPECT_EQ(kb, kd);             // Should reuse the same spot
 
@@ -288,8 +296,16 @@ TEST_F(StringPoolTest, coalesce_adjacent_holes)
     pool_.free(kb);
     pool_.free(kc);
 
-    // Alloc E of 10 bytes ("123456789", 10 bytes with null)
-    // Should fit into coalesced spot of B + C (indices 5..14)
+    // Fill block 0 so that remaining space at end is smaller than 10 bytes.
+    // Used: 20. Remaining: 1004. 502 * 2 = 1004 bytes. Offset becomes 1024.
+    for (int i = 0; i < 502; ++i)
+    {
+        pool_.alloc("A");
+    }
+
+    // Alloc E of 10 bytes ("123456789", 10 bytes with null).
+    // Does not fit at currentBlockOffset_ (1024 + 10 > 1024), so find_hole is called.
+    // Should fit into coalesced spot of B + C (indices 5..14).
     auto ke = pool_.alloc("123456789");
     EXPECT_EQ(kb, ke);
 

--- a/src/utils/StringPool.hxx
+++ b/src/utils/StringPool.hxx
@@ -1,0 +1,89 @@
+/** @copyright
+ * Copyright (c) 2026, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file StringPool.hxx
+ *
+ * A dynamically adjusting data structure for holding C strings.
+ *
+ * @author Balazs Racz
+ * @date 2026-01-11
+ */
+
+#ifndef _UTILS_STRINGPOOL_HXX_
+#define _UTILS_STRINGPOOL_HXX_
+
+#include <vector>
+#include <cstdint>
+#include <cstddef>
+
+/// A dynamically adjusting data structure for holding C strings.
+/// The StringPool allocates storage in chunks of 1 kb or memory. It supports up
+/// to 64 kb of contents. Each participating string can be at most 127 bytes
+/// long.
+class StringPool {
+public:
+  typedef uint16_t key_t;
+
+  static constexpr size_t BLOCK_SIZE = 1024;
+  static constexpr size_t MAX_BLOCKS = 64;
+  static constexpr key_t INVALID_KEY = 0xFFFF;
+  static constexpr key_t EMPTY_KEY = 0xFFFE;
+  static constexpr size_t MAX_STRING_LEN = 127;
+
+  StringPool();
+  ~StringPool();
+
+  /// Allocates storage for a string and copies the string into storage.
+  /// @param value the string to store. Must be null-terminated.
+  /// @return a key handle to the stored string, or INVALID_KEY if allocation
+  /// failed, or EMPTY_KEY if the string is empty.
+  key_t alloc(const char* value);
+
+  /// Frees the storage of a previously allocated string.
+  /// @param key the key of the string to free.
+  void free(key_t key);
+
+  /// @return the string stored under a given key. The returned pointer remains
+  /// valid so long as the respective key is not free'd.
+  const char* lookup(key_t key) const;
+
+private:
+  /// Tries to find a hole of at least size `size` in the existing blocks.
+  /// @param size the size in bytes to allocate (including null terminator).
+  /// @return a key if a hole was found, or INVALID_KEY.
+  key_t find_hole(size_t size);
+
+  /// Storage blocks.
+  std::vector<char*> blocks_;
+
+  /// Current block index we are appending to.
+  uint8_t currentBlockIdx_;
+
+  /// Current offset in the current block where free space starts.
+  uint16_t currentBlockOffset_;
+};
+
+#endif // _UTILS_STRINGPOOL_HXX_

--- a/src/utils/StringPool.hxx
+++ b/src/utils/StringPool.hxx
@@ -39,16 +39,18 @@
 #include <cstdint>
 #include <cstddef>
 
+#include "utils/macros.h"
+
 /// A dynamically adjusting data structure for holding C strings.
 /// The StringPool allocates storage in chunks of 1 kb or memory. It supports up
-/// to 64 kb of contents. Each participating string can be at most 127 bytes
+/// to 63 kb of contents. Each participating string can be at most 127 bytes
 /// long.
 class StringPool {
 public:
   typedef uint16_t key_t;
 
   static constexpr size_t BLOCK_SIZE = 1024;
-  static constexpr size_t MAX_BLOCKS = 64;
+  static constexpr size_t MAX_BLOCKS = 63;
   static constexpr key_t INVALID_KEY = 0xFFFF;
   static constexpr key_t EMPTY_KEY = 0xFFFE;
   static constexpr size_t MAX_STRING_LEN = 127;
@@ -71,6 +73,23 @@ public:
   const char* lookup(key_t key) const;
 
 private:
+  DISALLOW_COPY_AND_ASSIGN(StringPool);
+
+  /// Computes a key handle from a block index and offset within the block.
+  static inline key_t compute_key(uint16_t block_idx, uint16_t offset) {
+    return (static_cast<key_t>(block_idx) << 10) | (offset & 0x03FF);
+  }
+
+  /// Extracts the block index from a key handle.
+  static inline uint16_t block_idx_from_key(key_t key) {
+    return key >> 10;
+  }
+
+  /// Extracts the byte offset within a block from a key handle.
+  static inline uint16_t block_offset_from_key(key_t key) {
+    return key & 0x03FF;
+  }
+
   /// Tries to find a hole of at least size `size` in the existing blocks.
   /// @param size the size in bytes to allocate (including null terminator).
   /// @return a key if a hole was found, or INVALID_KEY.

--- a/src/utils/StringPool.hxx
+++ b/src/utils/StringPool.hxx
@@ -35,9 +35,9 @@
 #ifndef _UTILS_STRINGPOOL_HXX_
 #define _UTILS_STRINGPOOL_HXX_
 
-#include <vector>
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
+#include <vector>
 
 #include "utils/macros.h"
 
@@ -45,64 +45,68 @@
 /// The StringPool allocates storage in chunks of 1 kb or memory. It supports up
 /// to 63 kb of contents. Each participating string can be at most 127 bytes
 /// long.
-class StringPool {
+class StringPool
+{
 public:
-  typedef uint16_t key_t;
+    typedef uint16_t key_t;
 
-  static constexpr size_t BLOCK_SIZE = 1024;
-  static constexpr size_t MAX_BLOCKS = 63;
-  static constexpr key_t INVALID_KEY = 0xFFFF;
-  static constexpr key_t EMPTY_KEY = 0xFFFE;
-  static constexpr size_t MAX_STRING_LEN = 127;
+    static constexpr size_t BLOCK_SIZE = 1024;
+    static constexpr size_t MAX_BLOCKS = 63;
+    static constexpr key_t INVALID_KEY = 0xFFFF;
+    static constexpr key_t EMPTY_KEY = 0xFFFE;
+    static constexpr size_t MAX_STRING_LEN = 127;
 
-  StringPool();
-  ~StringPool();
+    StringPool();
+    ~StringPool();
 
-  /// Allocates storage for a string and copies the string into storage.
-  /// @param value the string to store. Must be null-terminated.
-  /// @return a key handle to the stored string, or INVALID_KEY if allocation
-  /// failed, or EMPTY_KEY if the string is empty.
-  key_t alloc(const char* value);
+    /// Allocates storage for a string and copies the string into storage.
+    /// @param value the string to store. Must be null-terminated.
+    /// @return a key handle to the stored string, or INVALID_KEY if allocation
+    /// failed, or EMPTY_KEY if the string is empty.
+    key_t alloc(const char *value);
 
-  /// Frees the storage of a previously allocated string.
-  /// @param key the key of the string to free.
-  void free(key_t key);
+    /// Frees the storage of a previously allocated string.
+    /// @param key the key of the string to free.
+    void free(key_t key);
 
-  /// @return the string stored under a given key. The returned pointer remains
-  /// valid so long as the respective key is not free'd.
-  const char* lookup(key_t key) const;
+    /// @return the string stored under a given key. The returned pointer
+    /// remains valid so long as the respective key is not free'd.
+    const char *lookup(key_t key) const;
 
 private:
-  DISALLOW_COPY_AND_ASSIGN(StringPool);
+    DISALLOW_COPY_AND_ASSIGN(StringPool);
 
-  /// Computes a key handle from a block index and offset within the block.
-  static inline key_t compute_key(uint16_t block_idx, uint16_t offset) {
-    return (static_cast<key_t>(block_idx) << 10) | (offset & 0x03FF);
-  }
+    /// Computes a key handle from a block index and offset within the block.
+    static inline key_t compute_key(uint16_t block_idx, uint16_t offset)
+    {
+        return (static_cast<key_t>(block_idx) << 10) | (offset & 0x03FF);
+    }
 
-  /// Extracts the block index from a key handle.
-  static inline uint16_t block_idx_from_key(key_t key) {
-    return key >> 10;
-  }
+    /// Extracts the block index from a key handle.
+    static inline uint16_t block_idx_from_key(key_t key)
+    {
+        return key >> 10;
+    }
 
-  /// Extracts the byte offset within a block from a key handle.
-  static inline uint16_t block_offset_from_key(key_t key) {
-    return key & 0x03FF;
-  }
+    /// Extracts the byte offset within a block from a key handle.
+    static inline uint16_t block_offset_from_key(key_t key)
+    {
+        return key & 0x03FF;
+    }
 
-  /// Tries to find a hole of at least size `size` in the existing blocks.
-  /// @param size the size in bytes to allocate (including null terminator).
-  /// @return a key if a hole was found, or INVALID_KEY.
-  key_t find_hole(size_t size);
+    /// Tries to find a hole of at least size `size` in the existing blocks.
+    /// @param size the size in bytes to allocate (including null terminator).
+    /// @return a key if a hole was found, or INVALID_KEY.
+    key_t find_hole(size_t size);
 
-  /// Storage blocks.
-  std::vector<char*> blocks_;
+    /// Storage blocks.
+    std::vector<char *> blocks_;
 
-  /// Current block index we are appending to.
-  uint8_t currentBlockIdx_;
+    /// Current block index we are appending to.
+    uint8_t currentBlockIdx_;
 
-  /// Current offset in the current block where free space starts.
-  uint16_t currentBlockOffset_;
+    /// Current offset in the current block where free space starts.
+    uint16_t currentBlockOffset_;
 };
 
 #endif // _UTILS_STRINGPOOL_HXX_

--- a/src/utils/sources
+++ b/src/utils/sources
@@ -30,6 +30,7 @@ CXXSRCS += \
         Stats.cxx \
         SocketCan.cxx \
         SocketClient.cxx \
+        StringPool.cxx \
         StringPrintf.cxx \
         constants.cxx \
         format_utils.cxx \


### PR DESCRIPTION
utils: Add StringPool data structure for dynamic C-string storage

### Overview

`StringPool` is a dynamic data structure designed for efficiently storing and referencing C-strings (up to 127 bytes long) using compact 16-bit key handles (`uint16_t key_t`).

### Key Features & Implementation Details

- **Chunked Allocation**: Allocates memory in 1 KB blocks on demand, supporting up to 63 blocks (63 KB total storage capacity).
- **16-bit Key Handles**: Encodes keys as `(block_idx << 10) | offset`. Reducing max blocks to 63 guarantees key values stay below `0xFCFF`, avoiding collisions with reserved key constants:
  - `EMPTY_KEY` (`0xFFFE`): Returned for `nullptr` or `""` inputs.
  - `INVALID_KEY` (`0xFFFF`): Returned when allocation fails or length exceeds limits.
- **Hole Reuse & Coalescing**: Zeroes out memory when `free()` is called, and searches existing blocks for contiguous zero-byte holes during `alloc()` to minimize memory fragmentation.
- **Copy Safety**: Uses `DISALLOW_COPY_AND_ASSIGN(StringPool)` to prevent shallow-copying of dynamic memory block pointers.
- **Key Helper Utilities**: Internal inline helpers (`compute_key`, `block_idx_from_key`, `block_offset_from_key`) encapsulate bitwise operations and enforce 10-bit offset masking (`0x03FF`).

### Testing

Added comprehensive unit test suite in `src/utils/StringPool.cxxtest` covering:
- Basic `alloc` and `lookup` behavior.
- `nullptr` and empty string handling.
- Maximum string length enforcement (127 bytes).
- Multi-block boundary crossing.
- Single hole reuse and adjacent hole coalescing.
- Invalid/out-of-bounds key lookup and double-free safety.
- Full pool capacity exhaustion (`MAX_BLOCKS = 63`).