### PR TITLE
Adds query support to the railcom broadcast client.

### DIFF
--- a/src/openlcb/RailcomBroadcastClient.cxx
+++ b/src/openlcb/RailcomBroadcastClient.cxx
@@ -65,6 +65,12 @@ bool RailcomBroadcastClient::is_our_event(uint64_t event_id) const
     return (event_id & ~0xFFFFULL) == railcomEventBase_;
 }
 
+void RailcomBroadcastClient::query()
+{
+    openlcb::send_message(node_, openlcb::Defs::MTI_PRODUCER_IDENTIFY,
+        openlcb::eventid_to_buffer(railcomEventBase_));
+}
+
 RailcomBroadcastClient::LocoInfo RailcomBroadcastClient::parse_event(
     uint64_t event)
 {

--- a/src/openlcb/RailcomBroadcastClient.cxxtest
+++ b/src/openlcb/RailcomBroadcastClient.cxxtest
@@ -105,6 +105,15 @@ TEST_F(RailcomBroadcastClientTest, CreateDestroy)
     EXPECT_TRUE(client_->current_locos().empty());
 }
 
+TEST_F(RailcomBroadcastClientTest, Query)
+{
+    EXPECT_TRUE(client_->current_locos().empty());
+    clear_expect(true);
+    expect_packet(make_outgoing_event_packet(
+        Defs::MTI_PRODUCER_IDENTIFY, base_ | 0x0000ULL));
+    client_->query();
+}
+
 TEST_F(RailcomBroadcastClientTest, AddLoco)
 {
     uint64_t event = entry_event(3);

--- a/src/openlcb/RailcomBroadcastClient.hxx
+++ b/src/openlcb/RailcomBroadcastClient.hxx
@@ -132,6 +132,10 @@ public:
         return railcomEventBase_;
     }
 
+    /// Sends out a query to the bus. This does synchronous allocation of the
+    /// message, but does not wait for the query to get any replies.
+    void query();
+    
     void handle_event_report(const EventRegistryEntry &registry_entry,
         EventReport *event, BarrierNotifiable *done) override;
 


### PR DESCRIPTION
Adds a helper function on RailcomBroadcastClient to send out a query message to the bus.

The query message instructs a railcom broadcast flow to send the current state of the block in producer identified messages, thereby syncing the newly created client with the server.