### PR TITLE
Traction Modem State Transfer

### DIFF
--- a/etc/esp-idf/CMakeLists.txt
+++ b/etc/esp-idf/CMakeLists.txt
@@ -92,7 +92,9 @@ set(SRCS
     ${OPENMRNPATH}/src/os/TempFile.cxx
     ${OPENMRNPATH}/src/os/watchdog.c
 
+    ${OPENMRNPATH}/src/traction_modem/FunctionStatus.cxx
     ${OPENMRNPATH}/src/traction_modem/Output.cxx
+    ${OPENMRNPATH}/src/traction_modem/VelocityStatus.cxx
 
     ${OPENMRNPATH}/src/utils/Base64.cxx
     ${OPENMRNPATH}/src/utils/Blinker.cxx

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,7 +102,9 @@ set(SOURCES
     ${OPENMRNPATH}/src/os/TempFile.cxx
     ${OPENMRNPATH}/src/os/watchdog.c
 
+    ${OPENMRNPATH}/src/traction_modem/FunctionStatus.cxx
     ${OPENMRNPATH}/src/traction_modem/Output.cxx
+    ${OPENMRNPATH}/src/traction_modem/VelocityStatus.cxx
 
     ${OPENMRNPATH}/src/utils/Base64.cxx
     ${OPENMRNPATH}/src/utils/Blinker.cxx

--- a/src/traction_modem/Defs.hxx
+++ b/src/traction_modem/Defs.hxx
@@ -81,7 +81,7 @@ struct Defs
         CMD_SPEED_SET          = 0x0100, ///< set velocity
         CMD_FN_SET             = 0x0101, ///< set function
         CMD_ESTOP_SET          = 0x0102, ///< emergency stop request
-        CMD_SPEED_QUERY        = 0x0110, ///< query current speed
+        CMD_SPEED_QUERY        = 0x0110, ///< query current velocity
         CMD_FN_QUERY           = 0x0111, ///< query function status
         CMD_DC_DCC_PRESENT     = 0x0200, ///< DC/DCC present
         CMD_WIRELESS_PRESENT   = 0x0201, ///< wireless present
@@ -104,7 +104,7 @@ struct Defs
         RESP_FN_SET             = RESPONSE | CMD_FN_SET,
         /// emergency stop response
         RESP_ESTOP_SET          = RESPONSE | CMD_ESTOP_SET,
-        /// query current speed response
+        /// query current velocity response
         RESP_SPEED_QUERY        = RESPONSE | CMD_SPEED_QUERY,
         /// query function status response
         RESP_FN_QUERY           = RESPONSE | CMD_FN_QUERY,
@@ -158,8 +158,16 @@ struct Defs
     static constexpr unsigned LEN_BAUD_RATE_REQUEST = 2;
     /// Length of the data payload of a set function packet.
     static constexpr unsigned LEN_FN_SET = 6;
+    /// Length of the data payload of a function query packet.
+    static constexpr unsigned LEN_FN_QUERY = 4;
+    /// Length of the data payload of a function query response packet.
+    static constexpr unsigned LEN_FN_QUERY_RESP = 6;
     /// Length of the data payload of a set speed packet.
     static constexpr unsigned LEN_SPEED_SET = 1;
+    /// Length of the data payload of a speed query packet.
+    static constexpr unsigned LEN_SPEED_QUERY = 0;
+    /// Length of the data payload of a speed query response packet.
+    static constexpr unsigned LEN_SPEED_QUERY_RESP = 4;
     /// Length of the data payload of a set estop packet.
     static constexpr unsigned LEN_ESTOP_SET = 0;
     /// Length of the data payload of a wireless present packet.
@@ -194,6 +202,20 @@ struct Defs
     static constexpr unsigned OFS_LEN = 6;
     /// Offset of the first data byte in the packet.
     static constexpr unsigned OFS_DATA = 8;
+
+    /// Velocity structure mirroring NMRA 128 Speed Step format.
+    /// Single byte with direction bit and 7-bit speed value (0-127).
+    /// Speed value 0 = normal stop, 1 = emergency stop, 2-127 = proportional
+    /// speed steps. Used for motor control and Advanced Operations instructions.
+    typedef union
+    {
+        uint8_t data;               ///< Full 8-bit data
+        struct
+        {
+            uint8_t speed     : 7;  ///< Speed: 0=stop, 1=E-stop, 2-127=speed
+            uint8_t direction : 1;  ///< Direction: 0=reverse, 1=forward
+        };
+    } DCCVelocity;
 
     /// The header of a message.
     struct Header
@@ -280,6 +302,36 @@ struct Defs
         "OutputStateQueryResponse struct length or alignment mismatch.");
     static_assert(
         std::is_standard_layout<OutputStateQueryResponse>::value == true);
+
+    /// Structure of a function status query response.
+    struct FunctionStatusQueryResponse
+    {
+        Header header_; ///< packet header
+        uint32_t fn_; ///< function number (24-bits)
+        uint16_t value_; ///< function value
+        uint8_t end; ///< used for alignment and length validation only
+    };
+    static_assert(
+        offsetof(FunctionStatusQueryResponse, end) ==
+            (LEN_HEADER + LEN_FN_QUERY_RESP),
+        "FunctionStatusQueryResponse struct length or alignment mismatch.");
+    static_assert(
+        std::is_standard_layout<FunctionStatusQueryResponse>::value == true);
+
+    /// Structure of a speed query response.
+    struct SpeedQueryResponse
+    {
+        Header header_; ///< packet header
+        uint16_t error_; ///< error code
+        uint8_t targetSpeed_; ///< commanded speed (DCC 128-step encoding)
+        uint8_t currentSpeed_; ///< current speed (DCC 128-step encoding)
+        uint8_t end; ///< used for alignment and length validation only
+    };
+    static_assert(
+        offsetof(SpeedQueryResponse, end) ==
+            (LEN_HEADER + LEN_SPEED_QUERY_RESP),
+        "SpeedQueryResponse struct length or alignment mismatch.");
+    static_assert(std::is_standard_layout<SpeedQueryResponse>::value == true);
 
     /// Structure of an output restart command (synchronize lighting effect)
     struct OutputRestart
@@ -389,6 +441,19 @@ struct Defs
         return p;
     }
 
+    /// Computes payload to query a function.
+    /// @param fn function number
+    /// @return wire formatted payload
+    static Payload get_fn_query_payload(unsigned fn)
+    {
+        Payload p;
+        prepare(&p, CMD_FN_QUERY, LEN_FN_QUERY);
+        append_uint32(&p, fn);
+
+        append_crc(&p);
+        return p;
+    }
+
     /// Computes payload to set a function.
     /// @param fn function number
     /// @param value function value. For binary functions, 0 is off, 1 is on.
@@ -399,6 +464,17 @@ struct Defs
         prepare(&p, CMD_FN_SET, LEN_FN_SET);
         append_uint32(&p, fn);
         append_uint16(&p, value);
+
+        append_crc(&p);
+        return p;
+    }
+
+    /// Computes the payload to query the current speed.
+    /// @return wire formatted payload
+    static Payload get_speed_query_payload()
+    {
+        Payload p;
+        prepare(&p, CMD_SPEED_QUERY, LEN_SPEED_QUERY);
 
         append_crc(&p);
         return p;

--- a/src/traction_modem/FunctionStatus.cxx
+++ b/src/traction_modem/FunctionStatus.cxx
@@ -1,0 +1,90 @@
+/** @copyright
+ * Copyright (c) 2025, Stuart Baker
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file FunctionStatus.cxx
+ *
+ * Logic for querying function status.
+ *
+ * @author Stuart Baker
+ * @date 27 June 2025
+ */
+
+#include "traction_modem/FunctionStatus.hxx"
+
+#include "traction_modem/ModemTrainHwInterface.hxx"
+#include "traction_modem/RxFlow.hxx"
+#include "traction_modem/TxFlow.hxx"
+
+namespace traction_modem
+{
+
+//
+// FunctionStatus::FunctionStatus()
+//
+FunctionStatus::FunctionStatus(TxInterface *tx_flow, RxInterface *rx_flow,
+    ModemTrainHwInterface *hw_interface)
+    : txFlow_(tx_flow)
+    , rxFlow_(rx_flow)
+    , hwIf_(hw_interface)
+{
+    rxFlow_->register_handler(this, Defs::RESP_FN_QUERY);
+}
+
+//
+// FunctionStatus::~FunctionStatus()
+//
+FunctionStatus::~FunctionStatus()
+{
+    rxFlow_->unregister_handler_all(this);
+}
+
+//
+// FunctionStatus::query()
+//
+void FunctionStatus::query(unsigned fn)
+{
+    txFlow_->send_packet(Defs::get_fn_query_payload(fn));
+}
+
+//
+// FunctionStatus::send()
+//
+void FunctionStatus::send(Buffer<Message> *buf, unsigned prio)
+{
+    auto b = get_buffer_deleter(buf);
+    switch (b->data()->command())
+    {
+        case Defs::RESP_FN_QUERY:
+        {
+            Defs::FunctionStatusQueryResponse *fsqr =
+                (Defs::FunctionStatusQueryResponse *)b->data()->payload.data();
+            hwIf_->function_status(be32toh(fsqr->fn_), be16toh(fsqr->value_));
+            break;
+        }
+    }
+}
+
+} // namespace traction_modem

--- a/src/traction_modem/FunctionStatus.hxx
+++ b/src/traction_modem/FunctionStatus.hxx
@@ -1,0 +1,79 @@
+/** @copyright
+ * Copyright (c) 2025, Stuart Baker
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file FunctionStatus.hxx
+ *
+ * Logic for querying function status.
+ *
+ * @author Stuart Baker
+ * @date 27 June 2025
+ */
+
+#ifndef _TRACTION_MODEM_FUNCTIONSTATUS_HXX_
+#define _TRACTION_MODEM_FUNCTIONSTATUS_HXX_
+
+#include "traction_modem/Message.hxx"
+
+namespace traction_modem
+{
+
+// Forward declarations.
+class ModemTrainHwInterface;
+class TxInterface;
+class RxInterface;
+
+/// Object for querying and handling function status messages.
+class FunctionStatus : public PacketFlowInterface
+{
+public:
+    /// Constructor.
+    /// @param tx_flow reference to the transmit flow
+    /// @param rx_flow reference to the receive flow
+    /// @param hw_interface hardware specific interface to the modem train
+    FunctionStatus(TxInterface *tx_flow, RxInterface *rx_flow,
+        ModemTrainHwInterface *hw_interface);
+
+    /// Destructor.
+    ~FunctionStatus();
+
+    /// Send a function status query to the decoder.
+    /// @param fn function number to query
+    void query(unsigned fn);
+
+private:
+    /// Receive handler for function status response messages.
+    /// @param buf incoming message
+    /// @param prio message priority
+    void send(Buffer<Message> *buf, unsigned prio) override;
+
+    TxInterface *txFlow_; ///< reference to the transmit flow
+    RxInterface *rxFlow_; ///< reference to the receive flow
+    ModemTrainHwInterface *hwIf_; ///< hardware specific interface
+};
+
+} // namespace traction_modem
+
+#endif // _TRACTION_MODEM_FUNCTIONSTATUS_HXX_

--- a/src/traction_modem/FunctionStatus.hxx
+++ b/src/traction_modem/FunctionStatus.hxx
@@ -1,5 +1,5 @@
 /** @copyright
- * Copyright (c) 2025, Stuart Baker
+ * Copyright (c) 2026, Stuart Baker
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,7 @@
  * Logic for querying function status.
  *
  * @author Stuart Baker
- * @date 27 June 2025
+ * @date 27 June 2026
  */
 
 #ifndef _TRACTION_MODEM_FUNCTIONSTATUS_HXX_

--- a/src/traction_modem/ModemTrain.cxxtest
+++ b/src/traction_modem/ModemTrain.cxxtest
@@ -23,6 +23,10 @@ protected:
             register_handler(_, Defs::RESP_OUTPUT_STATE_QUERY, _)).Times(1);
         EXPECT_CALL(mRxFlow_, register_handler(_, Defs::CMD_MEM_W, _)).Times(1);
         EXPECT_CALL(mRxFlow_, register_handler(_, Defs::CMD_MEM_R, _)).Times(1);
+        EXPECT_CALL(mRxFlow_, register_handler(_, Defs::RESP_SPEED_QUERY, _))
+            .Times(1);
+        EXPECT_CALL(mRxFlow_, register_handler(_, Defs::RESP_FN_QUERY, _))
+            .Times(1);
         train_ = new ModemTrain(&g_service, &mTxFlow_, &mRxFlow_, &mHwIf_);
         testing::Mock::VerifyAndClearExpectations(&mRxFlow_);
     }
@@ -32,7 +36,7 @@ protected:
     {
         testing::Mock::VerifyAndClearExpectations(&mRxFlow_);
         using ::testing::_;
-        EXPECT_CALL(mRxFlow_, unregister_handler_all(_)).Times(2);
+        EXPECT_CALL(mRxFlow_, unregister_handler_all(_)).Times(4);
         delete train_;
     }
 
@@ -161,7 +165,7 @@ TEST_F(ModemTrainTest, Legacy_Address)
 
     // Get address value.
     address = train_->legacy_address();
-    EXPECT_EQ(883U ,address);
+    EXPECT_EQ(0U ,address);
 
     // Get address type.
     type = train_->legacy_address_type();

--- a/src/traction_modem/ModemTrain.hxx
+++ b/src/traction_modem/ModemTrain.hxx
@@ -39,6 +39,9 @@
 #include "traction_modem/Defs.hxx"
 #include "traction_modem/MemorySpace.hxx"
 #include "traction_modem/MemorySpaceServer.hxx"
+#include "traction_modem/FunctionStatus.hxx"
+#include "traction_modem/VelocityStatus.hxx"
+#include "traction_modem/ModemTrainHwInterface.hxx"
 #include "traction_modem/Output.hxx"
 #include "traction_modem/Link.hxx"
 
@@ -61,10 +64,13 @@ public:
         ModemTrainHwInterface *hw_interface)
         : txFlow_(tx_flow)
         , rxFlow_(rx_flow)
+        , hwIf_(hw_interface)
         , link_(tx_flow, rx_flow)
         , linkManager_(service, &link_)
         , cvSpace_(service, &link_)
         , fuSpace_(service, &link_)
+        , velocityStatus_(tx_flow, rx_flow, hw_interface)
+        , functionStatus_(tx_flow, rx_flow, hw_interface)
         , output_(tx_flow, rx_flow, hw_interface)
         , memorySpaceServer_(tx_flow, rx_flow, hw_interface)
         , isActive_(false)
@@ -179,25 +185,21 @@ public:
     /// @return the current value of the function
     uint16_t get_fn(uint32_t address) override
     {
-        /// @todo Need to implement this.
-        return 0;
+        return hwIf_->get_fn(address);
     }
 
     /// @Get the legacy address.
     /// @return legacy address (typically DCC)
     uint32_t legacy_address() override
     {
-        /// @todo What should this be? Should we do a CV1/17/18/29 read to get
-        ///       this?
-        return 883;
+        return hwIf_->legacy_address();
     }
 
     /// Get the type of legacy protocol in use.
     /// @return the legacy address type
     dcc::TrainAddressType legacy_address_type() override
     {
-        /// @todo What should this be. Should we do a CV29 read to get this?
-        return dcc::TrainAddressType::DCC_LONG_ADDRESS;
+        return hwIf_->legacy_address_type();
     }
 
 private:
@@ -211,6 +213,8 @@ private:
     TxInterface *txFlow_;
     /// Handles receiving message frames.
     RxInterface *rxFlow_;
+    /// Hardware specific interface.
+    ModemTrainHwInterface *hwIf_;
     /// Link status object.
     Link link_;
     /// Link Management object.
@@ -219,6 +223,10 @@ private:
     CvSpace cvSpace_;
     /// Space for firmware updates.
     CvSpace fuSpace_;
+    /// Velocity status handler.
+    VelocityStatus velocityStatus_;
+    /// Function status handler.
+    FunctionStatus functionStatus_;
     /// Output handler.
     Output output_;
     // Memory space handler for the modem.

--- a/src/traction_modem/ModemTrain.hxx
+++ b/src/traction_modem/ModemTrain.hxx
@@ -136,6 +136,13 @@ public:
         return &fuSpace_;
     }
 
+    /// Get a reference to the function status handler.
+    /// @return function status handler reference
+    FunctionStatus *get_function_status()
+    {
+        return &functionStatus_;
+    }
+
     // ====== Train interface =======
 
     /// Set train speed.
@@ -209,10 +216,6 @@ private:
     {
         hwIf_->on_link_up();
         velocityStatus_.query();
-        for (unsigned i = 0; i <=68; ++i)
-        {
-            functionStatus_.query(i);
-        }
     }
 
     /// True if the wireless is up and running.

--- a/src/traction_modem/ModemTrain.hxx
+++ b/src/traction_modem/ModemTrain.hxx
@@ -52,7 +52,7 @@ namespace traction_modem
 class ModemTrainHwInterface;
 
 /// ModemTrain definition.
-class ModemTrain : public openlcb::TrainImpl
+class ModemTrain : public openlcb::TrainImpl, public LinkStatusInterface
 {
 public:
     /// Constructor.
@@ -75,6 +75,7 @@ public:
         , memorySpaceServer_(tx_flow, rx_flow, hw_interface)
         , isActive_(false)
     {
+        link_.register_link_status(this);
     }
 
     /// Destructor.
@@ -203,6 +204,17 @@ public:
     }
 
 private:
+    /// Called when link transitions to "up" state.
+    void on_link_up() override
+    {
+        hwIf_->on_link_up();
+        velocityStatus_.query();
+        for (unsigned i = 0; i <=68; ++i)
+        {
+            functionStatus_.query(i);
+        }
+    }
+
     /// True if the wireless is up and running.
     bool isRunning_ = false;
     /// UART fd to send traffic to the device.

--- a/src/traction_modem/ModemTrainHwInterface.hxx
+++ b/src/traction_modem/ModemTrainHwInterface.hxx
@@ -48,8 +48,8 @@ public:
     /// Output state.
     enum class OutputState : uint16_t
     {
-        ON  = 0x0000, ///< output is on
-        OFF = 0xFFFF, ///< output is off
+        OFF = 0x0000, ///< output is off
+        ON  = 0xFFFF, ///< output is on
     };
 
     /// Memory write errors.

--- a/src/traction_modem/ModemTrainHwInterface.hxx
+++ b/src/traction_modem/ModemTrainHwInterface.hxx
@@ -35,6 +35,7 @@
 #ifndef _TRACTION_MODEMTRAINHWINTERFACE_HXX_
 #define _TRACTION_MODEMTRAINHWINTERFACE_HXX_
 
+#include "dcc/Defs.hxx"
 #include "openlcb/MemoryConfig.hxx"
 #include "traction_modem/Defs.hxx"
 
@@ -75,6 +76,43 @@ public:
         /// address out of bounds
         OUT_OF_BOUNDS     = openlcb::MemoryConfigDefs::ERROR_OUT_OF_BOUNDS,
     };
+
+    /// Report the current velocity in response to a query.
+    /// @param target commanded (target) velocity
+    /// @param current current velocity
+    virtual void velocity_status(
+        Defs::DCCVelocity target, Defs::DCCVelocity current)
+    {
+    }
+
+    /// Report the status of a function in response to a query.
+    /// @param fn function number
+    /// @param value function value; for binary functions, 0 is off, 1 is on
+    virtual void function_status(uint32_t fn, uint16_t value)
+    {
+    }
+
+    /// Get the current value of a function.
+    /// @param address function number
+    /// @return current function value
+    virtual uint16_t get_fn(uint32_t address)
+    {
+        return 0;
+    }
+
+    /// Get the legacy (DCC) address of the decoder.
+    /// @return legacy address
+    virtual uint32_t legacy_address()
+    {
+        return 0;
+    }
+
+    /// Get the type of legacy protocol in use.
+    /// @return legacy address type
+    virtual dcc::TrainAddressType legacy_address_type()
+    {
+        return dcc::TrainAddressType::DCC_LONG_ADDRESS;
+    }
 
     /// Set an output state.
     /// @param output output number

--- a/src/traction_modem/ModemTrainHwInterface.hxx
+++ b/src/traction_modem/ModemTrainHwInterface.hxx
@@ -82,17 +82,22 @@ public:
     {
     }
 
-    /// Report the current velocity in response to a query.
-    /// @param target commanded (target) velocity
-    /// @param current current velocity
+    /// Report the current velocity in response to a query. May also come
+    /// unsolicited.
+    /// @param target commanded (target) velocity (as understood by the decoder,
+    ///        not the modem)
+    /// @param current current velocity (as understood by the decoder, not the
+    ///        modem)
     virtual void velocity_status(
         Defs::DCCVelocity target, Defs::DCCVelocity current)
     {
     }
 
-    /// Report the status of a function in response to a query.
+    /// Report the status of a function in response to a query. May also come
+    /// unsolicited.
     /// @param fn function number
-    /// @param value function value; for binary functions, 0 is off, 1 is on
+    /// @param value function value (as understood by the decoder, not the
+    ///        modem); for binary functions, 0 is off, 1 is on
     virtual void function_status(uint32_t fn, uint16_t value)
     {
     }

--- a/src/traction_modem/ModemTrainHwInterface.hxx
+++ b/src/traction_modem/ModemTrainHwInterface.hxx
@@ -77,6 +77,11 @@ public:
         OUT_OF_BOUNDS     = openlcb::MemoryConfigDefs::ERROR_OUT_OF_BOUNDS,
     };
 
+    /// Called when link transitions to "up" state.
+    virtual void on_link_up()
+    {
+    }
+
     /// Report the current velocity in response to a query.
     /// @param target commanded (target) velocity
     /// @param current current velocity

--- a/src/traction_modem/VelocityStatus.cxx
+++ b/src/traction_modem/VelocityStatus.cxx
@@ -1,0 +1,97 @@
+/** @copyright
+ * Copyright (c) 2025, Stuart Baker
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file VelocityStatus.cxx
+ *
+ * Logic for querying velocity status.
+ *
+ * @author Stuart Baker
+ * @date 27 June 2025
+ */
+
+#include "traction_modem/VelocityStatus.hxx"
+
+#include "traction_modem/ModemTrainHwInterface.hxx"
+#include "traction_modem/RxFlow.hxx"
+#include "traction_modem/TxFlow.hxx"
+
+namespace traction_modem
+{
+
+//
+// VelocityStatus::VelocityStatus()
+//
+VelocityStatus::VelocityStatus(TxInterface *tx_flow, RxInterface *rx_flow,
+    ModemTrainHwInterface *hw_interface)
+    : txFlow_(tx_flow)
+    , rxFlow_(rx_flow)
+    , hwIf_(hw_interface)
+{
+    rxFlow_->register_handler(this, Defs::RESP_SPEED_QUERY);
+}
+
+//
+// VelocityStatus::~VelocityStatus()
+//
+VelocityStatus::~VelocityStatus()
+{
+    rxFlow_->unregister_handler_all(this);
+}
+
+//
+// VelocityStatus::query()
+//
+void VelocityStatus::query()
+{
+    txFlow_->send_packet(Defs::get_speed_query_payload());
+}
+
+//
+// VelocityStatus::send()
+//
+void VelocityStatus::send(Buffer<Message> *buf, unsigned prio)
+{
+    auto b = get_buffer_deleter(buf);
+    switch (b->data()->command())
+    {
+        case Defs::RESP_SPEED_QUERY:
+        {
+            Defs::SpeedQueryResponse *sqr =
+                (Defs::SpeedQueryResponse *)b->data()->payload.data();
+            if (sqr->error_ == 0)
+            {
+                Defs::DCCVelocity target;
+                Defs::DCCVelocity current;
+                target.data = sqr->targetSpeed_;
+                current.data = sqr->currentSpeed_;
+                hwIf_->velocity_status(target, current);
+            }
+            break;
+        }
+    }
+}
+
+} // namespace traction_modem

--- a/src/traction_modem/VelocityStatus.hxx
+++ b/src/traction_modem/VelocityStatus.hxx
@@ -1,0 +1,78 @@
+/** @copyright
+ * Copyright (c) 2025, Stuart Baker
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @file VelocityStatus.hxx
+ *
+ * Logic for querying velocity status.
+ *
+ * @author Stuart Baker
+ * @date 27 June 2025
+ */
+
+#ifndef _TRACTION_MODEM_VELOCITYSTATUS_HXX_
+#define _TRACTION_MODEM_VELOCITYSTATUS_HXX_
+
+#include "traction_modem/Message.hxx"
+
+namespace traction_modem
+{
+
+// Forward declarations.
+class ModemTrainHwInterface;
+class TxInterface;
+class RxInterface;
+
+/// Object for querying and handling velocity status messages.
+class VelocityStatus : public PacketFlowInterface
+{
+public:
+    /// Constructor.
+    /// @param tx_flow reference to the transmit flow
+    /// @param rx_flow reference to the receive flow
+    /// @param hw_interface hardware specific interface to the modem train
+    VelocityStatus(TxInterface *tx_flow, RxInterface *rx_flow,
+        ModemTrainHwInterface *hw_interface);
+
+    /// Destructor.
+    ~VelocityStatus();
+
+    /// Send a velocity status query to the decoder.
+    void query();
+
+private:
+    /// Receive handler for velocity status response messages.
+    /// @param buf incoming message
+    /// @param prio message priority
+    void send(Buffer<Message> *buf, unsigned prio) override;
+
+    TxInterface *txFlow_; ///< reference to the transmit flow
+    RxInterface *rxFlow_; ///< reference to the receive flow
+    ModemTrainHwInterface *hwIf_; ///< hardware specific interface
+};
+
+} // namespace traction_modem
+
+#endif // _TRACTION_MODEM_VELOCITYSTATUS_HXX_

--- a/src/traction_modem/VelocityStatus.hxx
+++ b/src/traction_modem/VelocityStatus.hxx
@@ -1,5 +1,5 @@
 /** @copyright
- * Copyright (c) 2025, Stuart Baker
+ * Copyright (c) 2026, Stuart Baker
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,7 @@
  * Logic for querying velocity status.
  *
  * @author Stuart Baker
- * @date 27 June 2025
+ * @date 27 June 2026
  */
 
 #ifndef _TRACTION_MODEM_VELOCITYSTATUS_HXX_

--- a/src/traction_modem/modem_test_helper.hxx
+++ b/src/traction_modem/modem_test_helper.hxx
@@ -50,6 +50,7 @@ public:
 class MockTrainHwInterface : public ModemTrainHwInterface
 {
 public:
+    MOCK_METHOD2(function_status, void(uint32_t, uint16_t));
     MOCK_METHOD2(output_state, void(uint16_t, uint16_t));
     MOCK_METHOD1(output_restart, void(uint16_t));
     MOCK_METHOD4(memory_write, MemoryWriteError(


### PR DESCRIPTION
## Summary

Adds support for the traction modem to query and receive decoder state (velocity and function status) instead of only pushing commands, and wires an initial state sync on link-up.

- Naturalize the on/off `OutputState` encoding (`OFF = 0x0000`, `ON = 0xFFFF`) to match the wire protocol.
- Add `VelocityStatus` and `FunctionStatus` packet handlers that send `CMD_SPEED_QUERY` / `CMD_FN_QUERY` and parse the corresponding responses, wired into `ModemTrain` alongside the existing `Output` handler.
- Extend `ModemTrainHwInterface` with `velocity_status()`, `function_status()`, `get_fn()`, `legacy_address()`, `legacy_address_type()`, and `on_link_up()` so hardware implementations can respond to modem-initiated queries and report real values instead of `/// @todo` stubs.
- Trigger a velocity status query on link-up so initial train state is synchronized when the modem comes online; expose `ModemTrain::get_function_status()` so function-status queries on link-up can be driven externally instead of from within `ModemTrain`.
