### PR TITLE
Expand Traction Modem CV space to cover bit oriented operations

### DIFF
--- a/src/traction_modem/MemorySpace.cxxtest
+++ b/src/traction_modem/MemorySpace.cxxtest
@@ -62,7 +62,7 @@ TEST_F(MemorySpaceTest, Create)
     EXPECT_FALSE(static_cast<openlcb::MemorySpace*>(&cs)->read_only());
     EXPECT_FALSE(static_cast<openlcb::MemorySpace*>(&fs)->read_only());
 
-    EXPECT_EQ((0x1U << 24) - 1,
+    EXPECT_EQ(0x17FFFFFFU,
         static_cast<openlcb::MemorySpace*>(&cs)->max_address());
     EXPECT_EQ(
         UINT32_MAX, static_cast<openlcb::MemorySpace*>(&fs)->max_address());
@@ -82,7 +82,7 @@ TEST_F(MemorySpaceTest, CvRead)
     // Read fail out of bounds.
     //
     error = 0;
-    EXPECT_EQ(0U, cs.read((0x1 << 24), data_, sizeof(data_), &error, &done));
+    EXPECT_EQ(0U, cs.read(0x18000000, data_, sizeof(data_), &error, &done));
     EXPECT_EQ(openlcb::MemoryConfigDefs::ERROR_OUT_OF_BOUNDS, error);
 
 
@@ -301,7 +301,7 @@ TEST_F(MemorySpaceTest, CvWrite)
     // Write fail out of bounds.
     //
     error = 0;
-    EXPECT_EQ(0U, cs.write((0x1 << 24), data_, sizeof(data_), &error, &done));
+    EXPECT_EQ(0U, cs.write(0x18000000, data_, sizeof(data_), &error, &done));
     EXPECT_EQ(openlcb::MemoryConfigDefs::ERROR_OUT_OF_BOUNDS, error);
 
 

--- a/src/traction_modem/MemorySpace.hxx
+++ b/src/traction_modem/MemorySpace.hxx
@@ -374,10 +374,22 @@ private:
     }
 
     /// Get the largest supported address.
-    /// @return 1023 (max CV address)
+    /// @return 0x17FFFFFF (Need to cover the full "bit mapped" range)
     address_t max_address() override
     {
-        return (0x1 << 24) - 1;
+        // Since this is always over the modem interface, it doesn't matter
+        // by which wire protocol we got here, all byte oriented modes will
+        // be treated the same.
+        //
+        // 0x00XXXXXX: default programming mode, byte oriented.
+        // 0x01XXXXXX: direct mode programming, byte oriented.
+        // 0x02XXXXXX: program-on-the-main, byte oriented.
+        // 0x03XXXXXX: paged mode programming, byte oriented.
+        // 0x10XXXXXX..
+        // 0x17XXXXXX: default programming mode, bit oriented
+        //
+        // All other address ranges reserved for future use.
+        return 0x17FFFFFF;
     };
 
     /// Get the space ID that will be used over the modem interface.


### PR DESCRIPTION
## Summary
- Expand the Traction Modem CV memory space's max address from `0xFFFFFF` (byte-oriented CVs only) to `0x17FFFFFF`, adding room for the bit-oriented programming address range (`0x10XXXXXX`-`0x17XXXXXX`) alongside the existing byte-oriented ranges (`0x00XXXXXX`-`0x03XXXXXX`).
- Update `MemorySpace.cxxtest` bounds-checking tests to match the new max address.

## Test plan
- [x] `cd targets/test && make` and run `./build/traction_modem_MemorySpace`