### PR TITLE
CC32xxnet: makes the wakeup socket non-blocking.

### DIFF
--- a/src/freertos_drivers/net_cc32xx/CC32xxWiFi.cxx
+++ b/src/freertos_drivers/net_cc32xx/CC32xxWiFi.cxx
@@ -1014,9 +1014,9 @@ void CC32xxWiFi::wlan_task()
         SlFdSet_t wfds_tmp = wfds;
         SlFdSet_t efds_tmp = efds;
         SlTimeval_t tv;
-        // Wake up every 20 msec in case we missed a select_wakeup.
+        // Wake up every 40 msec in case we missed a select_wakeup.
         tv.tv_sec = 0;
-        tv.tv_usec = 20000;
+        tv.tv_usec = 40000;
 
         result = sl_Select(fdHighest + 1, &rfds_tmp, &wfds_tmp, &efds_tmp, &tv);
 

--- a/src/freertos_drivers/net_cc32xx/CC32xxWiFi.cxx
+++ b/src/freertos_drivers/net_cc32xx/CC32xxWiFi.cxx
@@ -988,6 +988,14 @@ void CC32xxWiFi::wlan_task()
 
     unsigned next_wrssi_poll = (os_get_time_monotonic() >> 20) + 800;
 
+    // Set wakeup to nonblocking mode.
+    SlSockNonblocking_t opt;
+    opt.NonBlockingEnabled = 1;
+    // Enable or disable non-blocking mode
+    result = sl_SetSockOpt(
+        wakeup, SL_SOL_SOCKET, SL_SO_NONBLOCKING, (uint8_t *)&opt, sizeof(opt));
+    HASSERT(result == 0);
+
     for ( ; /* forever */ ; )
     {
 
@@ -1006,8 +1014,9 @@ void CC32xxWiFi::wlan_task()
         SlFdSet_t wfds_tmp = wfds;
         SlFdSet_t efds_tmp = efds;
         SlTimeval_t tv;
-        tv.tv_sec = 1;
-        tv.tv_usec = 0;
+        // Wake up every 20 msec in case we missed a select_wakeup.
+        tv.tv_sec = 0;
+        tv.tv_usec = 20000;
 
         result = sl_Select(fdHighest + 1, &rfds_tmp, &wfds_tmp, &efds_tmp, &tv);
 
@@ -1055,6 +1064,9 @@ void CC32xxWiFi::wlan_task()
                     /* this is the socket we use as a signal */
                     char data;
                     sl_Recv(wakeup, &data, 1, 0);
+                    portENTER_CRITICAL();
+                    --pendingWakeup_;
+                    portEXIT_CRITICAL();
                 }
                 else
                 {
@@ -1103,12 +1115,10 @@ void CC32xxWiFi::select_wakeup()
         char data = -1;
         ssize_t result = sl_SendTo(wakeup, &data, 1, 0, (SlSockAddr_t*)&address,
                                    length);
-        while (result != 1 && connected)
-        {
-            usleep(MSEC_TO_USEC(50));
-            result = sl_SendTo(wakeup, &data, 1, 0, (SlSockAddr_t*)&address,
-                               length);
-        }
+        portENTER_CRITICAL();
+        ++pendingWakeup_;
+        portEXIT_CRITICAL();
+        (void)result;
     }
 }
 

--- a/src/freertos_drivers/net_cc32xx/CC32xxWiFi.hxx
+++ b/src/freertos_drivers/net_cc32xx/CC32xxWiFi.hxx
@@ -678,6 +678,7 @@ private:
     OSMutex lock_;
 
     int wakeup; /**< loopback socket to wakeup select() */
+    int32_t pendingWakeup_; /**< number of sent -received wakeup messages */
 
     int16_t rssi; /**< receive signal strength indicator */
 

--- a/src/freertos_drivers/ti/CC32xxUart.cxx
+++ b/src/freertos_drivers/ti/CC32xxUart.cxx
@@ -259,6 +259,12 @@ void CC32xxUart::send()
         /* no more data left to send */
         MAP_UARTTxIntModeSet(base_, UART_TXINT_MODE_EOT);
         MAP_UARTIntClear(base_, UART_INT_TX);
+        if (!MAP_UARTBusy(base_))
+        {
+            // We lost a race and might have removed the expected TX interrupt.
+            // This will ensure that we enter the irq handler again.
+            MAP_IntPendSet(interrupt_);
+        }
     }
 }
 
@@ -329,7 +335,7 @@ void CC32xxUart::interrupt_handler()
         }
     }
     /* transmit a character if we have pending tx data */
-    if (txPending_ && (status & UART_INT_TX))
+    if (txPending_ && ((status & UART_INT_TX) || (!MAP_UARTBusy(base_))))
     {
         if (txBuf->pending())
         {

--- a/src/freertos_drivers/ti/CC32xxUart.cxx
+++ b/src/freertos_drivers/ti/CC32xxUart.cxx
@@ -234,6 +234,22 @@ void CC32xxUart::set_mode()
  */
 void CC32xxUart::send()
 {
+    /// @todo: We observed situations where the TX interrupt got lost, causing
+    /// a deadlock of the UART driver, with the txBuf being full, txPending ==
+    /// true, select being not write-active, the hardware TX fifo being empty,
+    /// and this situation persisting for an extended period of time.
+    ///
+    /// The tx_char and send function is being called either in an interrupt
+    /// context or in application context under a critical section lock. This
+    /// function normally does not take an extended period of time. However,
+    /// there is a possibility that during the switch from FIFO-low to EOT
+    /// interrupt a race condition makes the interrupt get lost. There is a
+    /// patch for this specific situation here, but it is unclear whether this
+    /// is the only cause or condition leading to the above deadlock.
+    ///
+    /// There is some additional discussion in
+    /// https://github.com/bakerstu/openmrn/pull/949.
+
     do
     {
         uint8_t data = 0;


### PR DESCRIPTION
When the NWP is out of transmit buffers, the select_wakeup could block the main executor. This is really bad.

As an alternative strategy, we make the wakeup socket nonblocking. To avoid getting stuck with the fd_set, we limit the select timeout to 20 msec. We always wake up select and re-do the fd_set after this time.