### PR TITLE
Learn remote aliases from initialization complete and node verified messages.

### DIFF
--- a/src/openlcb/Defs.hxx
+++ b/src/openlcb/Defs.hxx
@@ -102,9 +102,11 @@ struct Defs
         MTI_EXACT                     = 0xFFFF, /**< match mask for a single MTI */
         MTI_NONE                      = 0x0000, /**< invalid MTI */
         MTI_INITIALIZATION_COMPLETE   = 0x0100, /**< initialization complete */
+        MTI_INITIALIZATION_COMPLETE_SIMPLE = 0x0101, /**< initialization complete (simple subset) */
         MTI_VERIFY_NODE_ID_ADDRESSED  = 0x0488, /**< verify a Node ID */
         MTI_VERIFY_NODE_ID_GLOBAL     = 0x0490, /**< verify a Node ID globally */
         MTI_VERIFIED_NODE_ID_NUMBER   = 0x0170, /**< respond to a verify Node ID request */
+        MTI_VERIFIED_NODE_ID_SIMPLE   = 0x0171, /**< respond to a verify Node ID request (simple subset) */
         MTI_OPTIONAL_INTERACTION_REJECTED = 0x0068, /**< rejected request */
         MTI_TERMINATE_DUE_TO_ERROR    = 0x00A8, /**< terminate due to some error */
         MTI_PROTOCOL_SUPPORT_INQUIRY  = 0x0828, /**< inquire on supported protocols */

--- a/src/openlcb/IfCan.cxx
+++ b/src/openlcb/IfCan.cxx
@@ -214,8 +214,8 @@ public:
         /// Filter for CAN Control Messages (AMD_FRAME, AMR_FRAME).
         CAN_FILTER_CONTROL = CanMessageData::CAN_EXT_FRAME_FILTER |
             (CanDefs::CONTROL_MSG << CanDefs::FRAME_TYPE_SHIFT),
-        CAN_MASK_CONTROL =
-            CanMessageData::CAN_EXT_FRAME_MASK | CanDefs::FRAME_TYPE_MASK,
+        CAN_MASK_CONTROL = CanMessageData::CAN_EXT_FRAME_MASK |
+            CanDefs::FRAME_TYPE_MASK,
 
         /// Filter for Node Initialization Complete messages (0x0100 & 0x0101).
         CAN_FILTER_INIT = CanMessageData::CAN_EXT_FRAME_FILTER |
@@ -236,7 +236,8 @@ public:
             (0x0FFE << CanDefs::MTI_SHIFT),
     };
 
-    /// Constructor. Registers handlers for control, init, and verify CAN frames.
+    /// Constructor. Registers handlers for control, init, and verify CAN
+    /// frames.
     /// @param service CAN interface instance to register with.
     RemoteAliasCacheUpdater(IfCan *service)
         : CanFrameStateFlow(service)
@@ -329,8 +330,9 @@ public:
     }
 
 private:
-    /// Helper method to insert or update a NodeID to NodeAlias mapping in the cache.
-    /// Removes any previous alias associated with the given NodeID before adding the new mapping.
+    /// Helper method to insert or update a NodeID to NodeAlias mapping in the
+    /// cache. Removes any previous alias associated with the given NodeID
+    /// before adding the new mapping.
     /// @param node_id Node ID to associate.
     /// @param alias Alias to associate with the Node ID.
     void add_alias(NodeID node_id, NodeAlias alias)

--- a/src/openlcb/IfCan.cxx
+++ b/src/openlcb/IfCan.cxx
@@ -217,83 +217,140 @@ class RemoteAliasCacheUpdater : public CanFrameStateFlow
 public:
     enum
     {
-        CAN_FILTER = CanMessageData::CAN_EXT_FRAME_FILTER |
+        /// Filter for CAN Control Messages (AMD_FRAME, AMR_FRAME).
+        CAN_FILTER_CONTROL = CanMessageData::CAN_EXT_FRAME_FILTER |
             (CanDefs::CONTROL_MSG << CanDefs::FRAME_TYPE_SHIFT),
-        CAN_MASK =
+        CAN_MASK_CONTROL =
             CanMessageData::CAN_EXT_FRAME_MASK | CanDefs::FRAME_TYPE_MASK,
+
+        /// Filter for Node Initialization Complete messages (0x0100 & 0x0101).
+        CAN_FILTER_INIT = CanMessageData::CAN_EXT_FRAME_FILTER |
+            (CanDefs::NORMAL_PRIORITY << CanDefs::PRIORITY_SHIFT) |
+            (CanDefs::NMRANET_MSG << CanDefs::FRAME_TYPE_SHIFT) |
+            (CanDefs::GLOBAL_ADDRESSED << CanDefs::CAN_FRAME_TYPE_SHIFT) |
+            (Defs::MTI_INITIALIZATION_COMPLETE << CanDefs::MTI_SHIFT),
+        CAN_MASK_INIT = CanMessageData::CAN_EXT_FRAME_MASK |
+            CanDefs::PRIORITY_MASK | CanDefs::FRAME_TYPE_MASK |
+            CanDefs::CAN_FRAME_TYPE_MASK |
+            (0x0FFE << CanDefs::MTI_SHIFT),
+
+        /// Filter for Verified Node ID messages (0x0170 & 0x0171).
+        CAN_FILTER_VERIFY = CanMessageData::CAN_EXT_FRAME_FILTER |
+            (CanDefs::NORMAL_PRIORITY << CanDefs::PRIORITY_SHIFT) |
+            (CanDefs::NMRANET_MSG << CanDefs::FRAME_TYPE_SHIFT) |
+            (CanDefs::GLOBAL_ADDRESSED << CanDefs::CAN_FRAME_TYPE_SHIFT) |
+            (Defs::MTI_VERIFIED_NODE_ID_NUMBER << CanDefs::MTI_SHIFT),
+        CAN_MASK_VERIFY = CanMessageData::CAN_EXT_FRAME_MASK |
+            CanDefs::PRIORITY_MASK | CanDefs::FRAME_TYPE_MASK |
+            CanDefs::CAN_FRAME_TYPE_MASK |
+            (0x0FFE << CanDefs::MTI_SHIFT),
     };
 
     RemoteAliasCacheUpdater(IfCan *service)
         : CanFrameStateFlow(service)
     {
         if_can()->frame_dispatcher()->register_handler(
-            this, CAN_FILTER, CAN_MASK);
+            this, CAN_FILTER_CONTROL, CAN_MASK_CONTROL);
+        if_can()->frame_dispatcher()->register_handler(
+            this, CAN_FILTER_INIT, CAN_MASK_INIT);
+        if_can()->frame_dispatcher()->register_handler(
+            this, CAN_FILTER_VERIFY, CAN_MASK_VERIFY);
     }
 
     ~RemoteAliasCacheUpdater()
     {
         if_can()->frame_dispatcher()->unregister_handler(
-            this, CAN_FILTER, CAN_MASK);
+            this, CAN_FILTER_CONTROL, CAN_MASK_CONTROL);
+        if_can()->frame_dispatcher()->unregister_handler(
+            this, CAN_FILTER_INIT, CAN_MASK_INIT);
+        if_can()->frame_dispatcher()->unregister_handler(
+            this, CAN_FILTER_VERIFY, CAN_MASK_VERIFY);
     }
 
     Action entry() OVERRIDE
     {
         struct can_frame *f = message()->data();
         uint32_t id = GET_CAN_FRAME_ID_EFF(*f);
-        if (CanDefs::get_frame_type(id) != CanDefs::CONTROL_MSG)
-            return release_and_exit();
-        auto control_field = CanDefs::get_control_field(id);
         NodeAlias alias = CanDefs::get_src(id);
         if (!alias)
         {
             return release_and_exit();
         }
+
         NodeID node_id = 0;
         if (f->can_dlc == 6)
         {
             node_id = data_to_node_id(f->data);
         }
-        switch (control_field)
+
+        auto frame_type = CanDefs::get_frame_type(id);
+        if (frame_type == CanDefs::CONTROL_MSG)
         {
-            case CanDefs::AMD_FRAME:
+            auto control_field = CanDefs::get_control_field(id);
+            switch (control_field)
             {
-                if (!node_id)
+                case CanDefs::AMD_FRAME:
                 {
-                    return release_and_exit();
+                    add_alias(node_id, alias);
+                    break;
                 }
-                NodeAlias old_alias =
-                    if_can()->remote_aliases()->lookup(node_id);
-                if (old_alias == alias)
+                case CanDefs::AMR_FRAME:
                 {
-                    // No change.
-                    return release_and_exit();
-                }
-                if (old_alias)
-                {
-                    if_can()->remote_aliases()->remove(old_alias);
-                }
-                if_can()->remote_aliases()->add(node_id, alias);
-                return release_and_exit();
-            }
-            case CanDefs::AMR_FRAME:
-            {
-                if (node_id)
-                {
-                    NodeAlias old_alias =
-                        if_can()->remote_aliases()->lookup(node_id);
-                    if (old_alias && old_alias != alias)
+                    if (node_id)
                     {
-                        if_can()->remote_aliases()->remove(old_alias);
+                        NodeAlias old_alias =
+                            if_can()->remote_aliases()->lookup(node_id);
+                        if (old_alias && old_alias != alias)
+                        {
+                            if_can()->remote_aliases()->remove(old_alias);
+                        }
                     }
+                    if_can()->remote_aliases()->remove(alias);
+                    break;
                 }
-                if_can()->remote_aliases()->remove(alias);
-                return release_and_exit();
+                default:
+                    break;
             }
-            default: // ignore
-                ;
+        }
+        else if (frame_type == CanDefs::NMRANET_MSG)
+        {
+            Defs::MTI mti = static_cast<Defs::MTI>(CanDefs::get_mti(id));
+            switch (mti)
+            {
+                case Defs::MTI_INITIALIZATION_COMPLETE:
+                case Defs::MTI_INITIALIZATION_COMPLETE_SIMPLE:
+                case Defs::MTI_VERIFIED_NODE_ID_NUMBER:
+                case Defs::MTI_VERIFIED_NODE_ID_SIMPLE:
+                {
+                    add_alias(node_id, alias);
+                    break;
+                }
+                default:
+                    break;
+            }
         }
 
         return release_and_exit();
+    }
+
+private:
+    void add_alias(NodeID node_id, NodeAlias alias)
+    {
+        if (!node_id || !alias)
+        {
+            return;
+        }
+        NodeAlias old_alias = if_can()->remote_aliases()->lookup(node_id);
+        if (old_alias == alias)
+        {
+            // No change.
+            return;
+        }
+        if (old_alias)
+        {
+            if_can()->remote_aliases()->remove(old_alias);
+        }
+        if_can()->remote_aliases()->add(node_id, alias);
     }
 };
 

--- a/src/openlcb/IfCan.cxx
+++ b/src/openlcb/IfCan.cxx
@@ -225,24 +225,20 @@ public:
 
         /// Filter for Node Initialization Complete messages (0x0100 & 0x0101).
         CAN_FILTER_INIT = CanMessageData::CAN_EXT_FRAME_FILTER |
-            (CanDefs::NORMAL_PRIORITY << CanDefs::PRIORITY_SHIFT) |
             (CanDefs::NMRANET_MSG << CanDefs::FRAME_TYPE_SHIFT) |
             (CanDefs::GLOBAL_ADDRESSED << CanDefs::CAN_FRAME_TYPE_SHIFT) |
             (Defs::MTI_INITIALIZATION_COMPLETE << CanDefs::MTI_SHIFT),
         CAN_MASK_INIT = CanMessageData::CAN_EXT_FRAME_MASK |
-            CanDefs::PRIORITY_MASK | CanDefs::FRAME_TYPE_MASK |
-            CanDefs::CAN_FRAME_TYPE_MASK |
+            CanDefs::FRAME_TYPE_MASK | CanDefs::CAN_FRAME_TYPE_MASK |
             (0x0FFE << CanDefs::MTI_SHIFT),
 
         /// Filter for Verified Node ID messages (0x0170 & 0x0171).
         CAN_FILTER_VERIFY = CanMessageData::CAN_EXT_FRAME_FILTER |
-            (CanDefs::NORMAL_PRIORITY << CanDefs::PRIORITY_SHIFT) |
             (CanDefs::NMRANET_MSG << CanDefs::FRAME_TYPE_SHIFT) |
             (CanDefs::GLOBAL_ADDRESSED << CanDefs::CAN_FRAME_TYPE_SHIFT) |
             (Defs::MTI_VERIFIED_NODE_ID_NUMBER << CanDefs::MTI_SHIFT),
         CAN_MASK_VERIFY = CanMessageData::CAN_EXT_FRAME_MASK |
-            CanDefs::PRIORITY_MASK | CanDefs::FRAME_TYPE_MASK |
-            CanDefs::CAN_FRAME_TYPE_MASK |
+            CanDefs::FRAME_TYPE_MASK | CanDefs::CAN_FRAME_TYPE_MASK |
             (0x0FFE << CanDefs::MTI_SHIFT),
     };
 

--- a/src/openlcb/IfCan.cxx
+++ b/src/openlcb/IfCan.cxx
@@ -236,6 +236,8 @@ public:
             (0x0FFE << CanDefs::MTI_SHIFT),
     };
 
+    /// Constructor. Registers handlers for control, init, and verify CAN frames.
+    /// @param service CAN interface instance to register with.
     RemoteAliasCacheUpdater(IfCan *service)
         : CanFrameStateFlow(service)
     {
@@ -247,6 +249,7 @@ public:
             this, CAN_FILTER_VERIFY, CAN_MASK_VERIFY);
     }
 
+    /// Destructor. Unregisters all handlers from the frame dispatcher.
     ~RemoteAliasCacheUpdater()
     {
         if_can()->frame_dispatcher()->unregister_handler(
@@ -257,6 +260,8 @@ public:
             this, CAN_FILTER_VERIFY, CAN_MASK_VERIFY);
     }
 
+    /// StateFlow entry point for processing incoming CAN frames.
+    /// @return Action to release the message buffer and exit the state flow.
     Action entry() OVERRIDE
     {
         struct can_frame *f = message()->data();
@@ -324,6 +329,10 @@ public:
     }
 
 private:
+    /// Helper method to insert or update a NodeID to NodeAlias mapping in the cache.
+    /// Removes any previous alias associated with the given NodeID before adding the new mapping.
+    /// @param node_id Node ID to associate.
+    /// @param alias Alias to associate with the Node ID.
     void add_alias(NodeID node_id, NodeAlias alias)
     {
         if (!node_id || !alias)

--- a/src/openlcb/IfCan.cxxtest
+++ b/src/openlcb/IfCan.cxxtest
@@ -124,6 +124,48 @@ TEST_F(AsyncIfTest, RemoteAliasLearned)
     });
 }
 
+TEST_F(AsyncIfTest, RemoteAliasLearnedFromVerifiedNodeID)
+{
+    send_packet(":X19170782N010203040506;");
+    wait();
+    RX({
+        EXPECT_EQ(
+            0x782U, ifCan_->remote_aliases()->lookup(UINT64_C(0x010203040506)));
+        EXPECT_EQ(UINT64_C(0x010203040506),
+            ifCan_->remote_aliases()->lookup(NodeAlias(0x782U)));
+    });
+
+    send_packet(":X19171783N010203040507;");
+    wait();
+    RX({
+        EXPECT_EQ(
+            0x783U, ifCan_->remote_aliases()->lookup(UINT64_C(0x010203040507)));
+        EXPECT_EQ(UINT64_C(0x010203040507),
+            ifCan_->remote_aliases()->lookup(NodeAlias(0x783U)));
+    });
+}
+
+TEST_F(AsyncIfTest, RemoteAliasLearnedFromInitializationComplete)
+{
+    send_packet(":X19100784N010203040508;");
+    wait();
+    RX({
+        EXPECT_EQ(
+            0x784U, ifCan_->remote_aliases()->lookup(UINT64_C(0x010203040508)));
+        EXPECT_EQ(UINT64_C(0x010203040508),
+            ifCan_->remote_aliases()->lookup(NodeAlias(0x784U)));
+    });
+
+    send_packet(":X19101785N010203040509;");
+    wait();
+    RX({
+        EXPECT_EQ(
+            0x785U, ifCan_->remote_aliases()->lookup(UINT64_C(0x010203040509)));
+        EXPECT_EQ(UINT64_C(0x010203040509),
+            ifCan_->remote_aliases()->lookup(NodeAlias(0x785U)));
+    });
+}
+
 TEST_F(AsyncIfTest, AMEReceiveSupport)
 {
     // Example virtual node.

--- a/src/openlcb/IfCan.cxxtest
+++ b/src/openlcb/IfCan.cxxtest
@@ -143,6 +143,16 @@ TEST_F(AsyncIfTest, RemoteAliasLearnedFromVerifiedNodeID)
         EXPECT_EQ(UINT64_C(0x010203040507),
             ifCan_->remote_aliases()->lookup(NodeAlias(0x783U)));
     });
+
+    // Priority bit 0 (0x09170...) frame must also be learned.
+    send_packet(":X09170786N01020304050A;");
+    wait();
+    RX({
+        EXPECT_EQ(
+            0x786U, ifCan_->remote_aliases()->lookup(UINT64_C(0x01020304050A)));
+        EXPECT_EQ(UINT64_C(0x01020304050A),
+            ifCan_->remote_aliases()->lookup(NodeAlias(0x786U)));
+    });
 }
 
 TEST_F(AsyncIfTest, RemoteAliasLearnedFromInitializationComplete)
@@ -163,6 +173,16 @@ TEST_F(AsyncIfTest, RemoteAliasLearnedFromInitializationComplete)
             0x785U, ifCan_->remote_aliases()->lookup(UINT64_C(0x010203040509)));
         EXPECT_EQ(UINT64_C(0x010203040509),
             ifCan_->remote_aliases()->lookup(NodeAlias(0x785U)));
+    });
+
+    // Priority bit 0 (0x09100...) frame must also be learned.
+    send_packet(":X09100787N01020304050B;");
+    wait();
+    RX({
+        EXPECT_EQ(
+            0x787U, ifCan_->remote_aliases()->lookup(UINT64_C(0x01020304050B)));
+        EXPECT_EQ(UINT64_C(0x01020304050B),
+            ifCan_->remote_aliases()->lookup(NodeAlias(0x787U)));
     });
 }
 


### PR DESCRIPTION
Updates the remote alias listener class to act on incoming messages of MTIs
100, 101 (node initialization complete / with simple) and 170, 171 (global
verified node id).

Adds the 101 and 171 to the MTI enum. These have been in the standard for a
while now.