### PR TITLE
Fix race condition crash in broadcast time client.

### DIFF
--- a/src/openlcb/BroadcastTimeClient.hxx
+++ b/src/openlcb/BroadcastTimeClient.hxx
@@ -427,7 +427,7 @@ private:
         }
         if (sleeping_)
         {
-            timer_.trigger();
+            timer_.ensure_triggered();
             sleeping_ = false;
         }
     }


### PR DESCRIPTION
if the timer trigger comes at the time when the timer has expired, scheduled the flow, but the flow has not executed yet, then this code would crash.