### PR TITLE
Fix broken tests due to alias caching change.

### DIFF
--- a/src/openlcb/DatagramCan.cxxtest
+++ b/src/openlcb/DatagramCan.cxxtest
@@ -1014,7 +1014,6 @@ TEST_F(TwoNodeDatagramTest, PingPongTestOne)
 {
     print_all_packets();
     setup_other_node(true);
-    expect_other_node_lookup();
 
     PingPongHandler handler_one(&datagram_support_, node_);
     PingPongHandler handler_two(otherNodeDatagram_, otherNode_.get());
@@ -1055,7 +1054,6 @@ TEST_F(TwoNodeDatagramTest, PingPongTestError)
 {
     print_all_packets();
     setup_other_node(true);
-    expect_other_node_lookup();
 
     PingPongHandler handler_one(&datagram_support_, node_);
     PingPongHandler handler_two(otherNodeDatagram_, otherNode_.get());
@@ -1088,7 +1086,6 @@ TEST_F(TwoNodeDatagramTest, PingPongTestLoopback)
 {
     print_all_packets();
     setup_other_node(false);
-    // expect_other_node_lookup();
 
     PingPongHandler handler_one(&datagram_support_, node_);
     PingPongHandler handler_two(otherNodeDatagram_, otherNode_.get());
@@ -1122,7 +1119,6 @@ TEST_F(TwoNodeDatagramTest, PingPongLoopbackError)
 {
     print_all_packets();
     setup_other_node(false);
-    // expect_other_node_lookup();
 
     PingPongHandler handler_one(&datagram_support_, node_);
     PingPongHandler handler_two(otherNodeDatagram_, otherNode_.get());
@@ -1151,7 +1147,6 @@ TEST_F(TwoNodeDatagramTest, NoDestinationHandler)
 {
     print_all_packets();
     setup_other_node(true);
-    expect_other_node_lookup();
 
     DatagramClient *c = datagram_support_.client_allocator()->next_blocking();
     NodeHandle h{OTHER_NODE_ID, 0};

--- a/src/utils/async_datagram_test_helper.hxx
+++ b/src/utils/async_datagram_test_helper.hxx
@@ -119,17 +119,6 @@ protected:
         wait();
     }
 
-    /// Adds the necessary expectations for the address lookup reuqests on the
-    /// CANbus by the first datagram being sent from node_ to otherNode_. Not
-    /// needed for mode 1 operation.
-    void expect_other_node_lookup()
-    {
-        expect_packet(":X1070222AN02010D000103;"); // looking for DST node
-        expect_packet(":X10701225N02010D000103;"); // found dst node
-        // expect_packet(":X1949022AN02010D000103;"); // hard-looking for DST node
-        // expect_packet(":X19170225N02010D000103;"); // node ID verified
-    }
-
     std::unique_ptr<DefaultNode> otherNode_;
     // Second objects if we want a bus-traffic test.
     std::unique_ptr<IfCan> otherIfCan_;


### PR DESCRIPTION
openlcb: Remove obsolete expect_other_node_lookup test helper

Remove `expect_other_node_lookup()` from `async_datagram_test_helper.hxx` and its invocations in `DatagramCan.cxxtest`.

Because `RemoteAliasCacheUpdater` now automatically populates the remote alias cache upon receiving `MTI_INITIALIZATION_COMPLETE` (0x0100) frames, destination node aliases are already cached during node initialization. As a result, sending an addressed datagram to a newly initialized node no longer triggers an AME/AMD (0x10702 / 0x10701) CAN bus lookup.