### PR TITLE
Fix bugs related to groups with offsets.

### DIFF
--- a/src/openlcb/ConfigRenderer.cxxtest
+++ b/src/openlcb/ConfigRenderer.cxxtest
@@ -371,6 +371,83 @@ TEST(CdiRender, NoRenderHiddenSegment)
     EXPECT_EQ(34u, cfg.testseg().e2().offset());
 }
 
+CDI_GROUP(TestGroupEmptyGroupOffset);
+CDI_GROUP_ENTRY(revert_align, openlcb::EmptyGroup<0>, Offset(-104), Hidden(true));
+CDI_GROUP_END();
+
+CDI_GROUP(TestCdiEmptyGroupOffset, MainCdi());
+CDI_GROUP_ENTRY(seg, TestGroupEmptyGroupOffset, Segment(1));
+CDI_GROUP_END();
+
+TEST(CdiRender, EmptyGroupWithNegativeOffset)
+{
+    string s;
+    TestCdiEmptyGroupOffset cfg(0);
+    cfg.config_renderer().render_cdi(&s);
+    const char kExpectedTestNodeCdi[] = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" R"data(
+<cdi xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://openlcb.org/schema/cdi/1/1/cdi.xsd">
+<segment space='1'>
+<group offset='-104'/>
+</segment>
+</cdi>
+)data";
+    EXPECT_EQ(kExpectedTestNodeCdi, s);
+    EXPECT_THAT(s, ::testing::HasSubstr("<group offset='-104'/>"));
+}
+
+CDI_GROUP(TestGroupToHide);
+CDI_GROUP_ENTRY(entry, Uint8ConfigEntry);
+CDI_GROUP_END();
+
+CDI_GROUP(TestGroupHiddenGroupOffset);
+CDI_GROUP_ENTRY(hidden_group, TestGroupToHide, Hidden(true), Offset(-50));
+CDI_GROUP_END();
+
+CDI_GROUP(TestCdiHiddenGroupOffset, MainCdi());
+CDI_GROUP_ENTRY(seg, TestGroupHiddenGroupOffset, Segment(1));
+CDI_GROUP_END();
+
+TEST(CdiRender, HiddenGroupWithNegativeOffset)
+{
+    string s;
+    TestCdiHiddenGroupOffset cfg(0);
+    cfg.config_renderer().render_cdi(&s);
+    EXPECT_THAT(s, ::testing::HasSubstr("<group offset='-49'/>"));
+}
+
+CDI_GROUP(TestGroupNonHiddenEmptyGroupOffset);
+CDI_GROUP_ENTRY(revert_align_visible, openlcb::EmptyGroup<0>, Offset(-104));
+CDI_GROUP_END();
+
+CDI_GROUP(TestCdiNonHiddenEmptyGroupOffset, MainCdi());
+CDI_GROUP_ENTRY(seg, TestGroupNonHiddenEmptyGroupOffset, Segment(1));
+CDI_GROUP_END();
+
+TEST(CdiRender, NonHiddenEmptyGroupWithNegativeOffset)
+{
+    string s;
+    TestCdiNonHiddenEmptyGroupOffset cfg(0);
+    cfg.config_renderer().render_cdi(&s);
+    EXPECT_THAT(s, ::testing::HasSubstr("<group offset='-104'/>"));
+}
+
+CDI_GROUP(TestGroupNonZeroEmptyGroupOffset);
+CDI_GROUP_ENTRY(nonzero_align, openlcb::EmptyGroup<10>, Offset(-104));
+CDI_GROUP_END();
+
+CDI_GROUP(TestCdiNonZeroEmptyGroupOffset, MainCdi());
+CDI_GROUP_ENTRY(seg, TestGroupNonZeroEmptyGroupOffset, Segment(1));
+CDI_GROUP_END();
+
+TEST(CdiRender, NonZeroEmptyGroupWithNegativeOffset)
+{
+    string s;
+    TestCdiNonZeroEmptyGroupOffset cfg(0);
+    cfg.config_renderer().render_cdi(&s);
+    // 10 + (-104) = -94 offset in CDI
+    EXPECT_THAT(s, ::testing::HasSubstr("<group offset='-94'/>"));
+}
+
 
 } // namespace
 } // namespace openlcb

--- a/src/openlcb/ConfigRenderer.hxx
+++ b/src/openlcb/ConfigRenderer.hxx
@@ -416,7 +416,9 @@ public:
 
     template <typename... Args> void render_cdi(string *s, Args... args) const
     {
-        *s += StringPrintf("<group offset='%d'/>\n", size_);
+        GroupConfigOptions opts(args...);
+        int ofs = size_ + opts.offset();
+        *s += StringPrintf("<group offset='%d'/>\n", ofs);
     }
 
 private:
@@ -446,7 +448,7 @@ public:
             if (!opts.is_segment())
             {
                 EmptyGroupConfigRenderer(Body::size() * replication_)
-                    .render_cdi(s);
+                    .render_cdi(s, opts);
             }
             return;
         }

--- a/src/openlcb/ConfigRenderer.hxx
+++ b/src/openlcb/ConfigRenderer.hxx
@@ -470,8 +470,7 @@ public:
         {
             if (!opts.is_segment())
             {
-                EmptyGroupConfigRenderer(
-                    (Body::size() * replication_) + opts.offset())
+                EmptyGroupConfigRenderer((Body::size() * replication_))
                     .render_cdi(s, opts);
             }
             return;


### PR DESCRIPTION
Hidden groups did not correctly take the Offset() argument into account. This made it difficult to have negative jumps in the CDI, since negative jumps are easiest to represent with an empty or a hidden group.